### PR TITLE
fix(fleet): restore reliable nightly deploys

### DIFF
--- a/docs/old/migration-journal/harness-sweep.md
+++ b/docs/old/migration-journal/harness-sweep.md
@@ -233,7 +233,7 @@ drop fcitx5.sh). resolved-default tmpfiles → `services.resolved`.
   `//10.42.0.2/G`, nix-test wrongly had `/LaCie`).
 - **Thunderbolt cluster** (from report-thunderbolt-connection.md +
   ds4-dual-node-lessons.md): static `thunderbolt0` IPs 10.77.0.1/.2 (NM profile,
-  persistent) + `networking.hosts` (coordinator-tb/worker-tb) +
+  persistent) + split-horizon `networking.hosts` (`coordinator`/`worker`) +
   `networking.firewall.trustedInterfaces = ["thunderbolt0"]` **on BOTH nodes**
   (kv-disk offload dials inbound bidirectionally) + bolt auto-auth.
 - **ds4 / LLM cluster** → quadlet-nix units (the docs' "TODO: systemd units").

--- a/flake.nix
+++ b/flake.nix
@@ -226,8 +226,6 @@
       ];
 
       # One hardened operational SSH path for deploy-rs and the Zenbook preflight.
-      # Use the tailnet names (rather than localhost / worker-tb) so magic rollback
-      # confirms the connectivity the fleet actually depends on after activation.
       fleetDeploySshOpts = [
         "-F"
         "/dev/null"
@@ -249,6 +247,11 @@
         "StrictHostKeyChecking=yes"
         "-o"
         "UserKnownHostsFile=/etc/ssh/ssh_known_hosts"
+        "-o"
+        # Bootstrap the first unattended deploy from a tailnet-down coordinator:
+        # before split-horizon /etc/hosts is activated, LLMNR also advertises an
+        # unusable link-local AAAA answer for the worker's direct connection.
+        "AddressFamily=inet"
         "-o"
         "ConnectTimeout=10"
         "-o"
@@ -380,7 +383,17 @@
               "zenbook-duo"
             ]
             (host: {
+              # Canonical names are split-horizon: the Strix peers resolve each
+              # other over Thunderbolt; hosts without that link use MagicDNS.
+              # Pin the worker's transport here as well so the first deployment
+              # can bootstrap before the new /etc/hosts has been activated.
               hostname = host;
+              sshOpts =
+                fleetDeploySshOpts
+                ++ nixpkgs.lib.optionals (host == "worker") [
+                  "-o"
+                  "HostName=10.77.0.2"
+                ];
               profiles.system.path =
                 inputs.deploy-rs.lib.${system}.activate.nixos
                   self.nixosConfigurations.${host};
@@ -449,6 +462,46 @@
 
       # The RAW out-of-store dotfiles are never checked at switch, so check them here.
       checks.${system} = {
+        fleet-connectivity =
+          let
+            coordinator = self.nixosConfigurations.coordinator.config;
+            worker = self.nixosConfigurations.worker.config;
+            retiredAliases = nixpkgs.lib.concatStringsSep "|" [
+              ("worker-" + "tb")
+              ("coordinator-" + "tb")
+            ];
+            monthlySources = builtins.fromJSON (builtins.readFile ./pkgs/local-ai-monthly/sources.json);
+          in
+          assert coordinator.networking.hosts."10.77.0.2" == [ "worker" ];
+          assert worker.networking.hosts."10.77.0.1" == [ "coordinator" ];
+          assert self.deploy.nodes.worker.hostname == "worker";
+          assert self.deploy.nodes.coordinator.hostname == "coordinator";
+          assert nixpkgs.lib.elem "AddressFamily=inet" self.deploy.sshOpts;
+          assert nixpkgs.lib.elem "HostName=10.77.0.2" self.deploy.nodes.worker.sshOpts;
+          assert coordinator.services.tailscale.extraUpFlags == [ "--ssh" ];
+          assert coordinator.systemd.services.tailscaled-autoconnect.serviceConfig.RestartSec == "1min";
+          assert (builtins.head coordinator.nix.buildMachines).hostName == "worker";
+          assert coordinator.home-manager.users.tom.services.tally.executors.worker.host == "worker";
+          assert
+            coordinator.programs.ssh.knownHosts.worker.hostNames == [
+              "worker"
+              "10.77.0.2"
+            ];
+          assert
+            worker.programs.ssh.knownHosts.coordinator.hostNames == [
+              "coordinator"
+              "10.77.0.1"
+            ];
+          assert nixpkgs.lib.elem "http://coordinator:8080/fleet" worker.nix.settings.extra-substituters;
+          assert monthlySources.inference.url == "http://worker:9292";
+          pkgs.runCommand "fleet-connectivity" { } ''
+            if ${pkgs.ripgrep}/bin/rg --line-number '${retiredAliases}' ${self}; then
+              echo "retired mesh alias found" >&2
+              exit 1
+            fi
+            touch "$out"
+          '';
+
         deadnix = pkgs.runCommand "deadnix" { } ''
           ${pkgs.deadnix}/bin/deadnix --fail --no-lambda-pattern-names \
             ${./flake.nix} ${./lib} ${./modules} ${./hosts} ${./overlays} ${./home} > $out 2>&1 \

--- a/home/tally.nix
+++ b/home/tally.nix
@@ -117,7 +117,7 @@ in
     # manager. Lease ownership and the durable row never leave coordinator.
     executors = lib.optionalAttrs isCoordinator {
       worker = {
-        host = "worker-tb";
+        host = "worker";
         user = "tom";
         identityFile = meshIdentity;
         knownHostsFile = knownHosts;

--- a/hosts/coordinator/fleet-deploy.nix
+++ b/hosts/coordinator/fleet-deploy.nix
@@ -71,8 +71,9 @@ let
       sed 's/^/fleet-deploy:   /' "$candidate"
 
       # Build the same deploy-rs-wrapped profile that will be copied and activated.
-      # Coordinator's Nix daemon retains its worker-tb distributed builder; the
-      # explicit Attic push preserves the former cache warmer's full-closure mirror.
+      # Coordinator's Nix daemon retains its worker distributed builder; local
+      # split-horizon resolution keeps that traffic on Thunderbolt. The explicit
+      # Attic push preserves the former cache warmer's full-closure mirror.
       build_profile() {
         local host="$1"
         local out

--- a/modules/build-offload.nix
+++ b/modules/build-offload.nix
@@ -10,10 +10,11 @@
 # or the always-on coordinator and the actual `gcc`/`rustc` work lands on the
 # worker, then the closure is cached for the next host. refs #42.
 #
-# Transport: the coordinator reaches the worker over the always-on TB5 fast lane
-# (worker-tb → 10.77.0.2, modules/strix.nix); the zenbook over the tailscale mesh
-# (worker, MagicDNS). Root's nix-daemon authenticates with the shared tom@mesh
-# key as `tom` — a trusted Nix user on the worker (@wheel), so it may run
+# Transport uses the canonical `worker` name everywhere. Split-horizon resolution
+# in modules/strix.nix sends the coordinator over the always-on TB5 fast lane;
+# the Zenbook resolves the same name over the Tailscale mesh. Root's nix-daemon
+# authenticates with the shared tom@mesh key as `tom` — a trusted Nix user on the
+# worker (@wheel), so it may run
 # `nix-store --serve --write`. known_hosts is pre-seeded fleet-wide
 # (modules/mesh.nix), so there is no TOFU prompt.
 #
@@ -28,12 +29,6 @@
 # worker powered down) nix falls back to building locally. The remote is a
 # PREFERENCE (speedFactor), never a hard dependency — so a travelling laptop can
 # always still rebuild itself.
-let
-  # coordinator↔worker is the direct Thunderbolt cable (worker-tb resolves only on
-  # the Strix pair, via networking.hosts in modules/strix.nix); every other client
-  # routes to the worker over the tailnet.
-  builderHost = if config.networking.hostName == "coordinator" then "worker-tb" else "worker";
-in
 {
   config = lib.mkIf (config.mySecrets.enable && config.networking.hostName != "worker") {
     nix.distributedBuilds = true;
@@ -46,7 +41,7 @@ in
 
     nix.buildMachines = [
       {
-        hostName = builderHost;
+        hostName = "worker";
         sshUser = "tom";
         sshKey = config.age.secrets.ssh-root-key.path; # root's outbound mesh key (modules/secrets.nix)
         systems = [ "x86_64-linux" ];

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -64,12 +64,11 @@
       "https://cache.numtide.com"
       "https://nix-amd-ai.cachix.org"
       "https://cache.hellas.ai"
-      # Fleet binary cache — atticd on the coordinator (hosts/coordinator/attic.nix),
-      # over the Tailscale mesh (MagicDNS `coordinator`; the Strix pair could also
-      # use the TB5 fast lane `coordinator-tb`). The `fleet` cache is made public at
-      # bootstrap so pulls need no per-client token/netrc — only the signing key
-      # below. A cold host substitutes the ~7,744 llm-agents paths from here instead
-      # of the ~8h from-source build. refs #42.
+      # Fleet binary cache — atticd on the coordinator (hosts/coordinator/attic.nix).
+      # Split-horizon naming sends the worker over the TB5 fast lane and other
+      # remote hosts over the Tailscale mesh. The cache is public, so pulls need
+      # only the signing key below. A cold host substitutes the ~7,744 llm-agents
+      # paths instead of rebuilding them. refs #42.
       "http://coordinator:8080/fleet"
     ];
     extra-trusted-public-keys = [
@@ -196,12 +195,14 @@
   services.tailscale.enable = true;
   # Tailscale SSH: any mesh node can reach any other over the tailnet in ANY
   # situation (LAN, remote, or when the TB5 fabric is down), authenticated by
-  # tailnet identity — no user keypair needed for this path. extraSetFlags runs
-  # `tailscale set --ssh` on every activation, so it also enables SSH on nodes
-  # already joined to the tailnet (the autoconnect unit only runs `up` while
-  # BackendState=NeedsLogin, so extraUpFlags alone would never re-fire).
+  # tailnet identity — no user keypair needed for this path. Keep the flag on
+  # BOTH paths: `extraUpFlags` lets the autoconnect unit recover a stopped node
+  # whose stored preferences already have SSH enabled (tailscale up requires all
+  # non-default preferences), while `extraSetFlags` also repairs already-running
+  # nodes on every activation.
   # NB: requires an `ssh` rule in the tailnet ACL allowing tag:mesh → tag:mesh
   # for users [autogroup:nonroot, root] — added in the Tailscale admin console.
+  services.tailscale.extraUpFlags = [ "--ssh" ];
   services.tailscale.extraSetFlags = [ "--ssh" ];
   services.resolved.enable = true;
   networking.firewall.enable = true;

--- a/modules/mesh-registry.nix
+++ b/modules/mesh-registry.nix
@@ -14,12 +14,18 @@
 # on the operator box + USB). See the agenix handoff.
 {
   coordinator = {
-    aliases = [ "coordinator" "coordinator-tb" "10.77.0.1" ];
+    aliases = [
+      "coordinator"
+      "10.77.0.1"
+    ];
     hostKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFPCZFlnHQSNH3D0R1/qs9A/W498f8xTNUNBtLWZgU2A root@coordinator";
     userKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAlTzKx0n2pQ4/1qv3mThyyh1+QCuT/Qcg+/40Nr1JB6 tom@mesh";
   };
   worker = {
-    aliases = [ "worker" "worker-tb" "10.77.0.2" ];
+    aliases = [
+      "worker"
+      "10.77.0.2"
+    ];
     hostKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIC9xaf+UX4cjDEme+Ath3EZYLiUJla/+3QlG4TvCzwLO root@worker";
     userKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAlTzKx0n2pQ4/1qv3mThyyh1+QCuT/Qcg+/40Nr1JB6 tom@mesh";
   };

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -143,8 +143,10 @@ in
         # agenix's /run/agenix.d mount too, or it can race the key's decryption at boot.
         # It also raced the uplink on the coordinator's first boot (the boot-time
         # `tailscale up` predated wifi, so the join needed a manual restart, refs #37):
-        # order after network-online.target and retry with backoff so a late uplink
-        # (wifi associating after the unit fired) self-heals instead of staying down.
+        # order after network-online.target and retry so a late uplink (wifi
+        # associating after the unit fired) self-heals instead of staying down.
+        # A minute keeps permanent auth/config failures from creating a tight
+        # restart storm while still recovering promptly from a late network.
         systemd.services.tailscaled-autoconnect = {
           after = [
             "run-agenix.d.mount"
@@ -156,7 +158,7 @@ in
           ];
           serviceConfig = {
             Restart = "on-failure";
-            RestartSec = "10s";
+            RestartSec = "1min";
           };
         };
       }

--- a/modules/strix.nix
+++ b/modules/strix.nix
@@ -111,12 +111,14 @@
       "sys-subsystem-net-devices-thunderbolt0.device"
     ];
 
-    # Naming fabric: both nodes resolve both TB endpoints by role name
-    # (-tb suffix so LAN/tailscale resolution of the plain hostnames is untouched).
-    networking.hosts = {
-      "10.77.0.1" = [ "coordinator-tb" ];
-      "10.77.0.2" = [ "worker-tb" ];
-    };
+    # Split-horizon naming: each Strix node resolves its peer's canonical name
+    # over the direct TB link. The node's own canonical name remains local, and
+    # devices without this module resolve the same names through MagicDNS.
+    networking.hosts =
+      if config.myCluster.role == "coordinator" then
+        { "10.77.0.2" = [ "worker" ]; }
+      else
+        { "10.77.0.1" = [ "coordinator" ]; };
 
     # docs/old/migration-journal/ds4-dual-node-lessons.md Lesson #5 + Appendix A:
     # an untrusted TB interface

--- a/pkgs/local-ai-monthly/sources.json
+++ b/pkgs/local-ai-monthly/sources.json
@@ -3,7 +3,7 @@
   "accepted_through": "2026-07-21",
   "inference": {
     "provider": "llama-swap",
-    "url": "http://worker-tb:9292",
+    "url": "http://worker:9292",
     "model_class": "strongest",
     "fallback_classes": ["fast"],
     "classes": {


### PR DESCRIPTION
## What changed

- make `worker` and `coordinator` the only canonical fleet names
- resolve the Strix peer names over the direct Thunderbolt addresses while leaving non-Strix hosts on Tailscale MagicDNS
- route deploy-rs, distributed builds, Tally, Attic, and the local-AI reviewer through those canonical names
- pin the first worker deployment to the direct address so tonight's job can bootstrap before the new host map is active
- repeat `--ssh` on the Tailscale recovery path and slow persistent autoconnect retries
- add a fleet-connectivity check that asserts the transport/naming contract and rejects retired aliases

## Root cause

The coordinator's Tailscale state was stopped, while `tailscaled-autoconnect` could not recover because its `tailscale up` invocation omitted the already-enabled non-default `--ssh` preference. Fleet deployment targeted the ambiguous plain worker name through the resolver instead of explicitly using the preferred direct fabric; fallback LLMNR intermittently supplied an unusable link-local IPv6 address, so deploy-rs failed its activation SSH wait with `EINVAL` and rolled back.

## Impact

The coordinator/worker pair now stays on Thunderbolt for control, build, cache, and model traffic without maintaining separate transport-specific hostnames. Devices without the direct link continue to use the same names over Tailscale. A successful nightly run removes the existing fleet failure marker automatically.

No live switch, flash, or activation was performed; the 02:00 Tally job will pick up the merged candidate.

## Validation

- `nix flake check --no-build`
- built `fleet-connectivity`, `deadnix`, `deploy-schema`, and `deploy-activate`
- formatting and whitespace checks
- 12 consecutive canonical `root@worker` bootstrap probes using the exact deploy SSH transport
- repository-wide retired-alias scan