### PR TITLE
fix(local-ai): complete llama-swap backend renderers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-All local-AI model calls must go through llama-swap; never call a backend directly.
+All local LLM calls must go through llama-swap; stable diffusion is outside this LLM route.

--- a/flake.nix
+++ b/flake.nix
@@ -331,6 +331,7 @@
             ec-su-axb35-monitor
             llama-cpp-rocm
             llama-cpp-vulkan
+            mlx-lm
             mlx-rocm
             strix-halo-mes-firmware
             strix-halo-vllm-pair-bench-gfx1151
@@ -376,6 +377,24 @@
             modelPackagePaths = map toString (builtins.attrValues localModelStore.packages);
             coordinatorExtraDependencies = map toString coordinator.system.extraDependencies;
             workerExtraDependencies = map toString worker.system.extraDependencies;
+            testRenderers = import ./lib/local-model-runtime.nix {
+              lib = nixpkgs.lib;
+              packages = {
+                llamaRocm = "/runtime/rocm";
+                llamaVulkan = "/runtime/vulkan";
+                ds4 = "/runtime/ds4";
+                vllm = "/runtime/vllm";
+                mlxLm = "/runtime/mlx-lm";
+              };
+            };
+            testRender =
+              renderer:
+              renderer {
+                deployment.model = "test-model";
+                modelPath = "/models/model.gguf";
+                modelDirectory = "/models/model-directory";
+              };
+            renderedBackends = nixpkgs.lib.mapAttrs (_: testRender) testRenderers;
           in
           assert
             builtins.attrNames self.nixosConfigurations.coordinator.options.services.local-models == [
@@ -397,6 +416,44 @@
           assert workerSettings.peers == { };
           assert !(nixpkgs.lib.hasInfix "-hf" (builtins.toJSON coordinatorSettings));
           assert !(nixpkgs.lib.hasInfix "-hf" (builtins.toJSON workerSettings));
+          assert
+            localModelCatalog.backendKinds == {
+              local = [
+                "rocm"
+                "vulkan"
+                "ds4"
+                "vllm"
+                "mlx"
+              ];
+              peers = [ "npu" ];
+            };
+          assert
+            builtins.attrNames renderedBackends == [
+              "ds4"
+              "mlx"
+              "rocm"
+              "vllm"
+              "vulkan"
+            ];
+          assert
+            renderedBackends.rocm.cmd == "/runtime/rocm/bin/llama-server --port \${PORT} -m /models/model.gguf";
+          assert
+            renderedBackends.vulkan.cmd
+            == "/runtime/vulkan/bin/llama-server --port \${PORT} -m /models/model.gguf";
+          assert
+            renderedBackends.ds4.cmd
+            == "/runtime/ds4/bin/ds4-server --host 127.0.0.1 --port \${PORT} -m /models/model.gguf";
+          assert
+            renderedBackends.vllm.cmd
+            == "/runtime/vllm/bin/vllm serve /models/model-directory --host 127.0.0.1 --port \${PORT} --served-model-name test-model";
+          assert renderedBackends.vllm.useModelName == "test-model";
+          assert nixpkgs.lib.elem "HF_HUB_OFFLINE=1" renderedBackends.vllm.env;
+          assert
+            renderedBackends.mlx.cmd
+            == "/runtime/mlx-lm/bin/mlx_lm.server --model /models/model-directory --host 127.0.0.1 --port \${PORT}";
+          assert renderedBackends.mlx.useModelName == "default_model";
+          assert nixpkgs.lib.elem "HF_HUB_OFFLINE=1" renderedBackends.mlx.env;
+          assert builtins.hasAttr "mlx-lm" inputs.nix-strix-halo.packages.${system};
           pkgs.runCommand "local-model-routing" { } ''
             touch "$out"
           '';

--- a/lib/local-model-backends.nix
+++ b/lib/local-model-backends.nix
@@ -1,0 +1,10 @@
+{
+  local = [
+    "rocm"
+    "vulkan"
+    "ds4"
+    "vllm"
+    "mlx"
+  ];
+  peers = [ "npu" ];
+}

--- a/lib/local-model-runtime.nix
+++ b/lib/local-model-runtime.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  packages,
+}:
+
+let
+  offlineModelEnv = [
+    "HF_HOME=/var/cache/llama-swap/huggingface"
+    "HF_HUB_OFFLINE=1"
+    "TRANSFORMERS_OFFLINE=1"
+  ];
+in
+{
+  rocm =
+    { modelPath, ... }:
+    {
+      cmd = "${packages.llamaRocm}/bin/llama-server --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}";
+    };
+  vulkan =
+    { modelPath, ... }:
+    {
+      cmd = "${packages.llamaVulkan}/bin/llama-server --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}";
+    };
+  ds4 =
+    { modelPath, ... }:
+    {
+      cmd = "${packages.ds4}/bin/ds4-server --host 127.0.0.1 --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}";
+    };
+  vllm =
+    {
+      deployment,
+      modelDirectory,
+      ...
+    }:
+    {
+      cmd = "${packages.vllm}/bin/vllm serve ${lib.escapeShellArg (toString modelDirectory)} --host 127.0.0.1 --port \${PORT} --served-model-name ${lib.escapeShellArg deployment.model}";
+      env = offlineModelEnv ++ [
+        "TORCHINDUCTOR_CACHE_DIR=/var/cache/llama-swap/torchinductor"
+        "TRITON_CACHE_DIR=/var/cache/llama-swap/triton"
+        "VLLM_CACHE_ROOT=/var/cache/llama-swap/vllm"
+        "VLLM_DO_NOT_TRACK=1"
+        "VLLM_NO_USAGE_STATS=1"
+      ];
+      useModelName = deployment.model;
+    };
+  mlx =
+    {
+      modelDirectory,
+      ...
+    }:
+    {
+      cmd = "${packages.mlxLm}/bin/mlx_lm.server --model ${lib.escapeShellArg (toString modelDirectory)} --host 127.0.0.1 --port \${PORT}";
+      env = offlineModelEnv;
+      # mlx-lm maps this sentinel to the immutable --model directory. Without
+      # the rewrite it treats the public roster ID as a Hugging Face repo.
+      useModelName = "default_model";
+    };
+}

--- a/lib/local-models.nix
+++ b/lib/local-models.nix
@@ -3,6 +3,7 @@
 let
   inherit (lib) mkOption types;
 
+  backendKinds = import ./local-model-backends.nix;
   nullableString = types.nullOr types.str;
 
   checkpointType = types.submodule {
@@ -199,15 +200,7 @@ let
         ];
       };
       backend = mkOption {
-        type = types.enum [
-          "rocm"
-          "vulkan"
-          "ds4"
-          "vllm"
-          "mlx"
-          "sd-rocm"
-          "npu"
-        ];
+        type = types.enum (backendKinds.local ++ backendKinds.peers);
       };
       hosts = mkOption {
         type = types.nonEmptyListOf (
@@ -305,5 +298,6 @@ let
   };
 in
 {
+  inherit backendKinds;
   inherit (evaluated.config) artifacts deployments;
 }

--- a/lib/model-store.nix
+++ b/lib/model-store.nix
@@ -22,16 +22,13 @@ let
         inherit (file) path;
         derivation = fetchFile artifactId artifact.source file;
       }) artifact.source.files;
-      package =
-        if builtins.length fetched == 1 then
-          (builtins.head fetched).derivation
-        else
-          pkgs.linkFarm "local-model-${safeName artifactId}" (
-            map (file: {
-              name = builtins.baseNameOf file.path;
-              path = file.derivation;
-            }) fetched
-          );
+      directory = pkgs.linkFarm "local-model-${safeName artifactId}" (
+        map (file: {
+          name = builtins.baseNameOf file.path;
+          path = file.derivation;
+        }) fetched
+      );
+      package = if builtins.length fetched == 1 then (builtins.head fetched).derivation else directory;
       primary =
         if builtins.length fetched == 1 then
           package
@@ -39,7 +36,7 @@ let
           "${package}/${builtins.baseNameOf artifact.source.primary}";
     in
     {
-      inherit package primary;
+      inherit directory package primary;
     };
 
   materialized = lib.mapAttrs materializeArtifact catalog.artifacts;

--- a/modules/local-models.nix
+++ b/modules/local-models.nix
@@ -40,6 +40,18 @@ let
     lib.filter (unit: unit != null) (map (deployment: deployment.peer.systemdUnit) peerDeployments)
   );
 
+  modelRenderers = import ../lib/local-model-runtime.nix {
+    inherit lib;
+    packages = {
+      llamaRocm = strixAi.llama-cpp-rocm;
+      llamaVulkan = strixAi.llama-cpp-vulkan;
+      ds4 = strixAi.ds4-rocm;
+      vllm = strixAi.vllm-rocm;
+      mlxLm = strixAi.mlx-lm;
+    };
+  };
+  rendererBackends = builtins.attrNames modelRenderers;
+
   referencedArtifactIds =
     deployment: lib.filter (artifactId: artifactId != null) (builtins.attrValues deployment.artifacts);
   hostArtifactIds = lib.unique (
@@ -75,24 +87,23 @@ let
     deploymentName: deployment:
     let
       resolved = resolveArtifacts deployment;
-      modelPath = resolved.model;
+      modelArtifact = modelStore.materialized.${deployment.artifacts.model};
+      modelPath = modelArtifact.primary;
+      modelDirectory = modelArtifact.directory;
       runtimeArgs = map (expandRuntimeArg deploymentName resolved) deployment.runtime.args;
       extraArgs = lib.concatMapStringsSep " " lib.escapeShellArg runtimeArgs;
-      command =
-        if deployment.backend == "rocm" then
-          "${strixAi.llama-cpp-rocm}/bin/llama-server --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}"
-        else if deployment.backend == "vulkan" then
-          "${strixAi.llama-cpp-vulkan}/bin/llama-server --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}"
-        else if deployment.backend == "ds4" then
-          "${strixAi.ds4-rocm}/bin/ds4-server --host 127.0.0.1 --port \${PORT} -m ${lib.escapeShellArg (toString modelPath)}"
+      renderer = modelRenderers.${deployment.backend} or null;
+      rendered =
+        if renderer == null then
+          throw "local-model deployment ${deploymentName}: backend ${deployment.backend} has no llama-swap command renderer"
         else
-          throw "local-model deployment ${deploymentName}: backend ${deployment.backend} has no llama-swap command renderer yet";
+          renderer { inherit deployment modelDirectory modelPath; };
     in
     {
       name = deployment.model;
-      value = {
+      value = rendered // {
         name = deployment.model;
-        cmd = command + lib.optionalString (runtimeArgs != [ ]) " ${extraArgs}";
+        cmd = rendered.cmd + lib.optionalString (runtimeArgs != [ ]) " ${extraArgs}";
       };
     };
 
@@ -111,6 +122,22 @@ let
   manifest = (pkgs.formats.json { }).generate "local-model-catalog.json" catalog;
 
   catalogAssertions = [
+    {
+      assertion =
+        lib.sort builtins.lessThan rendererBackends
+        == lib.sort builtins.lessThan catalog.backendKinds.local;
+      message = "Every local-model backend must have exactly one llama-swap command renderer.";
+    }
+    {
+      assertion = lib.all (
+        deployment:
+        if deployment.peer == null then
+          lib.elem deployment.backend catalog.backendKinds.local
+        else
+          lib.elem deployment.backend catalog.backendKinds.peers
+      ) deploymentList;
+      message = "Local deployments must use rendered backends and peers must use peer-only backends.";
+    }
     {
       assertion = lib.all (
         artifact: lib.elem artifact.source.primary (map (file: file.path) artifact.source.files)


### PR DESCRIPTION
## Summary

- align the local-LLM backend schema with the PR #85 runtime plane: llama.cpp ROCm/Vulkan, DS4, vLLM, MLX, plus FastFlowLM as a llama-swap peer
- remove stable diffusion from the LLM backend enum while leaving its standalone package installation intact
- add complete vLLM and MLX llama-swap command renderers, including local model-directory materialization, offline Hugging Face mode, vLLM's served-model name, and MLX's required `default_model` rewrite
- expose the pinned upstream `mlx-lm` server wrapper and make backend names and renderers mechanically agree

## Root cause

PR #86 carried every package-plane label into the roster enum but only implemented command rendering for llama.cpp ROCm/Vulkan and DS4. It also treated bare `mlx-rocm`—a runtime library—as if it were the MLX HTTP server. That left two declared LLM backends unusable and incorrectly placed stable diffusion in the LLM route.

## Impact

`services.local-models.downloadAllModels = false` is unchanged. Coordinator and worker still expose no GPU models and root no roster weights. No model was downloaded and no live rebuild was run.

When canonical rows are added later, every declared local LLM backend now projects directly to a runnable llama-swap model command; FastFlowLM remains a routed peer. Stable diffusion remains outside this LLM route.

## Validation

- `nix fmt` and `nix-instantiate --parse` on changed Nix files
- `git diff --check`
- `nix build .#checks.x86_64-linux.local-model-routing --no-link`
- `nix build .#checks.x86_64-linux.deadnix --no-link`
- `statix check`
- verified the pinned nix-strix-halo flake exposes `mlx-lm`
