### PR TITLE
feat(nvim): Ctrl+word editing & shift-arrow selection

### DIFF
--- a/home/dot_config/nvim/lua/mappings.lua
+++ b/home/dot_config/nvim/lua/mappings.lua
@@ -63,6 +63,13 @@ map("i", "<C-E>", "<End>")
 map("i", "<C-A>", "<Home>")
 map("i", "<S-TAB>", "<ESC><<<Ins>")
 
+-- Insert mode word deletion (text-box muscle memory)
+-- <C-w>'s notion of a word follows 'iskeyword', so punctuation boundaries
+-- differ slightly from a browser text box.
+map("i", "<C-BS>", "<C-w>")
+map("i", "<C-H>", "<C-w>")
+map("i", "<C-Del>", "<C-o>dw")
+
 -- ============================================================================
 -- UI & DISPLAY TOGGLES
 -- ============================================================================

--- a/home/dot_config/nvim/lua/options.lua
+++ b/home/dot_config/nvim/lua/options.lua
@@ -49,6 +49,10 @@ opt.showmatch = true
 opt.smartcase = true
 opt.whichwrap:append "<>[]hl"
 
+-- shift-arrow text selection (text-box muscle memory)
+opt.selectmode = 'key'
+opt.keymodel = 'startsel,stopsel'
+
 -- remove intro
 opt.shortmess:append "sI"
 


### PR DESCRIPTION
## Summary
- Insert-mode `<C-BS>`/`<C-H>` delete the previous word (`<C-w>`), `<C-Del>` deletes the next word, matching common text-box muscle memory.
- Shift-arrow now extends a select-mode selection (`selectmode=key`, `keymodel=startsel,stopsel`).
- Of the four sibling proposals captured in #48, `<C-S>` save and `clipboard=unnamedplus` were already implemented in the config — only the two missing ones are added here.

## Test plan
- [x] Verified via headless nvim loading the repo's `options.lua`/`mappings.lua` directly (bypassing stale home-manager store symlinks)
- [x] `<C-BS>` on `hello world` → `hello ` (word deleted)
- [x] `<C-H>` on `foo bar` → `foo ` (word deleted)
- [x] `<C-Del>` at start of `hello world` → `world` (word deleted forward)
- [x] `<S-Right><S-Right>` enters select mode (`mode() == 's'`)

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)