### PR TITLE
fix(storage): keep LaCie media consumers gated

### DIFF
--- a/hosts/coordinator/services.nix
+++ b/hosts/coordinator/services.nix
@@ -9,14 +9,19 @@
 #
 # LaCie access — the crux. Both libraries live on the directly-attached LaCie
 # USB NAS at /mnt/nas (see uplink-nas.nix), migrated to Btrfs on 2026-07-23.
-# The media subvolumes have ordinary on-disk POSIX ownership as tom:users and
-# mode 0755, so both services continue to run as that identity during the
-# verified restore and later integration.
+# The media subvolumes have ordinary on-disk POSIX ownership as tom:users, so
+# both services continue to run as that identity during the verified restore
+# and later integration. Preserve each accepted tree's existing mode.
 # The native modules assume a local mediaLocation and add no mount ordering, so
 # each unit gets RequiresMountsFor=/mnt/nas to fire the x-systemd.automount
 # before the service (and, for navidrome, before its sandbox bind-mounts the
 # music folder read-only). Moving these services to dedicated system users is a
 # separate post-restore decision; it is not coupled to the filesystem anymore.
+#
+# Media activation remains deferred to issue #104. Require an ephemeral,
+# operator-created approval file on every consumer so a reboot cannot erase the
+# restore-era runtime guards and start the stack implicitly. Issue #104 removes
+# this condition only when the canonical import and service checks are ready.
 #
 # No secrets: services.immich provisions its own postgresql over a unix socket
 # (peer auth, database.host=/run/postgresql), so the module's assertion is
@@ -50,7 +55,16 @@
   };
   # The LaCie is an x-systemd.automount; pull the real mount in before the server
   # touches mediaLocation (uses the .automount, so the drive still spins down).
-  systemd.services.immich-server.unitConfig.RequiresMountsFor = [ "/mnt/nas" ];
+  systemd.services.immich-server.unitConfig = {
+    RequiresMountsFor = [ "/mnt/nas" ];
+    ConditionPathExists = [ "/run/lacie-media-services-approved" ];
+  };
+  systemd.services.immich-machine-learning.unitConfig.ConditionPathExists = [
+    "/run/lacie-media-services-approved"
+  ];
+  systemd.services.redis-immich.unitConfig.ConditionPathExists = [
+    "/run/lacie-media-services-approved"
+  ];
 
   services.navidrome = {
     enable = true;
@@ -71,7 +85,10 @@
       AutoImportPlaylists = true;
     };
   };
-  systemd.services.navidrome.unitConfig.RequiresMountsFor = [ "/mnt/nas" ];
+  systemd.services.navidrome.unitConfig = {
+    RequiresMountsFor = [ "/mnt/nas" ];
+    ConditionPathExists = [ "/run/lacie-media-services-approved" ];
+  };
 
   # atuin — self-hosted shell-history sync server, same tailnet-only posture as
   # Immich/Navidrome above (no extra app-level auth; the tailnet IS the trust


### PR DESCRIPTION
## What changed

- require `/run/lacie-media-services-approved` before Immich server, Immich machine learning, Redis-Immich, or Navidrome can start
- retain `RequiresMountsFor=/mnt/nas` for the two filesystem consumers
- correct the stale comment that assumed every accepted media tree remained mode `0755`

## Why

Issue #66 completed the declarative LaCie Btrfs cutover, while issue #104 deliberately defers Takeout import and media-service validation. The restore-era guards lived under `/run`, so a reboot would otherwise erase them and implicitly start the media stack before #104 authorizes that work.

## Impact

The LaCie Btrfs automount remains available, but all four media consumers stay stopped across reboot until an operator deliberately supplies the approval file or #104 removes the condition.

## Root cause

The 2026-07-25 fleet activation still carried the stale NTFS declaration and failed on `ntfsfix-lacie`. After the Btrfs cutover, the remaining gap was that media quiescence was runtime-only rather than part of the installed generation.

## Validation

- `nix flake check --no-build --show-trace`
- built `nixosConfigurations.worker.config.system.build.toplevel`
- built `nixosConfigurations.coordinator.config.system.build.toplevel`
- live coordinator automount, Btrfs scrub/device statistics, SMART, and protected-subvolume checks passed

Closes #66