### PR TITLE
feat: add the Strix Halo AI package plane

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -113,6 +113,43 @@
         "type": "github"
       }
     },
+    "bun2nix_2": {
+      "inputs": {
+        "flake-parts": [
+          "nix-strix-halo",
+          "nix-ai-tools",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nix-strix-halo",
+          "nix-ai-tools",
+          "nixpkgs"
+        ],
+        "systems": [
+          "nix-strix-halo",
+          "nix-ai-tools",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "nix-strix-halo",
+          "nix-ai-tools",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "ci": {
       "inputs": {
         "blueprint": "blueprint",
@@ -177,6 +214,71 @@
         "type": "github"
       }
     },
+    "ds4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781677530,
+        "narHash": "sha256-Ieuc72GHZs20ModQfnvI5Me31n4Pj+WFYtsuqaKJceo=",
+        "owner": "antirez",
+        "repo": "ds4",
+        "rev": "80ebbc396aee40eedc1d829222f3362d10fa4c6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "antirez",
+        "repo": "ds4",
+        "type": "github"
+      }
+    },
+    "ds4-hip": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780562402,
+        "narHash": "sha256-W0PW0274eHM3nYDtpwiMNKk3y4R42f4VpWKY5Nx9b8A=",
+        "owner": "ejpir",
+        "repo": "ds4-hip",
+        "rev": "3490c2e46c91331323dc0f2bfb7d3018e227fdff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ejpir",
+        "ref": "rocm-upstream-shape-cyberneurova",
+        "repo": "ds4-hip",
+        "type": "github"
+      }
+    },
+    "ec-su-axb35": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783792693,
+        "narHash": "sha256-+fN7C07oYYZW6qp4kDlg51N1mAgQTbgPiQnf2wX1KUs=",
+        "owner": "cmetz",
+        "repo": "ec-su_axb35-linux",
+        "rev": "7a9f372edcaa99e562dece70204c4f609692a778",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cmetz",
+        "repo": "ec-su_axb35-linux",
+        "type": "github"
+      }
+    },
+    "fastflowlm": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784320030,
+        "narHash": "sha256-kSOZvOqiiIMIRwcLivbRJwcBhkzr0fpeC8w3Q4iTj+M=",
+        "owner": "FastFlowLM",
+        "repo": "FastFlowLM",
+        "rev": "fd371409897d7c0abb4de4dbc5098b9b43c094ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FastFlowLM",
+        "repo": "FastFlowLM",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -232,9 +334,31 @@
         "type": "github"
       }
     },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-strix-halo",
+          "nix-ai-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -252,7 +376,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -309,6 +433,57 @@
         "type": "github"
       }
     },
+    "linux-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780549139,
+        "narHash": "sha256-HkhLiKigaUCQeH6z5enWhExJtW2LLh4NHVBrSlZc3XU=",
+        "ref": "refs/heads/next",
+        "rev": "503c5ae1e72aa9ed91925dafa3d82ee2e992747f",
+        "shallow": true,
+        "type": "git",
+        "url": "https://git.kernel.org/pub/scm/linux/kernel/git/westeri/thunderbolt.git"
+      },
+      "original": {
+        "ref": "refs/heads/next",
+        "shallow": true,
+        "type": "git",
+        "url": "https://git.kernel.org/pub/scm/linux/kernel/git/westeri/thunderbolt.git"
+      }
+    },
+    "llama-cpp-master": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784379738,
+        "narHash": "sha256-PU2rQT1KBxrox6Fo8sryTphR8Ir7i6Z2NEodKKgNOfI=",
+        "owner": "ggml-org",
+        "repo": "llama.cpp",
+        "rev": "571d0d540df04f25298d0e159e520d9fc62ed121",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ggml-org",
+        "repo": "llama.cpp",
+        "type": "github"
+      }
+    },
+    "llama-cpp-spacemit": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783141934,
+        "narHash": "sha256-Z8APQR0Xp9/zm+izIW0ICY8NhD5RQbZC/G49z3j9bJE=",
+        "owner": "spacemit-com",
+        "repo": "llama.cpp",
+        "rev": "86d4ff230bdfef62de1cc4987783a8d29af66d49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "spacemit-com",
+        "ref": "v0.1.5",
+        "repo": "llama.cpp",
+        "type": "github"
+      }
+    },
     "llm-agents": {
       "inputs": {
         "bun2nix": "bun2nix",
@@ -318,11 +493,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1784434920,
-        "narHash": "sha256-skbXCzMgZVerToN3LWaE1V9anxpVWn+RZqRUzpT9io0=",
+        "lastModified": 1784615936,
+        "narHash": "sha256-DzPXJmiePXn0+G6t5/H8nqTNX/AT7KlzVrpL5LZe8OE=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "40c1d8a8e37ee71560953cd269fb52cc2ba9d464",
+        "rev": "ba8c89d5b4836d46f7bdbffd2df34c66dadef725",
         "type": "github"
       },
       "original": {
@@ -352,6 +527,48 @@
         "type": "github"
       }
     },
+    "mlx-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784241827,
+        "narHash": "sha256-aYsfPcYIwsuKkYwssy0ANHuRVlM/KarfoTqlT8VJggo=",
+        "owner": "NripeshN",
+        "repo": "mlx",
+        "rev": "0dadb703d77301af29405cf7e12627efb88a6d0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NripeshN",
+        "ref": "rocm-support",
+        "repo": "mlx",
+        "type": "github"
+      }
+    },
+    "nix-ai-tools": {
+      "inputs": {
+        "bun2nix": "bun2nix_2",
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": [
+          "nix-strix-halo",
+          "nixpkgs"
+        ],
+        "systems": "systems_3",
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1784470748,
+        "narHash": "sha256-/A+1q5cjAdh/HH30MMzi7JDu1CM3mBoj2jFewUbq520=",
+        "owner": "numtide",
+        "repo": "nix-ai-tools",
+        "rev": "26b51974319a3931a16ae9eb7dd3f4b8b1c67fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-ai-tools",
+        "type": "github"
+      }
+    },
     "nix-amd-ai": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -360,11 +577,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1783698851,
-        "narHash": "sha256-cxQ4PCAdX/yN+WRQiR+9dhvYJlpS7kJOGuNZUafliAk=",
+        "lastModified": 1784641307,
+        "narHash": "sha256-SE/mAz26o4vnaWSlHQV2Ve0eDQvU5vVff1Vepb2BEGQ=",
         "owner": "noamsto",
         "repo": "nix-amd-ai",
-        "rev": "a4bf7884d964b327b65ac456abf4c29fd7ac0e8b",
+        "rev": "ca774cd41416ff75ed20168b23474cf70873ce8d",
         "type": "github"
       },
       "original": {
@@ -394,9 +611,74 @@
         "type": "github"
       }
     },
+    "nix-strix-halo": {
+      "inputs": {
+        "ds4": "ds4",
+        "ds4-hip": "ds4-hip",
+        "ec-su-axb35": "ec-su-axb35",
+        "fastflowlm": "fastflowlm",
+        "llama-cpp-master": "llama-cpp-master",
+        "llama-cpp-spacemit": "llama-cpp-spacemit",
+        "mlx-src": "mlx-src",
+        "nix-ai-tools": "nix-ai-tools",
+        "nixpkgs": "nixpkgs_3",
+        "spine-triton": "spine-triton",
+        "therock-src-7-15-gfx1151-base-half-011b45bd": "therock-src-7-15-gfx1151-base-half-011b45bd",
+        "therock-src-7-15-gfx1151-base-rocm-cmake-ec512d84": "therock-src-7-15-gfx1151-base-rocm-cmake-ec512d84",
+        "therock-src-7-15-gfx1151-compiler-amd-llvm-1e702164": "therock-src-7-15-gfx1151-compiler-amd-llvm-1e702164",
+        "therock-src-7-15-gfx1151-compiler-hipify-ea979a85": "therock-src-7-15-gfx1151-compiler-hipify-ea979a85",
+        "therock-src-7-15-gfx1151-compiler-spirv-llvm-translator-b9250448": "therock-src-7-15-gfx1151-compiler-spirv-llvm-translator-b9250448",
+        "therock-src-7-15-gfx1151-debug-tools-rocgdb-source-e3322990": "therock-src-7-15-gfx1151-debug-tools-rocgdb-source-e3322990",
+        "therock-src-7-15-gfx1151-math-libs-libhipcxx-10b48ff4": "therock-src-7-15-gfx1151-math-libs-libhipcxx-10b48ff4",
+        "therock-src-7-15-gfx1151-rocm-libraries-36c771f3": "therock-src-7-15-gfx1151-rocm-libraries-36c771f3",
+        "therock-src-7-15-gfx1151-rocm-systems-9c0ec3e9": "therock-src-7-15-gfx1151-rocm-systems-9c0ec3e9",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-lib-external-fmt-db1fc275": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-lib-external-fmt-db1fc275",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-lib-external-json-c887b002": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-lib-external-json-c887b002",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-vendored-pyyaml-b64e5974": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-vendored-pyyaml-b64e5974",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-abseil-cpp-471579c4": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-abseil-cpp-471579c4",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-cereal-7f708e93": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-cereal-7f708e93",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-elfio-cf38c296": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-elfio-cf38c296",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-filesystem-807165f4": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-filesystem-807165f4",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-gotcha-10fa2c98": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-gotcha-10fa2c98",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-json-a3f85fd2": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-json-a3f85fd2",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-perfetto-9d309359": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-perfetto-9d309359",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-ptl-db721fa0": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-ptl-db721fa0",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-pybind11-6da66437": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-pybind11-6da66437",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-dyninst-5f477976": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-dyninst-5f477976",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-json-ef3d2b7e": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-json-ef3d2b7e",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-onetbb-9159eae3": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-onetbb-9159eae3",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-papi-ae8ec169": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-papi-ae8ec169",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-perfetto-c27c4344": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-perfetto-c27c4344",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-pybind11-92d9411d": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-pybind11-92d9411d",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-1cc6846c": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-1cc6846c",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-742cff1f": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-742cff1f",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-811a2531": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-811a2531",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-d76a29fa": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-d76a29fa",
+        "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf": "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf",
+        "therock-src-7-15-gfx1151-root": "therock-src-7-15-gfx1151-root",
+        "therock-src-7-15-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c": "therock-src-7-15-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c",
+        "thunderbolt-ibverbs": "thunderbolt-ibverbs",
+        "vllm-src": "vllm-src",
+        "xdna-driver-src": "xdna-driver-src",
+        "xrt-src": "xrt-src"
+      },
+      "locked": {
+        "lastModified": 1784649118,
+        "narHash": "sha256-jQEqcJRFVHOV23YIBF9H5pM2ovrmUPvOAFQP4U8TTxo=",
+        "owner": "hellas-ai",
+        "repo": "nix-strix-halo",
+        "rev": "12e2ed21113e451a40414025eea012f2da984877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hellas-ai",
+        "repo": "nix-strix-halo",
+        "type": "github"
+      }
+    },
     "nixos-hardware": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1781622756,
@@ -415,11 +697,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784364478,
-        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {
@@ -431,11 +713,11 @@
     },
     "nixpkgs-fresh": {
       "locked": {
-        "lastModified": 1783776592,
-        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -462,11 +744,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1783224372,
-        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -477,6 +759,22 @@
       }
     },
     "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1784356753,
+        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1767892417,
         "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
@@ -489,7 +787,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1781577229,
         "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
@@ -505,7 +803,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1778556142,
         "narHash": "sha256-n6P0m0ahFtMMkubMcHe4ole6N01B2Ywhz8ROq6ncSxk=",
@@ -581,8 +879,9 @@
         "llm-agents": "llm-agents",
         "microvm": "microvm",
         "nix-amd-ai": "nix-amd-ai",
+        "nix-strix-halo": "nix-strix-halo",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-fresh": "nixpkgs-fresh",
         "ntm": "ntm",
         "piri": "piri",
@@ -706,6 +1005,25 @@
         "url": "https://spectrum-os.org/git/spectrum"
       }
     },
+    "spine-triton": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780563047,
+        "narHash": "sha256-z7t6hb+rQXqjDt0OwdcWkeDXosi4Vw+LsSQ9IYL1Zqw=",
+        "ref": "refs/tags/0.5.5",
+        "rev": "c62b11c5ea994ed6f7ce1d5ac881f14fc5e4aba4",
+        "revCount": 444,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/spacemit-com/spine-triton.git"
+      },
+      "original": {
+        "ref": "refs/tags/0.5.5",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/spacemit-com/spine-triton.git"
+      }
+    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -766,6 +1084,21 @@
         "type": "github"
       }
     },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "tally": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -785,6 +1118,606 @@
       "original": {
         "owner": "mecattaf",
         "repo": "tally.nix",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-base-half-011b45bd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750971477,
+        "narHash": "sha256-If9O5BEeymsLN+C0drZsPSxEWXpJTxeDBGNHNXSumm4=",
+        "owner": "ROCm",
+        "repo": "half",
+        "rev": "207ee58595a64b5c4a70df221f1e6e704b807811",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "half",
+        "rev": "207ee58595a64b5c4a70df221f1e6e704b807811",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-base-rocm-cmake-ec512d84": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755709169,
+        "narHash": "sha256-im6UO0crO0Jc27zkTsdvJYPHit8IGlw/vDPGrmP1XqY=",
+        "owner": "ROCm",
+        "repo": "rocm-cmake",
+        "rev": "10155d7272ea1bf79f6b5a9dbc339657af1aa372",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocm-cmake",
+        "rev": "10155d7272ea1bf79f6b5a9dbc339657af1aa372",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-compiler-amd-llvm-1e702164": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784147967,
+        "narHash": "sha256-UpoXFyhaO0H4TFYgPRvBo/MxSKr9NpJQgTM+NunfqdY=",
+        "owner": "ROCm",
+        "repo": "llvm-project",
+        "rev": "92fe31231dd83aedaedd822daa2079ca8a445547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "llvm-project",
+        "rev": "92fe31231dd83aedaedd822daa2079ca8a445547",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-compiler-hipify-ea979a85": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778159713,
+        "narHash": "sha256-hS13lgo2sDBfkOV5Nsiz0HixqgE9B0d7oRuU4o274ns=",
+        "owner": "ROCm",
+        "repo": "HIPIFY",
+        "rev": "c917282dbc1fe85d3814807a2c77d4288cff112d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "HIPIFY",
+        "rev": "c917282dbc1fe85d3814807a2c77d4288cff112d",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-compiler-spirv-llvm-translator-b9250448": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780443579,
+        "narHash": "sha256-OQi8TBqJ7K3vE5YSQkNtzAinylfd5QQtOUqiFf/ZDQI=",
+        "owner": "ROCm",
+        "repo": "SPIRV-LLVM-Translator",
+        "rev": "ddeda6468d45cf1e888a0e81e50bc170756a335b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "SPIRV-LLVM-Translator",
+        "rev": "ddeda6468d45cf1e888a0e81e50bc170756a335b",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-debug-tools-rocgdb-source-e3322990": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784124121,
+        "narHash": "sha256-oc/2aXdb8DJ+F9y2r91ocls+3EJtMKyOVDA6LQ6fEIE=",
+        "owner": "ROCm",
+        "repo": "rocgdb",
+        "rev": "1b5ded2e8e4239e9dc94b7c77c1b753cc7f68e26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocgdb",
+        "rev": "1b5ded2e8e4239e9dc94b7c77c1b753cc7f68e26",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-math-libs-libhipcxx-10b48ff4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782909735,
+        "narHash": "sha256-rXHXco98x1cD36MXA6UnJeBXK0s3PJibeSzwtr1eMV8=",
+        "owner": "ROCm",
+        "repo": "libhipcxx",
+        "rev": "3ea4c70920e0cdd1bab79d1897043090a93372b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "libhipcxx",
+        "rev": "3ea4c70920e0cdd1bab79d1897043090a93372b6",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-libraries-36c771f3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784062192,
+        "narHash": "sha256-X9MoNiS5JDiM7q1GTQgfJYJ2kTRCYWEKGs6n4qsMpC8=",
+        "owner": "ROCm",
+        "repo": "rocm-libraries",
+        "rev": "fa9cdd186b222f6449a6be1710038bdee4faa328",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocm-libraries",
+        "rev": "fa9cdd186b222f6449a6be1710038bdee4faa328",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-9c0ec3e9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784212595,
+        "narHash": "sha256-M6jbvyL+R9yVZ3iezUx5w67oXWRHJBFgR+Bh/6TzF68=",
+        "owner": "ROCm",
+        "repo": "rocm-systems",
+        "rev": "8ceab8e581fbd0e191b1a0a56f9e59d8d1ca4e00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocm-systems",
+        "rev": "8ceab8e581fbd0e191b1a0a56f9e59d8d1ca4e00",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-lib-external-fmt-db1fc275": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761748827,
+        "narHash": "sha256-ZmI1Dv0ZabPlxa02OpERI47jp7zFfjpeWCy1WyuPYZ0=",
+        "owner": "fmtlib",
+        "repo": "fmt",
+        "rev": "407c905e45ad75fc29bf0f9bb7c5c2fd3475976f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fmtlib",
+        "repo": "fmt",
+        "rev": "407c905e45ad75fc29bf0f9bb7c5c2fd3475976f",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-lib-external-json-c887b002": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777055253,
+        "narHash": "sha256-lQr/3uut38g00JEuBIXP4mLGPXiskbsz7r1XU448AQ8=",
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "98386eb08b609c172f9f4bf3e74c8d18c5ad583c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "98386eb08b609c172f9f4bf3e74c8d18c5ad583c",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-compute-src-vendored-pyyaml-b64e5974": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758834645,
+        "narHash": "sha256-jUooIBp80cLxvdU/zLF0X8Yjrf0Yp9peYeiFjuV8AHA=",
+        "owner": "yaml",
+        "repo": "pyyaml",
+        "rev": "49790e73684bebad1df05ef8d828fa12f685bffb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yaml",
+        "repo": "pyyaml",
+        "rev": "49790e73684bebad1df05ef8d828fa12f685bffb",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-abseil-cpp-471579c4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770824088,
+        "narHash": "sha256-TJT2Kzc64zI42FAbbGWP3Sshh1dU/D/AtEpgZrrhebg=",
+        "owner": "abseil",
+        "repo": "abseil-cpp",
+        "rev": "255c84dadd029fd8ad25c5efb5933e47beaa00c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "abseil",
+        "repo": "abseil-cpp",
+        "rev": "255c84dadd029fd8ad25c5efb5933e47beaa00c7",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-cereal-7f708e93": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1760484697,
+        "narHash": "sha256-iNg1U0g4Opj3VcZ2cv1q6hxXHio601KubCchNyfbih4=",
+        "owner": "jrmadsen",
+        "repo": "cereal",
+        "rev": "40a30defcb8874270a04836d316502b08904b2bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "cereal",
+        "rev": "40a30defcb8874270a04836d316502b08904b2bc",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-elfio-cf38c296": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755240366,
+        "narHash": "sha256-XvSK/OfH/krsiH3Tm/LdeuW9DePWGN8qHk8DDfzcP/Y=",
+        "owner": "serge1",
+        "repo": "ELFIO",
+        "rev": "575bfdb12cd90fa8913660295103549f151d116a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serge1",
+        "repo": "ELFIO",
+        "rev": "575bfdb12cd90fa8913660295103549f151d116a",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-filesystem-807165f4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678018010,
+        "narHash": "sha256-XZ0IxyNIAs2tegktOGQevkLPbWHam/AOFT+M6wAWPFg=",
+        "owner": "gulrak",
+        "repo": "filesystem",
+        "rev": "8a2edd6d92ed820521d42c94d179462bf06b5ed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gulrak",
+        "repo": "filesystem",
+        "rev": "8a2edd6d92ed820521d42c94d179462bf06b5ed3",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-gotcha-10fa2c98": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755016804,
+        "narHash": "sha256-FxCCtJnWFod5VXqfb+r0XlfcCAtcjNwfIsVhjUPlRQU=",
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "b944da10ff9b3364ef2e4b12e02cb2464e05dd48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "b944da10ff9b3364ef2e4b12e02cb2464e05dd48",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-json-a3f85fd2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732727001,
+        "narHash": "sha256-jqk9TS8qvucsZaK6HS5NNyFYnkyxQLNloF6pFtSrzMQ=",
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "e41905fcb0938a7502d25ea5242c6b41396e21b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "e41905fcb0938a7502d25ea5242c6b41396e21b0",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-perfetto-9d309359": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712741208,
+        "narHash": "sha256-9v4kUKpOLosGayu+GhhPOW/+NXSjX5Lngbt8YJ3KxFM=",
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "eb5ef24c58d13cec289d733d03f0f3f0ed321b12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "eb5ef24c58d13cec289d733d03f0f3f0ed321b12",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-ptl-db721fa0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1709321309,
+        "narHash": "sha256-DZQUjg8l1n6iPx9OCn3W3tt2vcwnQfgijCoIKjywF8I=",
+        "owner": "jrmadsen",
+        "repo": "PTL",
+        "rev": "48df41625430d27ce43cf197fd467a8dda87cb45",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "PTL",
+        "rev": "48df41625430d27ce43cf197fd467a8dda87cb45",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-pybind11-6da66437": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648696333,
+        "narHash": "sha256-O3bkexUBa+gfiJEM6KSR8y/iVqHqlCFmz/9EghxdIpw=",
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "914c06fb252b6cc3727d0eedab6736e88a3fcb01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "914c06fb252b6cc3727d0eedab6736e88a3fcb01",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-dyninst-5f477976": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781671772,
+        "narHash": "sha256-Q0GMeeGp8GNLYw5ydrWTGeaiU7rI267EXrsrOtRUPww=",
+        "owner": "ROCm",
+        "repo": "dyninst",
+        "rev": "5dff47bf6fb53e51cdc5e98c8ef6656080931ede",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "dyninst",
+        "rev": "5dff47bf6fb53e51cdc5e98c8ef6656080931ede",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-json-ef3d2b7e": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1744360948,
+        "narHash": "sha256-cECvDOLxgX7Q9R3IE86Hj9JJUxraDQvhoyPDF03B2CY=",
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "55f93686c01528224f448c19128836e7df245f72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "55f93686c01528224f448c19128836e7df245f72",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-onetbb-9159eae3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761737496,
+        "narHash": "sha256-HIHF6KHlEI4rgQ9Epe0+DmNe1y95K9iYa4V/wFnJfEU=",
+        "owner": "uxlfoundation",
+        "repo": "oneTBB",
+        "rev": "f1862f38f83568d96e814e469ab61f88336cc595",
+        "type": "github"
+      },
+      "original": {
+        "owner": "uxlfoundation",
+        "repo": "oneTBB",
+        "rev": "f1862f38f83568d96e814e469ab61f88336cc595",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-papi-ae8ec169": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773687226,
+        "narHash": "sha256-iII6W6HZXsHRgqniO5IH2GDjhl1JcwhYdhWuIE8Lymk=",
+        "owner": "icl-utk-edu",
+        "repo": "papi",
+        "rev": "c27003e1642f1c151c9b18ef9e7610072b3c852d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "icl-utk-edu",
+        "repo": "papi",
+        "rev": "c27003e1642f1c151c9b18ef9e7610072b3c852d",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-perfetto-c27c4344": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718298493,
+        "narHash": "sha256-L7RnOQmD74JFpa10mNwXcLV8YyyjaQ7qYx9eXJpizpw=",
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "35b3d9845c2f4017865c4dc93fafcf6d202f1651",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "35b3d9845c2f4017865c4dc93fafcf6d202f1651",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-pybind11-92d9411d": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689348038,
+        "narHash": "sha256-r0b1Wr/PtTk4kHOVhgSy3gi/GLED774Ys49J1E7B7WQ=",
+        "owner": "jrmadsen",
+        "repo": "pybind11",
+        "rev": "1a917f1852eb7819b671fc3fa862840f4c491a07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "pybind11",
+        "rev": "1a917f1852eb7819b671fc3fa862840f4c491a07",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-1cc6846c": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664927513,
+        "narHash": "sha256-MWdkZY255bVYLzUhV1BxMPb+LbM3dtDkg1M4AhrB2rQ=",
+        "owner": "jrmadsen",
+        "repo": "yaml-cpp",
+        "rev": "1b50109f7bea60bd382d8ea7befce3d2bd67da5f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "yaml-cpp",
+        "rev": "1b50109f7bea60bd382d8ea7befce3d2bd67da5f",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-742cff1f": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690716675,
+        "narHash": "sha256-z5YCue0zadQnMEbGFniFvDjXNy6dSHQDQnXRXS6Uh/Y=",
+        "owner": "libunwind",
+        "repo": "libunwind",
+        "rev": "24947191d61dda869e039e0414fe97e9f594acd5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libunwind",
+        "repo": "libunwind",
+        "rev": "24947191d61dda869e039e0414fe97e9f594acd5",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-811a2531": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752612818,
+        "narHash": "sha256-KHTPiNCzYtIsGcSwjVwFSIgO+GZgdBkruMfv1HNxzYk=",
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "6ef1232a0acc99f3340c2ca4c5d23890e9b8a459",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "6ef1232a0acc99f3340c2ca4c5d23890e9b8a459",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-d76a29fa": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689348038,
+        "narHash": "sha256-r0b1Wr/PtTk4kHOVhgSy3gi/GLED774Ys49J1E7B7WQ=",
+        "owner": "jrmadsen",
+        "repo": "pybind11",
+        "rev": "1a917f1852eb7819b671fc3fa862840f4c491a07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "pybind11",
+        "rev": "1a917f1852eb7819b671fc3fa862840f4c491a07",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780482623,
+        "narHash": "sha256-AAaBBfutxm0suCyJyTZK1vEEG9kAkeho2m6b0JGK4R8=",
+        "owner": "ROCm",
+        "repo": "timemory",
+        "rev": "54ae9d214a63132da22c7cab21c5fb4b7b5049f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "timemory",
+        "rev": "54ae9d214a63132da22c7cab21c5fb4b7b5049f8",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-root": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784405051,
+        "narHash": "sha256-mroWKdRD7qnOWpJI63s2h8fhZtvpHiD8f35aLtDu6m4=",
+        "owner": "ROCm",
+        "repo": "TheRock",
+        "rev": "1de3171d00f6de55e9ed517dc6ca6e825d1e4b55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "TheRock",
+        "rev": "1de3171d00f6de55e9ed517dc6ca6e825d1e4b55",
+        "type": "github"
+      }
+    },
+    "therock-src-7-15-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782156113,
+        "narHash": "sha256-DG3g3Ovdee/Sx6JFOYqEoRQFhm/z/4/Cmlj/kd6xxoA=",
+        "owner": "ROCm",
+        "repo": "mesa-fork",
+        "rev": "22abfc06d7cf4c115ca2e368505d75ba4af174b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "mesa-fork",
+        "rev": "22abfc06d7cf4c115ca2e368505d75ba4af174b4",
+        "type": "github"
+      }
+    },
+    "thunderbolt-ibverbs": {
+      "inputs": {
+        "linux-src": "linux-src",
+        "nixpkgs": [
+          "nix-strix-halo",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782863499,
+        "narHash": "sha256-Qx7O5WgO5wY8hUkERu2l+miVL4fTPONQyvtDmBBk0Yo=",
+        "owner": "hellas-ai",
+        "repo": "thunderbolt-ibverbs",
+        "rev": "76ba39b630a70accb72f19388eefe48844b50eb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hellas-ai",
+        "repo": "thunderbolt-ibverbs",
         "type": "github"
       }
     },
@@ -809,10 +1742,87 @@
         "type": "github"
       }
     },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-strix-halo",
+          "nix-ai-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vllm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783899612,
+        "narHash": "sha256-a2OoTfQOJyB8iKBfkfCC23MMBMOHEBjAZ0WGag8hcTQ=",
+        "owner": "vllm-project",
+        "repo": "vllm",
+        "rev": "752a3a504485790a2e8491cacbb35c137339ad34",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vllm-project",
+        "ref": "v0.25.1",
+        "repo": "vllm",
+        "type": "github"
+      }
+    },
+    "xdna-driver-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780591096,
+        "narHash": "sha256-pG9fptnKMoHbK2HSBObfflCyBt9k0uDO/leKvtsKUnA=",
+        "ref": "1.7",
+        "rev": "0fb464f6e043fdaf8d9007b76bd9e9a666ffe870",
+        "revCount": 873,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/amd/xdna-driver"
+      },
+      "original": {
+        "ref": "1.7",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/amd/xdna-driver"
+      }
+    },
+    "xrt-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780589208,
+        "narHash": "sha256-JrqJIGJoQiXTwXjZpqAXVaHx+6i09B1qtqkJzoRPZKw=",
+        "ref": "XRT-2.21",
+        "rev": "8661761775a266b11992a3bd6eb08209d88aa845",
+        "revCount": 8684,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Xilinx/XRT"
+      },
+      "original": {
+        "ref": "XRT-2.21",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Xilinx/XRT"
+      }
+    },
     "zig2nix": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1778610364,

--- a/flake.nix
+++ b/flake.nix
@@ -13,17 +13,10 @@
     # Browser point releases carry none of that risk, so they shouldn't have to wait
     # on it.
     #
-    # This input's OWN locked rev is never what actually builds: every real build
-    # (modules/auto-update.nix `system.autoUpgrade.flags`, hosts/worker/fleet-prebuild.nix)
-    # passes `--override-input nixpkgs-fresh github:NixOS/nixpkgs/nixos-unstable`,
-    # which re-resolves it to nixos-unstable HEAD at build time without writing
-    # anything to flake.lock — true "always latest" for just this input, no git-push
-    # automation or new credentials needed (only the coordinator holds a
-    # GitHub-authenticated `gh`; the worker, which builds nightly at 02:00, doesn't).
-    # Same decoupling trick the llm-agents.nix input comment describes for
-    # claude-code, inlined here instead of via a whole separate flake. A local build
-    # that omits the override flag just falls back to whatever's locked — bump it
-    # manually with `nix flake update nixpkgs-fresh` if that ever goes noticeably stale.
+    # Its lock entry is a reproducible fallback. Fleet prebuilds and switches use
+    # the centralized `rollingInputOverrides` list below to re-resolve it (alongside
+    # llm-agents and the two isolated AMD catalogs) at HEAD without writing the
+    # lock. A plain local build intentionally uses the reviewed fallback revision.
     nixpkgs-fresh.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     home-manager = {
@@ -76,8 +69,10 @@
     # ...). Its `overlays.default` exposes the whole set, prebuilt against its OWN
     # fresh nixpkgs-unstable, under the namespaced `pkgs.llm-agents.*` — so it
     # neither re-evaluates our nixpkgs nor collides with it. This is how we get
-    # newest claude-code DECOUPLED from our (deliberately lagging) nixpkgs pin:
-    # `nix flake update llm-agents` bumps agents without touching kernel/Mesa.
+    # newest claude-code DECOUPLED from our (deliberately lagging) nixpkgs pin.
+    # Nightly fleet builds re-resolve this input at HEAD via
+    # `rollingInputOverrides`; `nix flake update llm-agents` updates the local and
+    # failure-fallback lock without touching kernel/Mesa.
     # Deliberately NO inputs.nixpkgs.follows — following our pin would rebuild
     # against stale deps and miss the numtide cache (substituter added in
     # modules/common.nix). home/home.nix installs the entire set via buildEnv.
@@ -194,6 +189,32 @@
     let
       system = "x86_64-linux";
 
+      # Inputs whose PACKAGE CONTENT may move independently of the committed
+      # flake.lock during the nightly fleet build. Centralized here so the worker's
+      # cache warmer and each host's later switch resolve the exact same set.
+      #
+      # This is intentionally NOT the main nixpkgs input: kernel/Mesa remain behind
+      # an explicit lock-file review. These inputs are isolated package catalogs or
+      # accelerator flakes that carry their own nixpkgs/provider pins and caches.
+      rollingInputOverrides = [
+        {
+          name = "nixpkgs-fresh";
+          url = "github:NixOS/nixpkgs/nixos-unstable";
+        }
+        {
+          name = "llm-agents";
+          url = "github:numtide/llm-agents.nix";
+        }
+        {
+          name = "nix-amd-ai";
+          url = "github:noamsto/nix-amd-ai";
+        }
+        {
+          name = "nix-strix-halo";
+          url = "github:hellas-ai/nix-strix-halo";
+        }
+      ];
+
       # One overlay list everywhere (top-level pkgs + every host): bespoke pkgs,
       # the apple-fonts families, and sfmono-liga — wired inline because it
       # needs the flake input as src (overlays/default.nix has no inputs).
@@ -243,7 +264,7 @@
         hostModule:
         nixpkgs.lib.nixosSystem {
           inherit system;
-          specialArgs = { inherit inputs; };
+          specialArgs = { inherit inputs rollingInputOverrides; };
           modules = [
             {
               nixpkgs.overlays = overlays;

--- a/flake.nix
+++ b/flake.nix
@@ -146,13 +146,27 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # nix-amd-ai — AMD Ryzen AI NPU stack (amdxdna driver + XRT + FastFlowLM).
-    # COORDINATOR ONLY: the conductor turns the NPU on (needs IOMMU in translated
-    # mode); the worker keeps the NPU off for max iGPU (iommu off). Deliberately
+    # nix-amd-ai — the proven coordinator NPU plane (hardware.amd-npu: amdxdna,
+    # XRT plugin discovery, udev/memlock, FastFlowLM) plus the one accelerator
+    # package nix-strix-halo does not expose: stable-diffusion-cpp-rocm.
+    # COORDINATOR ONLY for the NPU module: the conductor turns the NPU on (needs
+    # IOMMU in translated mode); the worker keeps it off for max iGPU. Deliberately
     # NO inputs.nixpkgs.follows — the overlay is built against its OWN pinned
     # nixpkgs so its Cachix (nix-amd-ai.cachix.org, substituter added in
     # modules/common.nix) serves prebuilt XRT/FastFlowLM instead of source builds.
     nix-amd-ai.url = "github:noamsto/nix-amd-ai";
+
+    # nix-strix-halo — the broad gfx1151 package plane for BOTH Framework Desktop
+    # nodes: llama.cpp ROCm/Vulkan, ds4-rocm, vLLM, MLX, tokenizers, MES firmware,
+    # the two-host benchmark driver, and a buildable live ISO. Consume its package
+    # outputs directly rather than applying its global overlay: that preserves its
+    # own TheRock/Python provider graph and avoids replacing the already-live
+    # nix-amd-ai XRT/FastFlowLM pair. The two flakes currently pin identical XRT +
+    # amdxdna revisions, so a second XRT in /run/current-system/sw would only create
+    # colliding binaries. All NPU components remain exclusively sourced from
+    # nix-amd-ai. No nixpkgs.follows: upstream's Hydra artifacts are keyed to its
+    # own nixpkgs and provider pins (cache configured in common.nix).
+    nix-strix-halo.url = "github:hellas-ai/nix-strix-halo";
 
     # microvm.nix — declarative microVMs (astro → microvm-nix/microvm.nix). The
     # instrument behind the /microvm skill: it exports nixosModules.{microvm,host}
@@ -271,9 +285,32 @@
         modules = [ ./home/home.nix ];
       };
 
-      packages.${system} = {
-        inherit (pkgs) mactahoe-gtk-theme mactahoe-icon-theme sfmono-liga;
-      };
+      packages.${system} =
+        let
+          amdAi = inputs.nix-amd-ai.packages.${system};
+          strixAi = inputs.nix-strix-halo.packages.${system};
+        in
+        {
+          inherit (pkgs) mactahoe-gtk-theme mactahoe-icon-theme sfmono-liga;
+
+          # Explicit accelerator escape hatches. The host module installs the
+          # operational subset safely; these aliases also make every requested
+          # upstream output directly buildable with `nix build .#<name>` without
+          # applying either upstream overlay to the fleet's global pkgs fixpoint.
+          stable-diffusion-cpp-rocm = amdAi.stable-diffusion-cpp-rocm;
+          inherit (strixAi)
+            ds4-rocm
+            ec-su-axb35-monitor
+            llama-cpp-rocm
+            llama-cpp-vulkan
+            mlx-rocm
+            strix-halo-mes-firmware
+            strix-halo-vllm-pair-bench-gfx1151
+            tokenizers-cpp
+            vllm-rocm
+            ;
+          live-iso = strixAi.live-iso;
+        };
 
       formatter.${system} = pkgs.nixfmt-rfc-style;
 

--- a/hosts/worker/fleet-prebuild.nix
+++ b/hosts/worker/fleet-prebuild.nix
@@ -1,4 +1,10 @@
-{ config, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  rollingInputOverrides,
+  ...
+}:
 # Cache warmer — the "build ONCE" half of the Tally-owned fleet update.
 # This file defines only the root execution unit. coordinator's 02:00 calendar
 # producer in home/tally.nix dispatches it through Tally's daemonless worker
@@ -15,6 +21,13 @@
 # login was never done, this fails visibly at 02:00 (the earliest warning you get).
 let
   flakeRef = "github:mecattaf/dotfiles/main";
+  rollingInputFlags = lib.escapeShellArgs (
+    lib.concatMap (input: [
+      "--override-input"
+      input.name
+      input.url
+    ]) rollingInputOverrides
+  );
   prebuild = pkgs.writeShellScript "fleet-prebuild" ''
     set -u
     # attic login state lives in root's config; nix-daemon gives a sparse env.
@@ -22,12 +35,11 @@ let
     status=0
     for h in coordinator worker zenbook-duo; do
       echo "fleet-prebuild: building $h" >&2
-      # Same nixpkgs-fresh override as modules/auto-update.nix's autoUpgrade.flags —
-      # keeps the cache warmed with the SAME fresh-chrome build the 03:30/04:30/06:00
-      # switches will substitute, instead of each host resolving a slightly different
-      # nixos-unstable HEAD and rebuilding from source.
+      # Same centralized rolling-input overrides as modules/auto-update.nix — keeps
+      # the cache warmed with the SAME fresh agents/accelerator/browser packages the
+      # later switches request. Main nixpkgs remains locked and review-gated.
       if out="$(${config.nix.package}/bin/nix build --refresh --no-link --print-out-paths \
-            --override-input nixpkgs-fresh github:NixOS/nixpkgs/nixos-unstable \
+            ${rollingInputFlags} \
             "${flakeRef}#nixosConfigurations.$h.config.system.build.toplevel")"; then
         ${pkgs.attic-client}/bin/attic push fleet $out >&2 || status=1
       else

--- a/modules/auto-update.nix
+++ b/modules/auto-update.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  rollingInputOverrides,
   ...
 }:
 # Fleet update EXECUTION units. The coordinator's tally calendar producers own the
@@ -9,9 +10,10 @@
 # implementation on each target but deliberately disables its native timer.
 #
 # Every invocation re-fetches github:mecattaf/dotfiles/main and switches to it. The
-# committed flake.lock pins ordinary inputs, while nixpkgs-fresh is deliberately
-# re-resolved for the small hot-package overlay below. Lock bumps remain an operator
-# decision and are the only door through which kernel churn enters the fleet.
+# committed flake.lock pins ordinary inputs, while the package-only inputs declared
+# as rollingInputOverrides in flake.nix are deliberately re-resolved at build time.
+# Lock bumps remain an operator decision and are the only door through which main
+# nixpkgs/kernel/Mesa churn enters the fleet.
 #
 # TALLY CALENDAR (Europe/Paris), declared centrally in home/tally.nix:
 #   02:00  worker prebuild       build
@@ -31,6 +33,11 @@
 # nix.settings.{connect-timeout,fallback} for the dead-substituter degradation.
 let
   host = config.networking.hostName;
+  rollingInputFlags = lib.concatMap (input: [
+    "--override-input"
+    input.name
+    input.url
+  ]) rollingInputOverrides;
 
   # zenbook power gate: proceed on AC, OR on battery ≥ 50%. ExecCondition contract:
   # exit 0 → run the unit; non-zero → SKIP it cleanly (not a failure). Reads sysfs
@@ -56,15 +63,10 @@ in
     flake = "github:mecattaf/dotfiles/main";
     operation = "switch"; # live activation; a new kernel awaits a separately queued reboot.
     upgrade = false; # `--upgrade` is channel machinery; meaningless in flake mode.
-    # Re-resolve nixpkgs-fresh to nixos-unstable HEAD on every run (flake.nix input
-    # comment) — the "hot" overlay packages (google-chrome, uv) get whatever's newest
-    # each night, without a flake.lock bump touching the deliberately-lagging main
-    # nixpkgs pin.
-    flags = [
-      "--override-input"
-      "nixpkgs-fresh"
-      "github:NixOS/nixpkgs/nixos-unstable"
-    ];
+    # Re-resolve the isolated rolling package inputs at HEAD on every run. This
+    # keeps llm-agents and both accelerator catalogs fresh without using the same
+    # door for the deliberately-reviewed main nixpkgs/kernel/Mesa pin.
+    flags = rollingInputFlags;
     allowReboot = false;
   };
 

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -60,11 +60,13 @@
     # each from source; with it they're fetched. Key from the upstream flake's
     # nixConfig.
     # numtide → the llm-agents catalog; nix-amd-ai → prebuilt XRT/FastFlowLM for
-    # the coordinator's NPU (its overlay is pinned to its own nixpkgs, so this
-    # Cachix — NOT flake nixConfig — is what avoids building XRT from source).
+    # the coordinator's NPU; hellas → its gfx1151/TheRock package graph. Both AMD
+    # flakes keep their own nixpkgs/provider pins, so daemon-level cache trust —
+    # NOT a flake-local nixConfig — is what avoids multi-hour source builds.
     extra-substituters = [
       "https://cache.numtide.com"
       "https://nix-amd-ai.cachix.org"
+      "https://cache.hellas.ai"
       # Fleet binary cache — atticd on the coordinator (hosts/coordinator/attic.nix),
       # over the Tailscale mesh (MagicDNS `coordinator`; the Strix pair could also
       # use the TB5 fast lane `coordinator-tb`). The `fleet` cache is made public at
@@ -76,6 +78,7 @@
     extra-trusted-public-keys = [
       "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
       "nix-amd-ai.cachix.org-1:F4OU4vw/lV2oiG6SBHZ+nqjl4EFJuqI4X9A7pvaBmhQ="
+      "cache.hellas.ai-1:PYolh95U/Ms5fKE+NQTcNZUHyEv4QikaNocg9I9iy0g="
       # fleet cache signing key — the `fleet:...=` line from `attic cache info fleet`.
       # RUNTIME BOOTSTRAP: unknown until the cache is created on first server boot
       # (attic generates the keypair server-side), so it is added here once, after:

--- a/modules/strix-ai.nix
+++ b/modules/strix-ai.nix
@@ -1,0 +1,95 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+# Accelerated AI package plane shared by the two Strix Halo nodes.
+#
+# Source split (deliberate, after inspecting both upstreams at their 2026-07-21
+# heads):
+#   * nix-amd-ai remains the coordinator's proven hardware.amd-npu/FastFlowLM
+#     plane and supplies stable-diffusion-cpp-rocm, which hellas does not package.
+#   * nix-strix-halo supplies every other GPU/runtime package below. Its gfx1151
+#     DS4 build uses the targeted TheRock ROCm provider; do not also install
+#     nix-amd-ai's older, manually-pinned ds4 package under the same bin names.
+#
+# XRT is intentionally absent here. hardware.amd-npu already composes and exports
+# nix-amd-ai's XRT + amdxdna plugin on coordinator. Hellas currently pins the exact
+# same upstream commits, and putting both implementations in the system profile
+# would collide. They are not imported or re-exported: all NPU components have one
+# source of truth, the already-live nix-amd-ai module.
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  amdAi = inputs.nix-amd-ai.packages.${system};
+  strixAi = inputs.nix-strix-halo.packages.${system};
+
+  # llama.cpp and stable-diffusion.cpp place backend shared objects in $out/bin.
+  # nix-amd-ai documents that exposing those .so files through the global system
+  # profile makes GLib's GIO loader try to dlopen them as plugins. Project only
+  # commands into PATH while retaining the complete upstream package as a closure.
+  commandsOnly =
+    name: package:
+    pkgs.runCommand name { } ''
+      mkdir -p "$out/bin"
+      for entry in ${package}/bin/*; do
+        [ -e "$entry" ] || continue
+        case "$(basename "$entry")" in
+          *.so | *.so.*) continue ;;
+        esac
+        ln -s "$entry" "$out/bin/$(basename "$entry")"
+      done
+    '';
+
+  llamaRocmCommands = commandsOnly "strix-llama-cpp-rocm-commands" strixAi.llama-cpp-rocm;
+  llamaVulkanCommands = commandsOnly "strix-llama-cpp-vulkan-commands" strixAi.llama-cpp-vulkan;
+  stableDiffusionRocmCommands = commandsOnly "strix-stable-diffusion-cpp-rocm-commands" amdAi.stable-diffusion-cpp-rocm;
+in
+{
+  assertions = [
+    {
+      assertion = config.myCluster.role == "coordinator" || config.myCluster.role == "worker";
+      message = "modules/strix-ai.nix is only valid on a Strix cluster role";
+    }
+  ];
+
+  # User-facing engines and launchers on BOTH GPU nodes. FLM is not repeated here:
+  # coordinator already receives it from hardware.amd-npu; worker deliberately has
+  # no NPU runtime while amd_iommu=off preserves maximum iGPU bandwidth.
+  environment.systemPackages = [
+    llamaRocmCommands
+    llamaVulkanCommands
+    stableDiffusionRocmCommands
+    strixAi.ds4-rocm
+    strixAi.vllm-rocm
+  ]
+  ++ lib.optionals (config.myCluster.role == "coordinator") [
+    # This program SSHes to both boxes and gathers the result, so only the
+    # orchestrating node needs it in PATH; its vLLM/Ray closure is still shared
+    # through the fleet cache with the worker's vLLM package.
+    strixAi.strix-halo-vllm-pair-bench-gfx1151
+  ];
+
+  # Development/runtime libraries have no useful standalone command. Root them in
+  # each generation without spraying Python/static-library trees into the global
+  # profile; use `nix shell .#mlx-rocm .#tokenizers-cpp` for an interactive env.
+  system.extraDependencies = [
+    strixAi.mlx-rocm
+    strixAi.tokenizers-cpp
+  ];
+
+  # The focused 0x80 MES blobs are the only part of upstream's `tuning` module we
+  # adopt. Importing that whole module would regress our 128 GiB GTT ceiling to
+  # upstream's 80 GiB default and enable unrelated tmpfs/TuneD policy.
+  hardware.firmware = [ strixAi.strix-halo-mes-firmware ];
+
+  # Not installed: ec-su-axb35-monitor is for Sixunited AXB35 boards. Both nodes
+  # identify as Framework Desktop / FRANMFCP06, so its matching kernel driver would
+  # no-op and the monitor would have no sysfs endpoint. It remains buildable as
+  # `.#ec-su-axb35-monitor` for a future compatible machine.
+  #
+  # Also not a system dependency: `.#live-iso`. Rooting an installer ISO in every
+  # generation would force a multi-GiB image build on each nightly switch; keeping it
+  # as a flake package gives either node a reproducible on-demand build instead.
+}

--- a/modules/strix.nix
+++ b/modules/strix.nix
@@ -10,6 +10,9 @@
   imports = [
     # Framework Desktop / Ryzen AI Max 300 series (gfx1151). Pulls amd cpu+gpu+ssd tuning.
     inputs.nixos-hardware.nixosModules.framework-desktop-amd-ai-max-300-series
+    # Shared accelerated inference/tooling packages from nix-strix-halo plus the
+    # one noamsto-only GPU backend. Host-role details stay in that module.
+    ./strix-ai.nix
   ];
 
   options.myCluster = {


### PR DESCRIPTION
## Summary

- add `hellas-ai/nix-strix-halo` as the broad gfx1151 package catalog for the two Framework Desktop Strix Halo hosts
- install llama.cpp ROCm/Vulkan, DS4 ROCm, vLLM ROCm, and noamsto's stable-diffusion.cpp ROCm on both `coordinator` and `worker`
- root MLX ROCm and tokenizers-cpp on both hosts, add the targeted MES firmware on both, and install the two-node vLLM benchmark launcher on the coordinator
- expose all requested non-host outputs as flake packages, including the live ISO and AXB35 EC monitor (the latter is deliberately not activated on the Framework FRANMFCP06 boards)
- retain one NPU source of truth: the coordinator's existing `noamsto/nix-amd-ai` `hardware.amd-npu` module continues to own amdxdna, XRT composition/discovery, udev/memlock, IOMMU policy, and FastFlowLM; no Hellas XRT or amdxdna output is imported
- trust the Hellas binary cache and roll `llm-agents`, `nix-amd-ai`, `nix-strix-halo`, and `nixpkgs-fresh` at HEAD during the existing nightly fleet prebuild/switch path while leaving main nixpkgs/kernel/Mesa lock-reviewed

## Placement

- `coordinator`: shared GPU package plane + pair benchmark + existing noamsto NPU/FastFlowLM
- `worker`: shared GPU package plane; no NPU/XRT/FastFlowLM
- `zenbook-duo`: unchanged; imports neither `modules/strix.nix` nor `modules/strix-ai.nix`

## Validation

- `nix fmt` on all changed Nix files
- `nix-instantiate --parse` on all changed Nix files
- `git diff --check`
- offline flake metadata evaluation
- evaluated coordinator and worker system-package lists and confirmed the requested engines
- evaluated the Zenbook system-package list and toplevel derivation; no Strix packages are present
- evaluated rolling auto-upgrade flags and confirmed all four package-only overrides
- evaluated individual derivations for DS4, llama.cpp ROCm/Vulkan, stable-diffusion.cpp ROCm, vLLM, the pair benchmark, tokenizers, MES firmware, and the EC monitor

No `nixos-rebuild switch` was run.

## Upstream evaluation caveat

A complete coordinator/worker toplevel derivation evaluation was stopped at Hellas' current `mlx-rocm` graph. Although the default provider is the binary TheRock SDK, that output eagerly materializes the locked `ROCm/rocm-libraries` source flake input. `cache.hellas.ai` advertises that store object as 9,513,023,432 bytes with `Compression: none`, so the otherwise read-only evaluation became a multi-hour 9.5 GB transfer. This is an upstream graph/cache characteristic, not a reported Nix module error; expect the first Strix test switch to spend time materializing it.