### PR TITLE
feat(local-ai): scaffold guarded model roster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+All local-AI model calls must go through llama-swap; never call a backend directly.

--- a/docs/strix-halo-llm.md
+++ b/docs/strix-halo-llm.md
@@ -88,6 +88,7 @@ loadout plan's model inventory (§1 of that note).
 - **Loadout row**: **2** (VibeVoice-ASR-7B on the worker, kyuz0 voice-toolbox image).
 
 ### 4.3 Live streaming STT (asr-rs)
+# ! UPDATED: will migrate to voxtype utility, still to be decided if installed from official repo or from llm-agents.nix (prefferred)
 
 - **What**: instant dictation on the coordinator — live grey preview plus offline
   finalize. Tom's active workstream; described here, not prescribed.

--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,13 @@
         config.allowUnfree = true; # google-chrome
       };
 
+      localModelCatalog = import ./lib/local-models.nix { lib = nixpkgs.lib; };
+      localModelStore = import ./lib/model-store.nix {
+        inherit pkgs;
+        lib = nixpkgs.lib;
+        catalog = localModelCatalog;
+      };
+
       # Single host-wiring point. Every host = common.nix + its own module + HM.
       mkHost =
         hostModule:
@@ -333,6 +340,10 @@
           live-iso = strixAi.live-iso;
         };
 
+      # Artifact rows are individually buildable as `nix build .#models.<id>`.
+      # This operator escape hatch does not change the one NixOS install switch.
+      legacyPackages.${system}.models = localModelStore.packages;
+
       formatter.${system} = pkgs.nixfmt-rfc-style;
 
       devShells.${system}.default = pkgs.mkShell {
@@ -352,9 +363,43 @@
       checks.${system} = {
         deadnix = pkgs.runCommand "deadnix" { } ''
           ${pkgs.deadnix}/bin/deadnix --fail --no-lambda-pattern-names \
-            ${./flake.nix} ${./modules} ${./hosts} ${./overlays} ${./home} > $out 2>&1 \
+            ${./flake.nix} ${./lib} ${./modules} ${./hosts} ${./overlays} ${./home} > $out 2>&1 \
             || (cat $out; exit 1)
         '';
+
+        local-model-routing =
+          let
+            coordinator = self.nixosConfigurations.coordinator.config;
+            worker = self.nixosConfigurations.worker.config;
+            coordinatorSettings = coordinator.services.llama-swap.settings;
+            workerSettings = worker.services.llama-swap.settings;
+            modelPackagePaths = map toString (builtins.attrValues localModelStore.packages);
+            coordinatorExtraDependencies = map toString coordinator.system.extraDependencies;
+            workerExtraDependencies = map toString worker.system.extraDependencies;
+          in
+          assert
+            builtins.attrNames self.nixosConfigurations.coordinator.options.services.local-models == [
+              "downloadAllModels"
+            ];
+          assert !coordinator.services.local-models.downloadAllModels;
+          assert !worker.services.local-models.downloadAllModels;
+          assert nixpkgs.lib.intersectLists modelPackagePaths coordinatorExtraDependencies == [ ];
+          assert nixpkgs.lib.intersectLists modelPackagePaths workerExtraDependencies == [ ];
+          assert coordinatorSettings.models == { };
+          assert workerSettings.models == { };
+          assert
+            coordinatorSettings.peers == {
+              flm = {
+                proxy = "http://127.0.0.1:52625";
+                models = [ "gemma4-it:e4b" ];
+              };
+            };
+          assert workerSettings.peers == { };
+          assert !(nixpkgs.lib.hasInfix "-hf" (builtins.toJSON coordinatorSettings));
+          assert !(nixpkgs.lib.hasInfix "-hf" (builtins.toJSON workerSettings));
+          pkgs.runCommand "local-model-routing" { } ''
+            touch "$out"
+          '';
       };
     };
 }

--- a/home/dot_local/bin/zmx-title
+++ b/home/dot_local/bin/zmx-title
@@ -15,13 +15,12 @@
 # can never change behavior when the task-model is unavailable — "titling off"
 # === today's shipped `<cwd-basename>-<HHMMSS>` naming.
 #
-# Task model: the coordinator's local FastFlowLM (`flm serve`, NPU-backed),
-# reached over its OpenAI-compatible HTTP API. Host/port/model/URL are all
-# overridable via env vars (defaults match `flm`'s own defaults):
-#   FLM_HOST         (default 127.0.0.1)
-#   FLM_PORT         (default 52625 — `flm port`)
-#   FLM_TITLE_MODEL  (default gemma4-it:e4b)
-#   FLM_URL          (default http://$FLM_HOST:$FLM_PORT/v1/chat/completions)
+# Task model: the coordinator's NPU-backed FastFlowLM model, reached only
+# through llama-swap's OpenAI-compatible API. Host/port/model/URL are overridable:
+#   LLAMA_SWAP_HOST  (default 127.0.0.1)
+#   LLAMA_SWAP_PORT  (default 9292)
+#   FLM_TITLE_MODEL  (default gemma4-it:e4b, the llama-swap peer model ID)
+#   LLAMA_SWAP_URL   (default http://$LLAMA_SWAP_HOST:$LLAMA_SWAP_PORT/v1/chat/completions)
 #   ZMX_TITLE        (set to 0 to disable titling entirely)
 #   ZMX_TITLE_TIMEOUT (default 3 — hard wall-clock cap, seconds)
 set -u
@@ -36,10 +35,10 @@ emit_fallback() { printf '%s\n' "$fallback"; exit 0; }
 command -v curl >/dev/null 2>&1 || emit_fallback
 command -v jq   >/dev/null 2>&1 || emit_fallback
 
-host="${FLM_HOST:-127.0.0.1}"
-port="${FLM_PORT:-52625}"
+host="${LLAMA_SWAP_HOST:-127.0.0.1}"
+port="${LLAMA_SWAP_PORT:-9292}"
 model="${FLM_TITLE_MODEL:-gemma4-it:e4b}"
-url="${FLM_URL:-http://$host:$port/v1/chat/completions}"
+url="${LLAMA_SWAP_URL:-http://$host:$port/v1/chat/completions}"
 timeout="${ZMX_TITLE_TIMEOUT:-3}"
 
 # Gather content: positional args, plus stdin if something is piped in. Bounded

--- a/hosts/coordinator/default.nix
+++ b/hosts/coordinator/default.nix
@@ -56,10 +56,10 @@
   };
 
   # Preload a small model on the NPU and keep `flm serve` warm so the local
-  # OpenAI-compatible endpoint (127.0.0.1:52625) is always available to on-box
-  # consumers — zmx session titling, and the memory-flush path. `model` is the
-  # ONE place to swap which model the coordinator warms; runs as tom so the pull
-  # lands in ~/.config/flm/models (weights stay out of the nix store).
+  # OpenAI-compatible backend (127.0.0.1:52625) stays warm behind llama-swap.
+  # zmx titling and every other local consumer use llama-swap on :9292. `model`
+  # is the ONE place to swap which model the coordinator warms; runs as tom so
+  # the pull lands in ~/.config/flm/models (weights stay out of the nix store).
   services.npu-llm = {
     enable = true;
     model = "gemma4-it:e4b";

--- a/lib/local-models.nix
+++ b/lib/local-models.nix
@@ -1,0 +1,309 @@
+{ lib }:
+
+let
+  inherit (lib) mkOption types;
+
+  nullableString = types.nullOr types.str;
+
+  checkpointType = types.submodule {
+    options = {
+      url = mkOption {
+        type = types.str;
+        description = "Canonical model/checkpoint URL.";
+      };
+      revision = mkOption {
+        type = types.str;
+        description = "Immutable source revision.";
+      };
+    };
+  };
+
+  fileType = types.submodule {
+    options = {
+      path = mkOption {
+        type = types.str;
+        description = "Path below the pinned Hugging Face revision.";
+      };
+      bytes = mkOption {
+        type = types.ints.positive;
+        description = "Exact byte size.";
+      };
+      oid = mkOption {
+        type = types.str;
+        description = "Upstream LFS object ID.";
+      };
+      hash = mkOption {
+        type = types.str;
+        description = "Nix SRI content hash.";
+      };
+    };
+  };
+
+  artifactType = types.submodule {
+    options = {
+      kind = mkOption {
+        type = types.enum [
+          "model"
+          "mtp-head"
+          "mmproj"
+          "tokenizer"
+          "template"
+        ];
+        description = "Artifact's role in a deployment.";
+      };
+      maker = mkOption {
+        type = types.str;
+        description = "Organization or person that trained the artifact.";
+      };
+      baseCheckpoint = mkOption {
+        type = types.nullOr checkpointType;
+        default = null;
+      };
+      fineTune = mkOption {
+        type = types.nullOr checkpointType;
+        default = null;
+      };
+      source = {
+        hfUrl = mkOption {
+          type = types.str;
+          description = "Canonical Hugging Face repository URL.";
+        };
+        revision = mkOption {
+          type = types.str;
+          description = "Pinned Hugging Face commit.";
+        };
+        primary = mkOption {
+          type = types.str;
+          description = "Primary file path; the first part for split GGUFs.";
+        };
+        files = mkOption {
+          type = types.nonEmptyListOf fileType;
+          description = "One file or every part of a split artifact.";
+        };
+      };
+      notes = mkOption {
+        type = types.str;
+        default = "";
+      };
+    };
+  };
+
+  artifactRefsType = types.submodule {
+    options = {
+      model = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      mtpHead = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      mmproj = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      tokenizer = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      template = mkOption {
+        type = nullableString;
+        default = null;
+      };
+    };
+  };
+
+  runtimeType = types.submodule {
+    options = {
+      repository = mkOption {
+        type = types.str;
+        description = "Runtime source repository.";
+      };
+      commit = mkOption {
+        type = types.str;
+        description = "Exact runtime commit.";
+      };
+      args = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = ''
+          Backend arguments. @model@, @mtpHead@, @mmproj@, @tokenizer@, and
+          @template@ resolve to immutable store paths.
+        '';
+      };
+    };
+  };
+
+  peerType = types.submodule {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = "llama-swap peer ID.";
+      };
+      proxy = mkOption {
+        type = types.str;
+        description = "OpenAI-compatible upstream base URL.";
+      };
+      systemdUnit = mkOption {
+        type = nullableString;
+        default = null;
+        description = "Optional local backend unit ordered before llama-swap.";
+      };
+    };
+  };
+
+  benchmarkType = types.submodule {
+    options = {
+      sourceRepo = mkOption { type = types.str; };
+      sourceCommit = mkOption { type = types.str; };
+      runId = mkOption { type = types.str; };
+      name = mkOption { type = types.str; };
+      score = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      speed = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      context = mkOption {
+        type = nullableString;
+        default = null;
+      };
+    };
+  };
+
+  deploymentType = types.submodule {
+    options = {
+      model = mkOption {
+        type = types.str;
+        description = "Model ID presented through llama-swap.";
+      };
+      role = mkOption {
+        type = types.enum [
+          "utility"
+          "coding"
+          "general"
+          "quality"
+          "vision"
+          "draft"
+        ];
+      };
+      status = mkOption {
+        type = types.enum [
+          "canonical"
+          "candidate"
+          "experimental"
+          "negative"
+          "retired"
+        ];
+      };
+      backend = mkOption {
+        type = types.enum [
+          "rocm"
+          "vulkan"
+          "ds4"
+          "vllm"
+          "mlx"
+          "sd-rocm"
+          "npu"
+        ];
+      };
+      hosts = mkOption {
+        type = types.nonEmptyListOf (
+          types.enum [
+            "coordinator"
+            "worker"
+          ]
+        );
+        description = "Hosts on which this canonical deployment is installed.";
+      };
+      ramTierGb = mkOption {
+        type = types.ints.unsigned;
+        default = 0;
+      };
+      artifacts = mkOption {
+        type = artifactRefsType;
+        default = { };
+      };
+      runtime = mkOption { type = runtimeType; };
+      peer = mkOption {
+        type = types.nullOr peerType;
+        default = null;
+      };
+      benchmark = mkOption {
+        type = types.nullOr benchmarkType;
+        default = null;
+      };
+      evidence = mkOption {
+        type = types.enum [
+          "matched-local"
+          "upstream-measured"
+          "api-only"
+          "unverified"
+        ];
+      };
+      hardware = mkOption {
+        type = types.str;
+        default = "";
+      };
+      supersedes = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      supersededBy = mkOption {
+        type = nullableString;
+        default = null;
+      };
+      notes = mkOption {
+        type = types.str;
+        default = "";
+      };
+    };
+  };
+
+  evaluated = lib.evalModules {
+    modules = [
+      {
+        options = {
+          artifacts = mkOption {
+            type = types.attrsOf artifactType;
+            default = { };
+          };
+          deployments = mkOption {
+            type = types.attrsOf deploymentType;
+            default = { };
+          };
+        };
+
+        config = {
+          # No GGUF is promoted during this storage-constrained bootstrap.
+          artifacts = { };
+
+          deployments.flm-gemma4-it-e4b = {
+            model = "gemma4-it:e4b";
+            role = "utility";
+            status = "canonical";
+            backend = "npu";
+            hosts = [ "coordinator" ];
+            runtime = {
+              repository = "https://github.com/FastFlowLM/FastFlowLM";
+              commit = "fd371409897d7c0abb4de4dbc5098b9b43c094ff";
+            };
+            peer = {
+              name = "flm";
+              proxy = "http://127.0.0.1:52625";
+              systemdUnit = "flm-serve.service";
+            };
+            evidence = "matched-local";
+            hardware = "coordinator XDNA2 NPU; amdxdna/XRT from nix-amd-ai";
+            notes = "FastFlowLM owns these weights via runtime flm pull; callers still enter through llama-swap.";
+          };
+        };
+      }
+    ];
+  };
+in
+{
+  inherit (evaluated.config) artifacts deployments;
+}

--- a/lib/model-store.nix
+++ b/lib/model-store.nix
@@ -1,0 +1,50 @@
+{
+  catalog,
+  lib,
+  pkgs,
+}:
+
+let
+  safeName = name: lib.replaceStrings [ "/" ":" " " ] [ "-" "-" "-" ] name;
+
+  fetchFile =
+    artifactId: source: file:
+    pkgs.fetchurl {
+      url = "${lib.removeSuffix "/" source.hfUrl}/resolve/${source.revision}/${file.path}";
+      hash = file.hash;
+      name = "${safeName artifactId}-${builtins.baseNameOf file.path}";
+    };
+
+  materializeArtifact =
+    artifactId: artifact:
+    let
+      fetched = map (file: {
+        inherit (file) path;
+        derivation = fetchFile artifactId artifact.source file;
+      }) artifact.source.files;
+      package =
+        if builtins.length fetched == 1 then
+          (builtins.head fetched).derivation
+        else
+          pkgs.linkFarm "local-model-${safeName artifactId}" (
+            map (file: {
+              name = builtins.baseNameOf file.path;
+              path = file.derivation;
+            }) fetched
+          );
+      primary =
+        if builtins.length fetched == 1 then
+          package
+        else
+          "${package}/${builtins.baseNameOf artifact.source.primary}";
+    in
+    {
+      inherit package primary;
+    };
+
+  materialized = lib.mapAttrs materializeArtifact catalog.artifacts;
+in
+{
+  inherit materialized;
+  packages = lib.mapAttrs (_: artifact: artifact.package) materialized;
+}

--- a/modules/llama-swap.nix
+++ b/modules/llama-swap.nix
@@ -6,11 +6,11 @@
 }:
 # Native llama-swap control plane for the two Strix Halo nodes.
 #
-# Part 1 of 2: this module owns only the proxy package, lifecycle, state, and
-# network boundary. The next session owns the model roster, backend commands,
-# groups, and weight materialization. The proxy itself is a small, always-on Go
+# This module owns only the proxy package, lifecycle, state, and network
+# boundary. local-models.nix owns the typed roster, backend commands, peers, and
+# guarded weight materialization. The proxy itself is a small, always-on Go
 # process and consumes no GPU. Tally remains the admission controller for the
-# per-box GPU pools; llama-swap supplies the stable API door and load/unload
+# per-box GPU pools; llama-swap supplies the one stable API door and load/unload
 # mechanism.
 let
   cfg = config.services.llama-swap;
@@ -51,10 +51,6 @@ in
       # independent global timer evict a model during an admitted batch job.
       globalTTL = 0;
       unloadTimeout = 60;
-
-      # The serving plane is live now; declarative per-role model definitions land
-      # here as their backend/weight choices are promoted from the loadout plan.
-      models = { };
     };
   };
 
@@ -68,11 +64,11 @@ in
   systemd.services.llama-swap = {
     wants = [ "network-online.target" ];
     after = [ "network-online.target" ];
-    environment.LLAMA_CACHE = "/var/cache/llama-swap";
     serviceConfig = {
       # The upstream NixOS module uses DynamicUser + ProtectSystem=strict. Add
-      # systemd-managed writable paths for v240's activity store and llama.cpp's
-      # on-demand `-hf` downloads (the same LLAMA_CACHE seam qmx's module uses).
+      # systemd-managed writable paths for v240's activity store and backend
+      # scratch state. Model weights are immutable store paths; runtime downloads
+      # are forbidden by modules/local-models.nix.
       StateDirectory = "llama-swap";
       StateDirectoryMode = "0750";
       CacheDirectory = "llama-swap";

--- a/modules/local-models.nix
+++ b/modules/local-models.nix
@@ -1,0 +1,213 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.local-models;
+  catalog = import ../lib/local-models.nix { inherit lib; };
+  modelStore = import ../lib/model-store.nix {
+    inherit catalog lib pkgs;
+  };
+  system = pkgs.stdenv.hostPlatform.system;
+  strixAi = inputs.nix-strix-halo.packages.${system};
+  host = config.networking.hostName;
+
+  deploymentList = builtins.attrValues catalog.deployments;
+  canonicalForHost = lib.filterAttrs (
+    _: deployment: deployment.status == "canonical" && lib.elem host deployment.hosts
+  ) catalog.deployments;
+  canonicalList = builtins.attrValues canonicalForHost;
+  canonicalModelIds = map (deployment: deployment.model) canonicalList;
+  peerDeployments = lib.filter (deployment: deployment.peer != null) canonicalList;
+  gpuDeployments = lib.filterAttrs (_: deployment: deployment.peer == null) canonicalForHost;
+
+  peerNames = lib.unique (map (deployment: deployment.peer.name) peerDeployments);
+  peers = lib.genAttrs peerNames (
+    peerName:
+    let
+      members = lib.filter (deployment: deployment.peer.name == peerName) peerDeployments;
+    in
+    {
+      proxy = (builtins.head members).peer.proxy;
+      models = map (deployment: deployment.model) members;
+    }
+  );
+  peerUnits = lib.unique (
+    lib.filter (unit: unit != null) (map (deployment: deployment.peer.systemdUnit) peerDeployments)
+  );
+
+  referencedArtifactIds =
+    deployment: lib.filter (artifactId: artifactId != null) (builtins.attrValues deployment.artifacts);
+  hostArtifactIds = lib.unique (
+    lib.concatMap referencedArtifactIds (builtins.attrValues gpuDeployments)
+  );
+  hostArtifactPackages = map (
+    artifactId: modelStore.materialized.${artifactId}.package
+  ) hostArtifactIds;
+
+  resolveArtifacts =
+    deployment:
+    lib.mapAttrs (
+      _: artifactId: if artifactId == null then null else modelStore.materialized.${artifactId}.primary
+    ) deployment.artifacts;
+
+  expandRuntimeArg =
+    deploymentName: resolved: arg:
+    lib.foldl' (
+      expanded: slot:
+      let
+        token = "@${slot}@";
+        path = resolved.${slot};
+      in
+      if lib.hasInfix token expanded && path == null then
+        throw "local-model deployment ${deploymentName}: ${token} has no artifact"
+      else if path == null then
+        expanded
+      else
+        lib.replaceStrings [ token ] [ (toString path) ] expanded
+    ) arg (builtins.attrNames resolved);
+
+  renderModel =
+    deploymentName: deployment:
+    let
+      resolved = resolveArtifacts deployment;
+      modelPath = resolved.model;
+      runtimeArgs = map (expandRuntimeArg deploymentName resolved) deployment.runtime.args;
+      extraArgs = lib.concatMapStringsSep " " lib.escapeShellArg runtimeArgs;
+      command =
+        if deployment.backend == "rocm" then
+          "${strixAi.llama-cpp-rocm}/bin/llama-server --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}"
+        else if deployment.backend == "vulkan" then
+          "${strixAi.llama-cpp-vulkan}/bin/llama-server --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}"
+        else if deployment.backend == "ds4" then
+          "${strixAi.ds4-rocm}/bin/ds4-server --host 127.0.0.1 --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}"
+        else
+          throw "local-model deployment ${deploymentName}: backend ${deployment.backend} has no llama-swap command renderer yet";
+    in
+    {
+      name = deployment.model;
+      value = {
+        name = deployment.model;
+        cmd = command + lib.optionalString (runtimeArgs != [ ]) " ${extraArgs}";
+      };
+    };
+
+  gpuModels = lib.mapAttrs' renderModel gpuDeployments;
+
+  artifactIds = builtins.attrNames catalog.artifacts;
+  deploymentIds = builtins.attrNames catalog.deployments;
+  artifactRows = builtins.attrValues catalog.artifacts;
+  peerProxyFor =
+    peerName:
+    lib.unique (
+      map (deployment: deployment.peer.proxy) (
+        lib.filter (deployment: deployment.peer != null && deployment.peer.name == peerName) deploymentList
+      )
+    );
+  manifest = (pkgs.formats.json { }).generate "local-model-catalog.json" catalog;
+
+  catalogAssertions = [
+    {
+      assertion = lib.all (
+        artifact: lib.elem artifact.source.primary (map (file: file.path) artifact.source.files)
+      ) artifactRows;
+      message = "Every local-model artifact primary must name one of its source files.";
+    }
+    {
+      assertion = lib.all (
+        artifact:
+        let
+          basenames = map (file: builtins.baseNameOf file.path) artifact.source.files;
+        in
+        builtins.length basenames == builtins.length (lib.unique basenames)
+      ) artifactRows;
+      message = "Split local-model artifact files must have unique basenames.";
+    }
+    {
+      assertion = lib.all (
+        deployment: lib.all (artifactId: lib.elem artifactId artifactIds) (referencedArtifactIds deployment)
+      ) deploymentList;
+      message = "Every local-model deployment artifact reference must exist in the artifact catalog.";
+    }
+    {
+      assertion = lib.all (
+        deployment:
+        if deployment.peer == null then
+          deployment.artifacts.model != null
+        else
+          referencedArtifactIds deployment == [ ]
+      ) deploymentList;
+      message = "Local GPU deployments require a model artifact; external peers must not root artifacts.";
+    }
+    {
+      assertion = lib.all (
+        deployment:
+        deployment.status != "canonical" || deployment.peer != null || lib.elem "worker" deployment.hosts
+      ) deploymentList;
+      message = "Every canonical GPU deployment must be assigned to the exhaustive worker roster.";
+    }
+    {
+      assertion = builtins.length canonicalModelIds == builtins.length (lib.unique canonicalModelIds);
+      message = "Canonical llama-swap model IDs must be unique per host.";
+    }
+    {
+      assertion = lib.all (
+        deployment: lib.all (arg: !(lib.hasInfix "-hf" arg)) deployment.runtime.args
+      ) deploymentList;
+      message = "Runtime model downloads (-hf) are forbidden; use pinned store artifacts.";
+    }
+    {
+      assertion = lib.all (peerName: builtins.length (peerProxyFor peerName) == 1) peerNames;
+      message = "All deployments on one llama-swap peer must use the same proxy URL.";
+    }
+    {
+      assertion = lib.all (
+        deployment:
+        (deployment.supersedes == null || lib.elem deployment.supersedes deploymentIds)
+        && (deployment.supersededBy == null || lib.elem deployment.supersededBy deploymentIds)
+      ) deploymentList;
+      message = "Local-model lineage must reference another deployment row.";
+    }
+  ];
+  failedCatalogAssertion = lib.findFirst (entry: !entry.assertion) null catalogAssertions;
+  catalogValid =
+    if failedCatalogAssertion == null then true else throw failedCatalogAssertion.message;
+in
+{
+  options.services.local-models.downloadAllModels = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = ''
+      Materialize every canonical model artifact assigned to this host and
+      expose it through llama-swap. False evaluates metadata only and roots no
+      roster weights in the NixOS closure.
+    '';
+  };
+
+  config = {
+    assertions = catalogAssertions;
+
+    # Metadata is generational and inspectable even while downloads are disabled.
+    environment.etc."local-models/catalog.json".source = manifest;
+
+    services.llama-swap.settings =
+      assert catalogValid;
+      {
+        inherit peers;
+        models = if cfg.downloadAllModels then gpuModels else { };
+      };
+
+    # This is the only branch that roots weight FODs. With the committed false
+    # setting, Nix never needs to resolve or fetch any catalog artifact.
+    system.extraDependencies = lib.optionals cfg.downloadAllModels hostArtifactPackages;
+
+    systemd.services.llama-swap = lib.mkIf (peerUnits != [ ]) {
+      wants = peerUnits;
+      after = peerUnits;
+    };
+  };
+}

--- a/modules/npu-llm.nix
+++ b/modules/npu-llm.nix
@@ -10,10 +10,10 @@
 # single obvious place that names the model the coordinator preloads on its XDNA2
 # NPU (today gemma4-it:e4b — Q4_1, 128k max ctx). Changing which model gets
 # warmed later = edit that one string. `flm serve` runs as a warm systemd unit so
-# the local OpenAI-compatible endpoint (FastFlowLM's default port 52625, bound to
-# localhost) is always up for on-box consumers: zmx session titling depends on
-# it, and this same always-on NPU small-model endpoint is what unblocks the
-# "memory flush" functionality.
+# the local OpenAI-compatible backend (FastFlowLM's default port 52625, bound to
+# localhost) stays warm behind llama-swap. zmx session titling and every other
+# consumer enter through llama-swap's port 9292; the NPU endpoint is never a
+# public application-facing route.
 #
 # The amdxdna driver, XRT userspace, and the `flm` binary itself all come from
 # hardware.amd-npu (nix-amd-ai) — upstream ships no serve unit or model option,

--- a/modules/strix.nix
+++ b/modules/strix.nix
@@ -15,6 +15,8 @@
     ./strix-ai.nix
     # Native local-model proxy/control plane on coordinator + worker only.
     ./llama-swap.nix
+    # Typed model catalog, guarded store materialization, and host projections.
+    ./local-models.nix
   ];
 
   options.myCluster = {
@@ -34,6 +36,10 @@
   };
 
   config = {
+    # THE one model-install switch. Keep false until the reviewed roster and the
+    # external cold-storage migration are ready; false roots zero model weights.
+    services.local-models.downloadAllModels = false;
+
     # One TUI for CPU, Radeon iGPU, and (on the coordinator) XDNA NPU telemetry.
     environment.systemPackages = [ pkgs.amdtop ];
 


### PR DESCRIPTION
## Summary

- add a typed artifact/deployment catalog plus pinned-Hugging-Face FOD/link-farm model-store machinery
- add the single `services.local-models.downloadAllModels` switch, explicitly committed as `false`
- project the coordinator's existing `gemma4-it:e4b` FastFlowLM service through a llama-swap peer while leaving the worker roster empty
- repoint `zmx-title` to llama-swap and establish the repo-wide local-AI routing rule
- expose future artifacts as `.#models.<id>` and add false-mode routing/closure assertions
- include the working-journal note for the planned voxtype migration

No GGUF roster row or model weight is added in this bootstrap.

## Validation

- both host configs evaluate with `downloadAllModels = false`
- coordinator settings: empty `models`, FLM-only peer
- worker settings: empty `models` and `peers`
- llama-swap v240 starts successfully with both generated YAML shapes
- `zmx-title` shell parse and deterministic fallback smoke test
- Nix parse/format and scoped `git diff --check`
- `checks.x86_64-linux.{local-model-routing,deadnix}`