### PR TITLE
feat(desktop): AirPlay + mDNS + Brother printing on coordinator

### DIFF
--- a/hosts/coordinator/default.nix
+++ b/hosts/coordinator/default.nix
@@ -31,6 +31,10 @@
     inputs.nix-amd-ai.nixosModules.default
     # Declarative `flm serve` unit + the coordinator's preloaded NPU model choice.
     ../../modules/npu-llm.nix
+    # Desktop-only local-media plane: mDNS discovery (avahi) + AirPlay output for
+    # the JBL Authentics 200 + CUPS/driverless printing for the Brother. refs the
+    # 2026-07-24 "Chrome can't find the JBL" fix (mDNS was firewalled off).
+    ../../modules/desktop-media.nix
   ];
 
   networking.hostName = "coordinator";

--- a/modules/desktop-media.nix
+++ b/modules/desktop-media.nix
@@ -1,0 +1,61 @@
+{ pkgs, ... }:
+# Local-network media + printing plane for the desktop (coordinator only).
+#
+# The Freebox wifi carries two appliances this box should "just work" with:
+#   - a JBL Authentics 200  — AirPlay 2 + Chromecast, 192.168.1.40
+#   - a Brother printer     — driverless IPP (currently powered off, see below)
+# Both are found over mDNS / DNS-SD: a multicast query to 224.0.0.251:5353.
+#
+# Why nothing worked before this module (diagnosed 2026-07-24):
+#   1. No mDNS at all. avahi was not installed, and common.nix's firewall
+#      (enable = true, no LAN holes) dropped inbound UDP 5353. A multicast probe
+#      for _googlecast/_raop/_ipp got ZERO responders even though the JBL pings
+#      fine and its cast/airplay ports are open — Chrome's Cast picker, PipeWire's
+#      AirPlay discovery, and CUPS printer discovery all saw an empty network.
+#   2. PipeWire had no RAOP (AirPlay) sender module, so a discovered JBL could
+#      not be selected as an output sink.
+#   3. No CUPS, so there was nothing to print to.
+#
+# AirPlay is the chosen path for the JBL, not Chromecast. Chromecast has no
+# native PipeWire sink — routing system audio to it needs a separate bridge
+# daemon (mkchromecast/pulseaudio-dlna) and still can't be a system default.
+# RAOP exposes the JBL as an ordinary PipeWire sink, so it sits in the normal
+# audio menu next to the USB INZONE headset and WirePlumber remembers it as the
+# default when present, falling back to the headset when it's gone. Chrome can
+# still cast a tab over the same open :5353 if ever wanted.
+{
+  # --- mDNS / DNS-SD discovery (the shared root cause) ---
+  # avahi owns :5353 and browses the wifi; openFirewall punches UDP 5353 so
+  # multicast replies reach us. Chrome does its own mDNS and only needs the port
+  # open; PipeWire + CUPS talk to the avahi daemon over D-Bus.
+  services.avahi = {
+    enable = true;
+    nssmdns4 = true; # resolve <device>.local (e.g. the printer's web UI)
+    openFirewall = true; # UDP 5353
+  };
+  # systemd-resolved also wants :5353 for its own mDNS stub; hand mDNS to avahi so
+  # the daemon binds cleanly. This only disables resolved's MULTICAST DNS — it
+  # merges with the AdGuard module's [Resolve] block (DNS/Domains) and leaves the
+  # unicast app → resolved → AdGuard → DoH path in modules/adguardhome.nix intact.
+  services.resolved.settings.Resolve.MulticastDNS = false;
+
+  # --- AirPlay output for the JBL ---
+  # RAOP discover turns AirPlay speakers into native PipeWire sinks. ~1-2s latency
+  # (fine for the lofi/piano listening this speaker is for; not lip-sync for video).
+  services.pipewire.extraConfig.pipewire."10-airplay" = {
+    "context.modules" = [
+      { name = "libpipewire-module-raop-discover"; }
+    ];
+  };
+
+  # --- printing (Brother) ---
+  # Modern Brother printers speak driverless IPP Everywhere, which CUPS
+  # auto-configures once avahi is up — no per-model driver needed. brlaser covers
+  # the older mono-laser models as a fallback. The printer was NOT on the wifi
+  # when this landed (a full subnet sweep found only the JBL, the Freebox, a
+  # phone and the worker); power it on and it should appear at http://localhost:631.
+  services.printing = {
+    enable = true;
+    drivers = [ pkgs.brlaser ];
+  };
+}


### PR DESCRIPTION
Makes the JBL Authentics 200 and the Brother printer on the Freebox wifi work from the coordinator desktop.

## Problem
Chrome could not find the JBL to cast to. A network probe showed why: a multicast mDNS query (`224.0.0.251:5353`) for `_googlecast` / `_raop` / `_ipp` got **zero responders**, even though the JBL (`192.168.1.40`) pings fine and its Cast + AirPlay ports are open.

Root cause: **no mDNS on this box.**
- `avahi` was never installed.
- `common.nix` enables the firewall with no LAN holes, so inbound **UDP 5353 was dropped** — Chrome's Cast picker, PipeWire's AirPlay discovery, and CUPS all saw an empty network.
- PipeWire had no RAOP module, so a discovered JBL could not be an output.
- No CUPS at all, so nothing to print to.

## Change — new `modules/desktop-media.nix` (coordinator-only)
- **avahi + `openFirewall`** (UDP 5353). `resolved`'s multicast stub disabled so avahi binds `:5353` cleanly — merges with `adguardhome.nix`'s `[Resolve]` block; the unicast app→resolved→AdGuard→DoH path is untouched.
- **PipeWire `libpipewire-module-raop-discover`** — exposes the JBL as a native sink, so it sits in the normal audio menu beside the USB INZONE headset and WirePlumber keeps it default when present.
- **CUPS driverless (IPP Everywhere) + `brlaser`** fallback for the Brother.

### Why AirPlay over Chromecast
The user was indifferent. AirPlay wins for a desktop default speaker: Chromecast has **no native PipeWire sink** (would need a separate bridge daemon and still could not be a system default), whereas RAOP gives an ordinary switchable sink. Chrome can still cast a tab over the same open `:5353` if ever wanted.

## Validation
- `nix eval` + full `nix build` of `nixosConfigurations.coordinator.toplevel` succeed.
- Generated artifacts confirmed in the build: `10-airplay.conf`, `avahi-daemon.service`, `cups.service`, `cups-browsed.service`.

## Note
The **Brother was offline** during the sweep (only the JBL, Freebox, a phone and the worker were on the subnet). Power it on after deploy and it should auto-discover at http://localhost:631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)