### PR TITLE
feat(strix): add amdtop

### DIFF
--- a/modules/strix.nix
+++ b/modules/strix.nix
@@ -2,6 +2,7 @@
   inputs,
   lib,
   config,
+  pkgs,
   ...
 }:
 # AMD Strix Halo layer — imported by `coordinator` + `worker` ONLY.
@@ -28,6 +29,9 @@
   };
 
   config = {
+    # One TUI for CPU, Radeon iGPU, and (on the coordinator) XDNA NPU telemetry.
+    environment.systemPackages = [ pkgs.amdtop ];
+
     # Strix Halo unified-memory tuning (128 GiB pinnable for the iGPU).
     # IOMMU is the ONE per-role knob: the coordinator runs the NPU, whose amdxdna
     # driver binds via IOMMU SVA/PASID and needs IOMMU ON in translated mode

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -81,6 +81,10 @@ final: prev: {
   # CGO on Linux via ebitengine/oto → ALSA. See pkgs/cliamp.nix.
   cliamp = final.callPackage ../pkgs/cliamp.nix { };
 
+  # amdtop — AMD GPU/CPU/XDNA NPU monitor. Not yet in our pinned nixpkgs;
+  # source-built from the latest stable upstream release for the Strix pair.
+  amdtop = final.callPackage ../pkgs/amdtop.nix { };
+
   # asr-rs — fully-local dual-Parakeet streaming STT daemon (v3: engine/client
   # split; the coordinator serves models on :8762 over tailscale0, thin clients
   # dictate against it). Source-built; onnxruntime static lib pinned as a FOD

--- a/pkgs/amdtop.nix
+++ b/pkgs/amdtop.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libdrm,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "amdtop";
+  version = "0.2.5";
+
+  src = fetchFromGitHub {
+    owner = "lhl";
+    repo = "amdtop";
+    rev = "v${version}";
+    hash = "sha256-31J4RC3npANffLXKQg7gjFe/XLVfM2NpV+t9+x7CpAU=";
+  };
+
+  cargoHash = "sha256-fgFiUmo4aRky91DHM7iR5UTL6tTcGAb5fBYGa8TpAMI=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libdrm ];
+
+  meta = {
+    description = "System monitor for AMD GPUs, CPUs, and XDNA NPUs";
+    homepage = "https://github.com/lhl/amdtop";
+    changelog = "https://github.com/lhl/amdtop/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    mainProgram = "amdtop";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Summary

- package `amdtop` v0.2.5 from the stable upstream tag with fixed source and Cargo hashes
- expose it through the local overlay
- install it from the shared Strix module, limiting it to `coordinator` and `worker`

## Why

The pinned nixpkgs revision does not yet provide `amdtop`. The Strix pair should have the unified AMD CPU, GPU, and XDNA NPU monitor available declaratively.

## Impact

`amdtop` will be on the system PATH of both Strix hosts after their next NixOS switch. No daemon or runtime configuration is introduced.

## Validation

- built `nixosConfigurations.coordinator.pkgs.amdtop`
- confirmed `amdtop --help` reports version 0.2.5 and links against the pinned `libdrm`
- evaluated both host package lists and confirmed `amdtop-0.2.5`
- ran `nix flake check --print-build-logs`
- built the complete coordinator and worker NixOS toplevels