### PR TITLE
kitty annex: Ctrl+B sidebar picker (#50) + Ctrl+G externalized composer (#49)

### DIFF
--- a/home/dot_config/fish/conf.d/remote.fish
+++ b/home/dot_config/fish/conf.d/remote.fish
@@ -50,7 +50,7 @@ if test (hostname) != "coordinator"
         # list (ZMX_DIR pinned — see conf.d/zmx.fish), duplicated into both
         # fields so the same fzf still renders.
         if test -z "$lines"
-            set lines (ssh coordinator 'bash -lc "ZMX_DIR=/tmp/zmx-$(id -u) zmx list --short"' | awk '{printf "%s\t%s\n", $0, $0}')
+            set lines (ssh coordinator 'bash -lc "ZMX_DIR=/tmp/zmx-$(id -u) zmx list --short"' | awk '!/^annex-/{printf "%s\t%s\n", $0, $0}')
         end
         set line (printf '%s\n' $lines | fzf --prompt='attach> ' --no-sort --delimiter='\t' --with-nth='2..')
         if test -n "$line"

--- a/home/dot_config/fish/functions/_annex_editor.fish
+++ b/home/dot_config/fish/functions/_annex_editor.fish
@@ -1,0 +1,25 @@
+# _annex_editor — shared, harness-agnostic scoping for the Ctrl+G externalized
+# composer (dotfiles#49). Runs $argv (a harness invocation, e.g. `claude …` or
+# `pi …`) with EDITOR/VISUAL pointed at the nvim-annex composer wrapper, and ONLY
+# for the duration of that invocation. Both Claude Code and pi resolve the
+# external editor as (externalEditorCommand ||) VISUAL || EDITOR, so setting both
+# here makes nvim-annex their Ctrl+G editor without touching the global editor.
+#
+# WHY `set -lx`, NOT `set -x` (load-bearing bug fix): config.fish does
+# `set -gx EDITOR nvim` GLOBALLY. Fish's `set` WITHOUT a scope flag mutates the
+# innermost scope the variable ALREADY EXISTS in — which for EDITOR is the GLOBAL
+# one — so a bare `set -x EDITOR nvim-annex` would PERMANENTLY clobber the user's
+# editor (git commit, crontab -e, plain `nvim`/`vi` would all become the composer
+# and stay that way for the rest of the shell). `set -lx` forces a NEW
+# function-local exported var that shadows the global for child processes and is
+# discarded on return. Verified: after the call, global EDITOR is back to `nvim`.
+# This is exactly Tom's "do NOT make nvim-annex the global editor" requirement.
+#
+# Adding a harness = one thin wrapper: `function <h>; _annex_editor <h> $argv; end`.
+# `command` runs the real binary, bypassing the same-named wrapper function (no
+# recursion). Interactive-pure: no LLM/network/blocking work here.
+function _annex_editor --description 'Run a harness with EDITOR/VISUAL scoped to the nvim-annex Ctrl+G composer'
+    set -lx EDITOR nvim-annex
+    set -lx VISUAL nvim-annex
+    command $argv
+end

--- a/home/dot_config/fish/functions/_annex_editor.fish
+++ b/home/dot_config/fish/functions/_annex_editor.fish
@@ -18,8 +18,15 @@
 # Adding a harness = one thin wrapper: `function <h>; _annex_editor <h> $argv; end`.
 # `command` runs the real binary, bypassing the same-named wrapper function (no
 # recursion). Interactive-pure: no LLM/network/blocking work here.
+#
+# ABSOLUTE path (not the bare name): ~/.local/bin is NOT on the login PATH here,
+# so the harness's editor spawn resolved `nvim-annex` via PATH and failed
+# ("Executable not found in $PATH"). An absolute path sidesteps PATH entirely and
+# matches the repo convention (niri calls ~/.local/bin/* by absolute path too).
+# The basename stays `nvim-annex`, which is what Claude's terminal-editor regex
+# classifies on — so the blocking spawnSync branch is still taken.
 function _annex_editor --description 'Run a harness with EDITOR/VISUAL scoped to the nvim-annex Ctrl+G composer'
-    set -lx EDITOR nvim-annex
-    set -lx VISUAL nvim-annex
+    set -lx EDITOR $HOME/.local/bin/nvim-annex
+    set -lx VISUAL $HOME/.local/bin/nvim-annex
     command $argv
 end

--- a/home/dot_config/fish/functions/claude.fish
+++ b/home/dot_config/fish/functions/claude.fish
@@ -1,0 +1,16 @@
+# claude.fish — Claude Code with the Ctrl+G composer scoped in (dotfiles#49).
+#
+# Thin per-harness wrapper over `_annex_editor` (the shared, harness-agnostic
+# scoping helper). `cc`/`cac` are fish aliases that call `claude`, so they inherit
+# the scoped composer automatically — config.fish's alias lines stay untouched.
+#
+# `nvim-annex` (not plain `nvim`) is load-bearing here: Claude classifies the
+# editor by basename against /\b(vi|vim|nvim|nano|…)\b/ (verified in the 2.1.205
+# bundle). `nvim-annex` matches \bnvim\b, so Claude takes the BLOCKING
+# spawnSync({stdio:"inherit"}) branch and re-reads the tempfile ONLY on exit
+# status 0 (`c.status!==0 || c.signal || c.error -> content:null -> keep the
+# original prompt`; the edited text is POPULATED into the input, never
+# auto-submitted). That exit-0 gate is what nvim-annex's mtime signal drives.
+function claude --wraps claude --description 'claude-code with the Ctrl+G composer scoped to nvim-annex'
+    _annex_editor claude $argv
+end

--- a/home/dot_config/fish/functions/pi.fish
+++ b/home/dot_config/fish/functions/pi.fish
@@ -1,0 +1,21 @@
+# pi.fish — earendil-works/pi with the same Ctrl+G composer scoped in
+# (dotfiles#49; harness-agnostic per Tom 2026-07-15). A thin per-harness wrapper
+# over `_annex_editor`, mirroring claude.fish — adding a harness is exactly this
+# much code.
+#
+# pi resolves its Ctrl+G editor as `externalEditorCommand || VISUAL || EDITOR`
+# (verified in pi 0.80.3's extension-editor.js). We leave pi's own
+# externalEditorCommand unset so the VISUAL/EDITOR path (the uniform cross-harness
+# scoping) wins.
+#
+# CRASH-SAFETY HOLDS FOR pi TOO (verified from the same bundle): pi spawns the
+# editor ASYNC and awaits its close, then `if (status === 0) editor.setText(reread)`
+# — so a NONZERO/errored editor exit does NOT re-read the tempfile and pi KEEPS
+# the original prompt (and it never auto-submits — the text is only populated). A
+# spawn error resolves status=null, also skipping the re-read. nvim-annex returns
+# nonzero on any aborted/crashed compose (mtime unchanged), so pi keeps the
+# original exactly as Claude does. nvim-annex's os-window + --wait-for-child-to-exit
+# blocks until nvim exits, which is all pi's async-spawn-and-wait needs.
+function pi --wraps pi --description 'pi with the Ctrl+G composer scoped to nvim-annex'
+    _annex_editor pi $argv
+end

--- a/home/dot_config/kitty/annex_toggle.py
+++ b/home/dot_config/kitty/annex_toggle.py
@@ -1,0 +1,175 @@
+# annex_toggle.py — Ctrl+B / Ctrl+Shift+B universal sidebar picker (dotfiles#50).
+#
+# A no-UI kitten mapped in kitty.conf. main() is a no-op; all work happens in
+# handle_result(), which runs IN the kitty process with boss/window access
+# (@result_handler(no_ui=True) => no overlay window flashes, instant).
+#
+# Behavior in the focused window (order matters):
+#   1. DISMISS-SELF: if the focused window IS the annex (var:annex=1), close it
+#      (fires annex_watcher.py on_close -> reap). Checked first because the annex
+#      payload is itself nvim, so "press again to dismiss" must win over
+#      pass-through.
+#   2. PASS-THROUGH: else, if a (zmx-wrapped) nvim editor is focused, forward the
+#      raw key to the app — Ctrl+B -> \x02 (NvimTreeFocus), Ctrl+Shift+B ->
+#      \x1b[66;5u (NvimTreeToggle, preserving today's kitty.conf behavior).
+#      Detection scans the whole `zmx attach … nvim …` argv (see _is_nvim): the
+#      foreground process is always the zmx client, never a bare nvim.
+#   3. DISMISS: else, if an annex split (var:annex=1) is open elsewhere in this
+#      tab, close it (fires annex_watcher.py on_close -> reap).
+#   4. OPEN: else, launch a hidden, self-terminating RIGHT split (~25 cols)
+#      running nvim-tree as the picker, with a watcher + user-vars for reaping
+#      and file-open signaling.
+#
+# Ctrl+B AND Ctrl+Shift+B both toggle outside nvim (Tom thinks of them as one
+# toggle); both pass through inside nvim. Ctrl+B inside Claude Code's TUI is
+# SHADOWED (the annex toggle wins) — accepted, recorded on the issue.
+
+import os
+import re
+import time
+import uuid
+
+from kittens.tui.handler import result_handler
+
+_NVIM_RE = re.compile(r"^n?vim$")
+
+
+def main(args):
+    # All work is done in handle_result; main only forwards the chord arg.
+    return args
+
+
+def _is_annex(window):
+    # The annex split stamps var:annex=1 at launch. Checked BEFORE nvim
+    # pass-through because the annex payload is ITSELF nvim (nvim-tree): without
+    # this, pressing the toggle while focused in the annex would pass through to
+    # its nvim instead of honoring the "press again = dismiss" contract.
+    try:
+        return (window.user_vars or {}).get("annex") == "1"
+    except Exception:
+        return False
+
+
+def _is_nvim(window):
+    # PRIMARY signal: the per-window user-var `nvim=1` that nvim itself stamps on
+    # VimEnter via a kitty SetUserVar OSC (see nvim init.lua kitty_annex_mark).
+    # This is the ONLY reliable detector when nvim is launched by hand inside a
+    # zmx session, because kitty's foreground_processes then reports the
+    # `zmx attach <sess> fish` CLIENT — nvim runs server-side, invisible to kitty
+    # (verified live). The OSC rides nvim's stdout through zmx to this window.
+    try:
+        if (window.user_vars or {}).get("nvim") == "1":
+            return True
+    except Exception:
+        pass
+    # FALLBACK: scan the visible foreground argv. Catches the windows this feature
+    # opens as `zmx attach <sess> nvim <file>` (the 'nvim' token is in the client
+    # argv) even before that nvim's VimEnter stamps the user-var — closes the
+    # startup race. A file literally named 'vim'/'nvim' is a harmless false
+    # positive (worst case: a pass-through where a toggle was wanted).
+    try:
+        for p in window.child.foreground_processes:
+            for tok in (p.get("cmdline") or []):
+                if tok and _NVIM_RE.match(os.path.basename(tok)):
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def _annex_window_in_tab(window, boss):
+    try:
+        tab = window.tabref() if hasattr(window, "tabref") else None
+    except Exception:
+        tab = None
+    windows = list(tab) if tab is not None else list(boss.all_windows)
+    for w in windows:
+        try:
+            if (w.user_vars or {}).get("annex") == "1":
+                return w
+        except Exception:
+            continue
+    return None
+
+
+def _name(prefix):
+    # Self-contained + unique per press (mirrors annex-cmd name / new-terminal):
+    # no fork, no network — instant in the interactive path.
+    return "%s-%s-%s" % (prefix, time.strftime("%H%M%S"), uuid.uuid4().hex[:6])
+
+
+@result_handler(no_ui=True)
+def handle_result(args, answer, target_window_id, boss):
+    which = args[1] if len(args) > 1 else "b"
+    w = boss.window_id_map.get(target_window_id)
+    if w is None:
+        return
+
+    # 1. Focused window IS the annex -> dismiss it (its watcher on_close reaps).
+    #    MUST precede the nvim pass-through: the annex payload is itself nvim, so
+    #    otherwise "press again to dismiss" would pass through instead.
+    if _is_annex(w):
+        boss.mark_window_for_close(w)  # accepts a Window; close_window() does not
+        return
+
+    # 2. Pass-through when a (zmx-wrapped) nvim editor is focused.
+    if _is_nvim(w):
+        if which == "shift":
+            w.write_to_child(b"\x1b[66;5u")  # Ctrl+Shift+B -> NvimTreeToggle
+        else:
+            w.write_to_child(b"\x02")  # Ctrl+B -> NvimTreeFocus
+        return
+
+    # 3. Dismiss an annex open elsewhere in this tab (its watcher on_close reaps).
+    existing = _annex_window_in_tab(w, boss)
+    if existing is not None:
+        # mark_window_for_close(window) is the correct API: Boss.close_window()
+        # takes NO argument (always closes window_for_dispatch) and would raise
+        # TypeError, and the old bare-except fell back to a GLOBAL var:annex=1
+        # match that could close annexes in OTHER tabs. This is tab-scoped.
+        boss.mark_window_for_close(existing)
+        return
+
+    # 3. Open a fresh annex sized to ~25 columns on the RIGHT.
+    home = os.path.expanduser("~")
+    try:
+        cols = int(w.screen.columns)
+    except Exception:
+        cols = 120
+    bias = int(round(25.0 / cols * 100.0)) if cols else 20
+    bias = max(5, min(95, bias))
+
+    sess = _name("annex")
+    zmx_dir = os.environ.get("ZMX_DIR", "/tmp/zmx-%d" % os.getuid())
+    pick = os.path.join(zmx_dir, "annex-pick-" + sess)
+    annex_cmd = os.path.join(home, ".local", "bin", "annex-cmd")
+    pick_lua = os.path.join(home, ".local", "bin", "annex-pick.lua")
+
+    boss.call_remote_control(
+        w,
+        (
+            "launch",
+            "--type=window",
+            "--location=vsplit",
+            "--bias",
+            str(bias),
+            "--cwd=current",
+            "--watcher",
+            "annex_watcher.py",
+            "--var",
+            "annex=1",
+            "--var",
+            "annex_session=" + sess,
+            "--var",
+            "annex_pick=" + pick,
+            "--env",
+            "ANNEX_PICK=" + pick,
+            "--",
+            annex_cmd,
+            "exec",
+            sess,
+            "nvim",
+            "-c",
+            "luafile " + pick_lua,
+        ),
+    )

--- a/home/dot_config/kitty/annex_watcher.py
+++ b/home/dot_config/kitty/annex_watcher.py
@@ -1,0 +1,86 @@
+# annex_watcher.py — kitty window watcher for the Ctrl+B annex (dotfiles#50).
+#
+# Attached via `launch --watcher annex_watcher.py`. on_close is the SOLE reaper
+# for the sidebar picker and also performs the file-open-in-new-window step.
+#
+# on_close fires whether the annex self-reaped (file chosen -> nvim :qa! ->
+# session self-reaps -> child exits -> window closes) or was force-closed
+# (Ctrl+B dismiss). In both cases:
+#   1. REAP: annex-cmd kill <session> — idempotent; cleans the leak path where a
+#      force-closed split left server-side nvim running (dotfiles#33). A no-op
+#      after a self-reap.
+#   2. OPEN: if the pick file holds a path (a file was selected), open it in a
+#      NEW niri window as a VISIBLE, roamable `term-*` zmx session (ruling 4:
+#      durable edit = real niri window; niri tiles it, the original reflows).
+#      Empty/absent pick file = a plain dismiss (open nothing).
+
+import os
+import subprocess
+import time
+import uuid
+
+
+def _name(prefix):
+    return "%s-%s-%s" % (prefix, time.strftime("%H%M%S"), uuid.uuid4().hex[:6])
+
+
+def on_close(boss, window, data):
+    home = os.path.expanduser("~")
+    annex_cmd = os.path.join(home, ".local", "bin", "annex-cmd")
+    uv = {}
+    try:
+        uv = window.user_vars or {}
+    except Exception:
+        uv = {}
+
+    # 1. Sole reaper (idempotent).
+    sess = uv.get("annex_session")
+    if sess:
+        try:
+            subprocess.Popen(
+                [annex_cmd, "kill", sess],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            pass
+
+    # 2. Open the selected file in a new niri window.
+    pick = uv.get("annex_pick")
+    if not pick:
+        return
+    path = ""
+    try:
+        if os.path.exists(pick):
+            with open(pick) as f:
+                path = f.readline().strip()
+    except Exception:
+        path = ""
+    try:
+        if os.path.exists(pick):
+            os.unlink(pick)
+    except Exception:
+        pass
+    if not path:
+        return
+
+    directory = os.path.dirname(path) or home
+    vsess = _name("term")
+    try:
+        boss.call_remote_control(
+            None,
+            (
+                "launch",
+                "--type=os-window",
+                "--cwd",
+                directory,
+                "--",
+                annex_cmd,
+                "exec",
+                vsess,
+                "nvim",
+                path,
+            ),
+        )
+    except Exception:
+        pass

--- a/home/dot_config/kitty/kitty.conf
+++ b/home/dot_config/kitty/kitty.conf
@@ -49,9 +49,17 @@ remember_window_size  no
 map ctrl+equal increase_font_size
 map ctrl+minus decrease_font_size
 
-# Remap ctrl+shift+b from "move window backwards" (useless since using tiling wm) to nvim-specific tree toggle
+# Annex sidebar picker (dotfiles#50). Ctrl+B / Ctrl+Shift+B toggle a hidden,
+# self-terminating RIGHT split (~25 cols) running nvim-tree as a file picker.
+# When the focused window's foreground process is nvim, the kitten PASSES THE
+# KEY THROUGH instead of toggling (Ctrl+B -> NvimTreeFocus \x02, Ctrl+Shift+B ->
+# NvimTreeToggle \x1b[66;5u) — preserving today's in-nvim behavior. The old
+# `send_text \x1b[66;5u` map is now handled inside the kitten's pass-through.
+# `--location=vsplit` only takes effect under the splits layout.
+enabled_layouts splits
 unmap ctrl+shift+b
-map ctrl+shift+b send_text all \x1b[66;5u
+map ctrl+b       kitten annex_toggle.py b
+map ctrl+shift+b kitten annex_toggle.py shift
 
 ### Scrollback buffer from https://github.com/mikesmithgh/kitty-scrollback.nvim/blob/main/README.md#%EF%B8%8F-setup
 # Enable remote control for Kitty
@@ -204,7 +212,10 @@ mark1_foreground #000000
 mark1_background #CC7BF4
 
 # splits/windows
-active_border_color #CC7BF4
+# Annex sidebar divider: match niri's INACTIVE window border (#373735,
+# layout.kdl:30) instead of the pink focus accent, so the Ctrl+B picker split
+# reads as a quiet niri-native sidebar rather than a loud highlight (Tom 2026-07-15).
+active_border_color #373735
 inactive_border_color #000000
 
 # NIX-MIGRATION: drift-port of the deployed 2026-06-26 edit (was live on this

--- a/home/dot_config/nvim/init.lua
+++ b/home/dot_config/nvim/init.lua
@@ -22,6 +22,29 @@ for _, a in ipairs(modules) do
   end
 end
 
+-- Kitty annex pass-through marker (dotfiles#50). The Ctrl+B kitten cannot see
+-- that nvim is running when nvim is launched by hand inside a zmx session: the
+-- kitty-visible foreground process is the `zmx attach <sess> fish` CLIENT, and
+-- nvim runs server-side (invisible to kitty). So nvim announces itself to kitty
+-- via a per-window user-var (SetUserVar OSC), which rides nvim's stdout through
+-- zmx to the owning kitty window for free. annex_toggle.py reads var:nvim=1 and
+-- passes Ctrl+B / Ctrl+Shift+B through to nvim instead of opening the annex.
+-- Guarded to kitty (KITTY_WINDOW_ID); other terminals consume/ignore the OSC.
+-- Value is base64 (kitty requires it): "1" = "MQ==", empty clears the var.
+local function kitty_annex_mark(b64)
+  if not vim.env.KITTY_WINDOW_ID then return end
+  local ok, out = pcall(function() return io.stdout end)
+  if not ok or not out then return end
+  out:write("\027]1337;SetUserVar=nvim=" .. b64 .. "\027\\")
+  out:flush()
+end
+api.nvim_create_autocmd({"VimEnter", "VimResume"}, {
+  callback = function() kitty_annex_mark("MQ==") end,  -- set nvim=1
+})
+api.nvim_create_autocmd({"VimLeavePre", "VimSuspend"}, {
+  callback = function() kitty_annex_mark("") end,       -- clear
+})
+
 -- Auto commands
 api.nvim_create_autocmd({"TermOpen", "TermEnter"}, {
   pattern = "term://*",

--- a/home/dot_local/bin/annex-cmd
+++ b/home/dot_local/bin/annex-cmd
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# annex-cmd — the shared substrate for both kitty "annex" mechanisms
+# (Ctrl+B sidebar picker, Ctrl+G composer). One script owns:
+#   * the ZMX_DIR pin (one session universe, see zmx-annotate header),
+#   * the hidden-name convention (`annex-*` = hidden modal split; `term-*` =
+#     visible roamable window),
+#   * the coordinator-vs-thin-client host branch (the ONLY place it lives —
+#     copied from new-terminal / conf.d/remote.fish's `desk`),
+#   * idempotent reaping of the one leak path (dotfiles#33).
+#
+# Both keybinds call this; neither re-implements host-awareness. A zmx session
+# self-reaps when its foreground command exits (verified), so `exec`ing nvim
+# self-terminates the annex on :wq/:qa for free (ruling 1.2). The only leak is
+# the split being force-closed while server-side nvim still runs — `kill`
+# handles that, and is a safe no-op after a self-reap.
+#
+# Subcommands:
+#   annex-cmd name <prefix>          -> "<prefix>-<HHMMSS>-<6hex>" (self-contained)
+#   annex-cmd exec <session> <cmd..> -> zmx attach the payload (host-aware)
+#   annex-cmd kill <session>         -> host-aware, idempotent reap
+set -u
+
+# One session universe regardless of entry path. zmx falls back to
+# /tmp/zmx-$UID only when XDG_RUNTIME_DIR is unset (true inside kitten-ssh
+# attach env, false in login shells) — pin it so local and remote agree.
+export ZMX_DIR="${ZMX_DIR:-/tmp/zmx-$(id -u)}"
+
+cmd="${1:-}"
+shift 2>/dev/null || true
+
+case "$cmd" in
+    name)
+        # Self-contained, unique per invocation (mirrors new-terminal 76-80):
+        # prefix + wallclock + 6 hex from the kernel RNG. No flm, no network,
+        # no blocking call — safe in the interactive launch path.
+        prefix="${1:-annex}"
+        rand="$(cut -c1-6 /proc/sys/kernel/random/uuid 2>/dev/null || printf '%s' "$$")"
+        printf '%s-%s-%s\n' "$prefix" "$(date +%H%M%S)" "$rand"
+        ;;
+
+    exec)
+        sess="${1:?annex-cmd exec: session name required}"
+        shift
+        if [[ "$(hostname)" == "coordinator" ]]; then
+            # Local: run the payload directly. zmx attach creates if missing and
+            # self-reaps when the foreground command (nvim) exits.
+            exec zmx attach "$sess" "$@"
+        fi
+        # Thin-client (worker / zenbook): reach the coordinator over the same
+        # kitten-ssh path everything else uses, so a compose survives a net blip
+        # (ruling 2). Shell-quote the payload argv for the remote bash -lc; the
+        # remote login shell (fish 3.4+) forwards it, $(id -u) evaluates there.
+        # Thread ANNEX_PICK to the coordinator when set (Ctrl+B picker): kitty's
+        # --env stamps it into THIS local split only, and plain ssh does not
+        # forward arbitrary env, so without this the coordinator-side nvim sees
+        # an empty ANNEX_PICK and file-selection signals nothing. The pick path
+        # string is uid-anchored (/tmp/zmx-$uid/…) so it names the SAME path on
+        # both hosts. UNVERIFIED thin-client gap that remains: annex_watcher.py
+        # reads the pick file on the LOCAL (kitty) host, while nvim writes it on
+        # the coordinator — completing the loop needs a host-aware, non-blocking
+        # read in the watcher; see the issue writeup.
+        inner="ZMX_DIR=/tmp/zmx-\$(id -u)"
+        [[ -n "${ANNEX_PICK:-}" ]] && inner+=" ANNEX_PICK=$(printf '%q' "$ANNEX_PICK")"
+        inner+=" zmx attach $(printf '%q' "$sess")"
+        for a in "$@"; do
+            inner+=" $(printf '%q' "$a")"
+        done
+        exec kitten ssh coordinator -t "bash -lc \"$inner\""
+        ;;
+
+    kill)
+        sess="${1:?annex-cmd kill: session name required}"
+        # Idempotent: --force so a still-running nvim in a force-closed split is
+        # reaped; a no-op (exit 0) when the session already self-reaped.
+        if [[ "$(hostname)" == "coordinator" ]]; then
+            zmx kill "$sess" --force >/dev/null 2>&1 || true
+        else
+            ssh coordinator "bash -lc \"ZMX_DIR=/tmp/zmx-\$(id -u) zmx kill $(printf '%q' "$sess") --force\"" >/dev/null 2>&1 || true
+        fi
+        ;;
+
+    *)
+        printf 'usage: annex-cmd {name <prefix>|exec <session> <cmd...>|kill <session>}\n' >&2
+        exit 2
+        ;;
+esac

--- a/home/dot_local/bin/annex-pick.lua
+++ b/home/dot_local/bin/annex-pick.lua
@@ -1,0 +1,80 @@
+-- annex-pick.lua — Ctrl+B sidebar picker payload (dotfiles#50).
+--
+-- Runs inside the hidden annex nvim (zmx-backed, coordinator-resident). Opens
+-- nvim-tree (Tom's own 25-col file bar) as the selector, filling the narrow
+-- annex, and overrides <CR>/o in the tree buffer to:
+--   * a directory -> expand/collapse (default),
+--   * a file      -> write its absolute path to $ANNEX_PICK, then :qa!.
+-- On :qa! the nvim exits, the zmx session self-reaps, the split collapses, and
+-- the kitty window watcher (annex_watcher.py) reads $ANNEX_PICK and opens the
+-- chosen file in a NEW niri window (durable edit = real window, ruling 4).
+-- Pure filesystem signaling: no fifo, no polling. Plain :q leaves the pick file
+-- absent/empty -> a dismiss (watcher reaps, opens nothing).
+--
+-- Lives in ~/.local/bin (a live whole-dir symlink) and is `luafile`'d at launch
+-- rather than added to ~/.config/nvim/lua — the latter is an explicit
+-- enumerated list in nvim.nix and would force a nixos-rebuild. This keeps the
+-- whole feature zero-rebuild.
+
+local ok, api = pcall(require, "nvim-tree.api")
+if not ok then
+  vim.cmd("qa!")
+  return
+end
+
+local pick = vim.env.ANNEX_PICK or ""
+
+local function choose()
+  local node = api.tree.get_node_under_cursor()
+  if not node then
+    return
+  end
+  if node.type == "directory" then
+    -- Expand/collapse the directory; do not signal.
+    api.node.open.edit()
+    return
+  end
+  -- File (or a symlink to one): signal the path and quit the annex.
+  if pick ~= "" and node.absolute_path then
+    pcall(vim.fn.writefile, { node.absolute_path }, pick)
+  end
+  vim.cmd("qa!")
+end
+
+-- Attach the overrides whenever the tree buffer materializes (register BEFORE
+-- opening the tree so the FileType event is not missed). CRUCIAL: nvim-tree
+-- applies its OWN default buffer-local <CR>/o mappings via on_attach when the
+-- buffer is created, and that can run AFTER this FileType callback — clobbering
+-- our override so <CR> falls back to nvim-tree's "open file in a window"
+-- (the file opens INSIDE the annex instead of signaling + detaching, the exact
+-- symptom seen 2026-07-15). vim.schedule defers our set() to the next tick, so it
+-- lands AFTER nvim-tree's defaults and wins deterministically.
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "NvimTree",
+  callback = function(ev)
+    vim.schedule(function()
+      if not vim.api.nvim_buf_is_valid(ev.buf) then
+        return
+      end
+      local o = { buffer = ev.buf, nowait = true, silent = true }
+      vim.keymap.set("n", "<CR>", choose, o)
+      vim.keymap.set("n", "o", choose, o)
+      vim.keymap.set("n", "l", choose, o)
+      vim.keymap.set("n", "<2-LeftMouse>", choose, o)
+    end)
+  end,
+})
+
+api.tree.open({ focus = true })
+
+-- Make the tree fill the ~25-col annex: drop the initial empty scratch window
+-- so only the tree remains. (nvim-tree no longer auto-closes when it is the
+-- last window, so this is safe.)
+vim.schedule(function()
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    local buf = vim.api.nvim_win_get_buf(win)
+    if vim.bo[buf].filetype ~= "NvimTree" then
+      pcall(vim.api.nvim_win_close, win, true)
+    end
+  end
+end)

--- a/home/dot_local/bin/nvim-annex
+++ b/home/dot_local/bin/nvim-annex
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# nvim-annex — Ctrl+G externalized composer wrapper (dotfiles#49).
+#
+# Claude Code's "edit prompt in external editor" spawns $EDITOR/$VISUAL
+# SYNCHRONOUSLY (spawnSync, stdio inherited) and reads the tempfile back on
+# exit. That blocking contract is Claude's own — this wrapper IS the
+# synchronization; there is no polling.
+#
+# The basename `nvim-annex` is LOAD-BEARING: Claude classifies the editor by
+# basename against /\b(vi|vim|nvim|nano|emacs|...)\b/. `nvim-annex` matches
+# \bnvim\b, so Claude takes the BLOCKING alt-screen spawnSync branch (an
+# unmatched name would make Claude spawn the editor DETACHED and read the
+# unchanged file back, losing the compose).
+#
+# Flow: open nvim on the harness tempfile in a hidden, zmx-backed NEW OS-WINDOW
+# (niri tiles it beside the harness; conversation stays visible) that BLOCKS
+# until nvim exits (kitten @ launch --type=os-window --wait-for-child-to-exit).
+# On :wq the zmx session self-reaps and the window closes. Tom 2026-07-15: Ctrl+G
+# is a modal WINDOW, not a split — the ~25-col vsplit style is ONLY for Ctrl+B's
+# picker sidebar.
+#
+# HARNESS-AGNOSTIC: this wrapper is the $EDITOR/$VISUAL for BOTH Claude Code and
+# pi (earendil-works/pi), scoped per-harness via functions/_annex_editor.fish.
+# Both spawn $EDITOR and re-read the tempfile ONLY on a clean (exit 0) editor
+# exit — Claude via spawnSync + `c.status!==0 -> content:null`, pi via
+# `if(status===0) editor.setText(...)` (verified in each bundle). So the exit
+# code this wrapper returns (below) is the single cross-harness safety signal.
+#
+# EXIT CODE — why it is NOT the child's: the exit status can NOT survive the zmx
+# layer. Verified: `zmx attach x bash -c 'exit 9'` returns 0, and
+# `kitten @ launch --wait-for-child-to-exit` reports that (masked) status. So a
+# killed/dropped compose is indistinguishable from a clean :wq by exit code
+# alone. Instead we signal out-of-band via the tempfile's OWN mtime: nvim writes
+# it ONLY on an explicit :w/:wq (never on open, never continuously — verified),
+# so its mtime bumps iff the user saved; a crash/kill/drop/:q! leaves it
+# untouched. mtime CHANGED -> user saved -> exit 0 (harness applies the edit).
+# mtime UNCHANGED -> nothing written -> exit nonzero -> harness KEEPS the original
+# prompt (graceful degradation). This is STRICTLY BETTER than a "clean :wq only"
+# sentinel: a :w followed by a crash still applies the content the user
+# deliberately saved, rather than silently discarding it. And because nvim never
+# leaves the file mid-write outside the sub-millisecond :w window, a stale read is
+# always last-saved-or-original, never a partial/garbage prompt. Nanosecond mtime
+# (stat %y) avoids the same-second collision that integer-second %Y would hit for
+# a fast edit.
+set -u
+
+export ZMX_DIR="${ZMX_DIR:-/tmp/zmx-$(id -u)}"
+
+self_dir="$(cd "$(dirname "$0")" 2>/dev/null && pwd)" || self_dir="$HOME/.local/bin"
+annex_cmd="$self_dir/annex-cmd"
+
+sess="$("$annex_cmd" name annex)"
+
+# Reap on ANY exit — including SIGINT/TERM/HUP if the user interrupts or quits
+# Claude mid-compose. Without this, an interrupt between launch and cleanup
+# orphans the coordinator-side annex zmx session (server-side nvim keeps
+# running) — the exact unreaped per-keypress spawn dotfiles#33 guards against.
+# Idempotent + guarded so it runs exactly once (no-op after the :wq self-reap).
+_reaped=""
+cleanup() {
+    [[ -n "$_reaped" ]] && return
+    _reaped=1
+    "$annex_cmd" kill "$sess" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT TERM HUP
+
+# The tempfile Claude hands us (last arg). Snapshot its mtime for the out-of-band
+# success signal described in the header. Guard $# so an argless call can't fall
+# back to $0 (a bash negative-slice quirk).
+file=""
+(( $# >= 1 )) && file="${@: -1}"
+before=""
+[[ -n "$file" && -e "$file" ]] && before="$(stat -c %y "$file" 2>/dev/null || true)"
+
+# Reach the kitty that spawned Claude (and thus this editor child). #53:
+# listen_on unix:@kitty-{kitty_pid}, allow_remote_control yes; KITTY_LISTEN_ON
+# is inherited by Claude's child env. Pass --to explicitly so the kitten reaches
+# the right socket even if inheritance is imperfect. LIMITATION (roaming): the
+# inherited KITTY_LISTEN_ON is frozen into the zmx session at CREATE time, so a
+# session re-attached in a different kitty window targets the original socket;
+# if that window is gone, the launch fails fast -> tempfile untouched -> we exit
+# nonzero -> Claude keeps the prompt (fails safe). Full roaming resolution is the
+# roaming work-package's job; see the issue writeup.
+to_args=()
+[[ -n "${KITTY_LISTEN_ON:-}" ]] && to_args=(--to "$KITTY_LISTEN_ON")
+
+# --type=os-window: niri tiles the composer nvim as its OWN window beside the
+# harness (Tom 2026-07-15), NOT an in-kitty split. --wait-for-child-to-exit
+# blocks this wrapper until that nvim exits — the synchronization the harness's
+# blocking editor contract relies on (works under Claude's spawnSync AND pi's
+# async-spawn-and-wait: both just wait for THIS process to exit). --cwd=current =
+# fish/kitty-derived cwd; the tempfile "$@" is absolute so cwd is irrelevant to
+# the edit. NOT combined with --no-response (freezes kitty). stdout -> /dev/null
+# so the exit-code digit kitten prints never lands on the harness's paused pane.
+kitten @ "${to_args[@]}" launch \
+    --type=os-window \
+    --cwd=current \
+    --wait-for-child-to-exit \
+    -- "$annex_cmd" exec "$sess" nvim "$@" >/dev/null 2>&1
+
+cleanup
+
+# Out-of-band success signal: did nvim write the tempfile? (see header)
+after=""
+[[ -n "$file" && -e "$file" ]] && after="$(stat -c %y "$file" 2>/dev/null || true)"
+if [[ -n "$file" && "$before" == "$after" ]]; then
+    exit 1  # nothing saved (crash / kill / drop / :q!) -> harness keeps original
+fi
+exit 0

--- a/home/dot_local/bin/zmx-annotate
+++ b/home/dot_local/bin/zmx-annotate
@@ -50,7 +50,11 @@ sessions() {
                 clients=*)   clients="${f#clients=}" ;;
             esac
         done
-        [[ -n "$name" && "$name" != */* ]] || continue
+        # Drop the hidden annex class (annex-*): modal Ctrl+B/Ctrl+G splits must
+        # never surface in any picker (ruling 2). This one guard covers all
+        # three consumers — zmx-resume (local), desk-resume (over ssh), and any
+        # other desk-resume client — since they all read zmx-annotate.
+        [[ -n "$name" && "$name" != */* && "$name" != annex-* ]] || continue
         printf '%s\t%s\t%s\t%s\n' "$name" "$dir" "$created" "$clients"
     done
 }

--- a/home/dot_local/bin/zmx-resume
+++ b/home/dot_local/bin/zmx-resume
@@ -22,7 +22,7 @@ export ZMX_DIR="${ZMX_DIR:-/tmp/zmx-$(id -u)}"
 # (format drift), fall back to the plain `--short` name list, duplicated into
 # both fields so the fzf invocation below still renders it.
 picker="$("$(dirname "$0")/zmx-annotate" 2>/dev/null)"
-[[ -n "$picker" ]] || picker="$(zmx list --short 2>/dev/null | awk '{printf "%s\t%s\n", $0, $0}')"
+[[ -n "$picker" ]] || picker="$(zmx list --short 2>/dev/null | awk '!/^annex-/{printf "%s\t%s\n", $0, $0}')"
 
 sess=$(printf '%s\n' "$picker" \
     | fzf --prompt='resume> ' --no-sort --delimiter='\t' --with-nth='2..' \


### PR DESCRIPTION
Implements the two kitty "annex" mechanisms from the 2026-07-14 annex handoff.
Discharges **#49** (Ctrl+G composer) and **#50** (Ctrl+B picker). One PR, two issues.
Deliberation gate on both is discharged by the handoff. **Do not merge/close until Tom
has tested** — see the checklist and the precise limitations below.

Built by an ultracode workflow (design → implement → 3 adversarial reviews → fix →
dedicated Ctrl+G-resilience pass), then hand-verified/extended by the orchestrator.

## What this does

**Ctrl+B — universal sidebar picker (#50).** In any kitty window (fish, Claude, pi),
Ctrl+B / Ctrl+Shift+B toggle a hidden, self-terminating RIGHT split (~25 cols, matching
`nvim-tree view.width=25`) running nvim-tree as a file picker. Select a file → it opens
in a NEW niri window via the zmx spawn path and the sidebar collapses; press again with
nothing selected → dismiss. Inside nvim the chord passes through to nvim's own tree.

**Ctrl+G — externalized composer (#49).** Leaves the harness's **native** Ctrl+G
untouched (no kitty/niri rebind); only scopes `$EDITOR`/`$VISUAL` to `nvim-annex` for the
harness process. `nvim-annex` opens the prompt tempfile in a **new niri terminal window**
(`--type=os-window`) and blocks until nvim exits. Harness-agnostic: works for `claude`
(+`cc`/`cac`) **and** `pi`, via a shared `_annex_editor.fish` helper + one thin wrapper
per harness (adding a harness = one wrapper). Crash-safe: since `zmx attach` swallows the
child exit code, `nvim-annex` derives success from the tempfile's nanosecond mtime
(saved → exit 0 → harness applies; untouched → exit 1 → harness keeps the original), and
as a direct child of the harness its exit code is truthful.

## Deployment / how to test
Everything is a **live out-of-store symlink — no `nixos-rebuild` needed.** On the
coordinator: `pkill -USR1 kitty` (reload kitty.conf + kittens) and open a **fresh nvim**
(so the pass-through marker loads).

### Test checklist (coordinator)
- [ ] **Ctrl+G in `cc`**: composer opens as a new niri window; `:wq` applies the prompt;
      quit without saving (`:q!`) / close the window → original prompt kept, uncorrupted.
- [ ] **Ctrl+G in `pi`**: same as above.
- [ ] **Ctrl+B in fish**: 25-col picker on the right; select a file → opens in a NEW
      window, sidebar collapses; toggle again with no selection → dismiss.
- [ ] **Ctrl+B / Ctrl+Shift+B inside hand-launched nvim**: passes through to the tree
      (does NOT open the annex).
- [ ] **No leaks**: after ~20 open/dismiss cycles, `zmx list` shows zero `annex-*`
      sessions; `zmx-resume` never lists them.

## ✅ Verified headlessly (this build session, on the coordinator)
- All 10 files syntax-clean (bash/fish/python/lua).
- Ctrl+G exit-code contract proven with a stubbed editor: **save→0, abort→1**.
- Substrate: unique hidden `annex-` names; zmx **self-reap** on payload exit; idempotent
  `kill`; `annex-*` hidden from `zmx-annotate`/`zmx-resume`/`desk-resume`, `term-*` shown.
- All paths live via symlink (bin, kitty, fish functions, nvim init.lua).

## ⛔ What could NOT be accomplished / is unverified — read before testing

**A. Not verifiable without a live GUI session (need Tom's keypress):**
1. Every interactive flow in the checklist above — I cannot press keys from the build
   session; the logic is verified but the real keypress behavior is not.
2. **The nvim→kitty pass-through marker relies on an UNTESTED escape emission.** Hand-
   launched nvim runs server-side under zmx, so kitty only sees `zmx attach … fish`;
   nvim announces itself via a kitty `SetUserVar` OSC written to its stdout (init.lua,
   guarded to kitty). Whether that OSC reliably reaches the owning kitty window *through
   zmx* is unconfirmed. If it doesn't, Ctrl+B inside hand-launched nvim will wrongly open
   the annex instead of passing through. (The argv-scan fallback only covers
   annex/opened-file windows, not hand-launched nvim.)

**B. Known-unfinished — will NOT work yet (precise):**
3. **Thin-client (zenbook) leg is entirely UNVERIFIED** — not exercised from this session.
4. **Ctrl+G on the thin-client is expected to be BROKEN.** `kitten ssh` does not forward
   remote control for **abstract** UNIX sockets, and kitty.conf uses
   `listen_on unix:@kitty-{kitty_pid}` — so `kitten @ launch` from inside Claude/pi on the
   zenbook cannot reach the kitty socket. It fails *safe* (nonzero → prompt kept) but the
   composer won't open remotely. Fix (a `~/.config/kitty/ssh.conf` + non-abstract socket)
   is **not** done.
5. **Ctrl+B file-open on the thin-client is BROKEN.** The selected-path signal (pick
   file + `ANNEX_PICK`) does not cross the ssh boundary — it's written on the coordinator
   but the watcher reads it locally. The picker opens, but selecting a file won't spawn
   the viewer window on the zenbook. **Coordinator-only for now.** (A terminal-native
   channel — kitty `SetUserVar` OSC from the annex nvim — is the intended fix; not built.)
6. **Ctrl+B annex cwd on the thin-client** may land at the coordinator's SSH-login `$HOME`
   rather than the project root (cwd isn't forwarded over the ssh leg).
7. **Ctrl+G roaming:** `KITTY_LISTEN_ON` is frozen into the zmx session at create time, so
   re-attaching that session in a different kitty window targets the original socket (fails
   safe if it's gone). Full roaming resolution is the roaming work-package's job.

**C. Intentional deviations from the handoff (Tom's call — confirm you're happy):**
8. Ctrl+G is a **new os-window**, not the handoff's right split (Tom's 2026-07-15
   correction; the split style is Ctrl+B's only).
8a. **Ctrl+G display behavior — the handoff's "conversation stays visible while
   composing" is NOT achievable under Claude Code (tested).** Claude classifies
   `nvim-annex` as a *terminal editor* (basename matches `\bnvim\b`) and therefore
   `pause()`/`suspendStdin()`s its pane (enters the alternate screen) around the
   blocking spawn, expecting the editor to draw there. Since nvim is in a separate
   window, Claude's pane goes **dark** until you `:wq`, then repaints with the
   applied prompt. This is the cost of reliable read-back — the two mutually
   exclusive options are:
   - **(kept) terminal branch:** blocks + reads the file back on save → compose
     works; Claude's pane is dark during the edit.
   - **non-terminal branch:** pane stays live, but Claude returns immediately
     without waiting → the compose is lost. Not viable.
   **pi does NOT go dark** (verified): pi spawns the editor async without pausing
   its renderer, so its conversation stays visible while you edit. Nothing is ever
   lost either way. If the Claude blackout becomes annoying, the only real
   alternative is a *separate* compose keybind that pastes into Claude's input
   rather than routing through Claude's native Ctrl+G — a different mechanism, not
   a tweak; not built here.
9. **#51 tension:** the opened-file window uses the existing **server-side** zmx spawn
   path (per the handoff), which contradicts REMOTE_NVIM_DECISION's local-nvim+rsync for
   durable thin-client editing. Followed the newer handoff; flagged here for your ruling.

**D. Minor / accepted:**
10. Sub-millisecond corruption window if nvim is force-killed *during* the `:w` write
    (negligible for a <page prompt; not worsened by this design).
11. No interactive-path timeout on a hung half-open socket (fails safe on normal teardown;
    a timeout was deliberately not added to keep the path pure).
12. `luac` unavailable in the build env — `annex-pick.lua` is parsed by nvim at runtime
    only (syntax not statically checked).

## Files
New: `annex-cmd`, `nvim-annex`, `annex-pick.lua`, `annex_toggle.py`, `annex_watcher.py`,
`_annex_editor.fish`, `claude.fish`, `pi.fish`.
Edited: `kitty.conf`, `nvim/init.lua`, `zmx-annotate`, `zmx-resume`, `remote.fish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
