### PR TITLE
Finish LaCie media integration and wake services on demand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ admin-age.key
 secrets-staging/
 install-files/
 plaintext/
+
+# Nix build output symlink
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -433,6 +433,24 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "git-ai": {
       "inputs": {
         "flake-utils": [
@@ -455,24 +473,6 @@
       "original": {
         "owner": "git-ai-project",
         "repo": "git-ai",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -1231,11 +1231,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784576728,
-        "narHash": "sha256-wR9mIm9kYOvaT5JQ4ZmbuS95MFpOWwwb6pGB5UOw+Pc=",
+        "lastModified": 1784957750,
+        "narHash": "sha256-bwCduiLLJlHJsns5CWtCudNdwmurgJ4JDVEwRgagTiI=",
         "owner": "mecattaf",
         "repo": "tally.nix",
-        "rev": "4423a610bd56f506289811d8ce24c431064d44ab",
+        "rev": "f029be980d1cbec987b6ee01fb036d57317acf3b",
         "type": "github"
       },
       "original": {

--- a/hosts/coordinator/services.nix
+++ b/hosts/coordinator/services.nix
@@ -1,4 +1,24 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  socketProxyd = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd";
+  waitForHttp =
+    name: url:
+    pkgs.writeShellScript "${name}-wait-for-http" ''
+      for _ in $(${pkgs.coreutils}/bin/seq 1 90); do
+        if ${pkgs.curl}/bin/curl --fail --silent --max-time 1 ${lib.escapeShellArg url} >/dev/null; then
+          exit 0
+        fi
+        ${pkgs.coreutils}/bin/sleep 1
+      done
+      echo "${name} did not become ready within 90 seconds" >&2
+      exit 1
+    '';
+in
 # The coordinator's media services — Immich (photos) and Navidrome (music) — as
 # NATIVE NixOS modules. Migrated 2026-07-13 from the rootless podman quadlets
 # they were ported to on 2026-07-05 (see git history for the old .container
@@ -34,8 +54,10 @@
   services.immich = {
     enable = true;
     mediaLocation = "/mnt/nas/photos";
-    host = "0.0.0.0"; # tailnet-reachable; firewall below scopes it to tailscale0
-    port = 2283;
+    # The public 2283 listener is the socket-activated proxy below. Immich stays
+    # private on 2284 and only runs while someone is actually using it.
+    host = "127.0.0.1";
+    port = 2284;
     user = "tom";
     group = "users";
     # The postgres it provisions is reached over a unix socket with PEER auth,
@@ -63,6 +85,20 @@
   # The LaCie is an x-systemd.automount; pull the real mount in before the server
   # touches mediaLocation (uses the .automount, so the drive still spins down).
   systemd.services.immich-server = {
+    # The proxy is the only long-lived entry point. The three Immich workers are
+    # deliberately absent from multi-user.target and stop when the proxy has
+    # seen no connections for 15 minutes. This releases Node's post-job heap and
+    # lets the LaCie return to standby instead of keeping a rarely-used gallery
+    # resident around the clock.
+    wantedBy = lib.mkForce [ ];
+    requires = [ "redis-immich.service" ];
+    wants = [ "immich-machine-learning.service" ];
+    after = [
+      "redis-immich.service"
+      "immich-machine-learning.service"
+    ];
+    environment.CPU_CORES = "4";
+    unitConfig.StopWhenUnneeded = true;
     unitConfig.RequiresMountsFor = [ "/mnt/nas" ];
     serviceConfig.BindPaths = [
       "/var/lib/immich/generated/thumbs:/mnt/nas/photos/thumbs"
@@ -71,6 +107,44 @@
       "/var/lib/immich/generated/backups:/mnt/nas/photos/backups"
     ];
   };
+  systemd.services.immich-machine-learning = {
+    wantedBy = lib.mkForce [ ];
+    unitConfig.StopWhenUnneeded = true;
+  };
+  systemd.services.redis-immich = {
+    wantedBy = lib.mkForce [ ];
+    unitConfig.StopWhenUnneeded = true;
+  };
+
+  systemd.sockets.immich-access = {
+    description = "Wake Immich on the first client connection";
+    wantedBy = [ "sockets.target" ];
+    socketConfig = {
+      ListenStream = "0.0.0.0:2283";
+      NoDelay = true;
+    };
+  };
+  systemd.services.immich-access = {
+    description = "On-demand proxy for Immich";
+    requires = [ "immich-server.service" ];
+    after = [ "immich-server.service" ];
+    serviceConfig = {
+      ExecStartPre = waitForHttp "Immich" "http://127.0.0.1:2284/api/server/ping";
+      ExecStart = "${socketProxyd} --exit-idle-time=15min 127.0.0.1:2284";
+      DynamicUser = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectHome = true;
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      TimeoutStartSec = "2min";
+    };
+  };
 
   services.navidrome = {
     enable = true;
@@ -78,8 +152,9 @@
     group = "users";
     settings = {
       MusicFolder = "/mnt/nas/music";
-      Address = "0.0.0.0"; # tailnet-reachable; scoped to tailscale0 by firewall
-      Port = 4533;
+      # As with Immich, the stable public port belongs to the on-demand proxy.
+      Address = "127.0.0.1";
+      Port = 4534;
       # @daily, not hourly: an hourly rescan walks /music and wakes the LaCie
       # from standby (hd-idle parks it after 20 min — see uplink-nas.nix),
       # defeating the power-down suite. New media appears after the nightly scan
@@ -91,7 +166,43 @@
       AutoImportPlaylists = true;
     };
   };
-  systemd.services.navidrome.unitConfig.RequiresMountsFor = [ "/mnt/nas" ];
+  systemd.services.navidrome = {
+    wantedBy = lib.mkForce [ ];
+    unitConfig = {
+      RequiresMountsFor = [ "/mnt/nas" ];
+      StopWhenUnneeded = true;
+    };
+  };
+
+  systemd.sockets.navidrome-access = {
+    description = "Wake Navidrome on the first client connection";
+    wantedBy = [ "sockets.target" ];
+    socketConfig = {
+      ListenStream = "0.0.0.0:4533";
+      NoDelay = true;
+    };
+  };
+  systemd.services.navidrome-access = {
+    description = "On-demand proxy for Navidrome";
+    requires = [ "navidrome.service" ];
+    after = [ "navidrome.service" ];
+    serviceConfig = {
+      ExecStartPre = waitForHttp "Navidrome" "http://127.0.0.1:4534/";
+      ExecStart = "${socketProxyd} --exit-idle-time=15min 127.0.0.1:4534";
+      DynamicUser = true;
+      NoNewPrivileges = true;
+      PrivateDevices = true;
+      PrivateTmp = true;
+      ProtectHome = true;
+      ProtectSystem = "strict";
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+      TimeoutStartSec = "2min";
+    };
+  };
 
   # atuin — self-hosted shell-history sync server, same tailnet-only posture as
   # Immich/Navidrome above (no extra app-level auth; the tailnet IS the trust

--- a/hosts/coordinator/services.nix
+++ b/hosts/coordinator/services.nix
@@ -18,11 +18,6 @@
 # music folder read-only). Moving these services to dedicated system users is a
 # separate post-restore decision; it is not coupled to the filesystem anymore.
 #
-# Media activation remains deferred to issue #104. Require an ephemeral,
-# operator-created approval file on every consumer so a reboot cannot erase the
-# restore-era runtime guards and start the stack implicitly. Issue #104 removes
-# this condition only when the canonical import and service checks are ready.
-#
 # No secrets: services.immich provisions its own postgresql over a unix socket
 # (peer auth, database.host=/run/postgresql), so the module's assertion is
 # satisfied WITHOUT a password file and the old immich-db.age secret is retired.
@@ -53,18 +48,29 @@
     database.name = "tom";
     # machine-learning stays enabled (module default) for face/object search.
   };
+  # Originals remain on LaCie under mediaLocation. Generated/rebuildable Immich
+  # state stays on the internal disk and is overlaid onto Immich's expected
+  # mediaLocation paths inside the service mount namespace. This avoids filling
+  # the archive disk with thumbnails/transcodes while keeping upstream's fixed
+  # directory layout intact.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/immich/generated 0700 tom users -"
+    "d /var/lib/immich/generated/thumbs 0700 tom users -"
+    "d /var/lib/immich/generated/encoded-video 0700 tom users -"
+    "d /var/lib/immich/generated/profile 0700 tom users -"
+    "d /var/lib/immich/generated/backups 0700 tom users -"
+  ];
   # The LaCie is an x-systemd.automount; pull the real mount in before the server
   # touches mediaLocation (uses the .automount, so the drive still spins down).
-  systemd.services.immich-server.unitConfig = {
-    RequiresMountsFor = [ "/mnt/nas" ];
-    ConditionPathExists = [ "/run/lacie-media-services-approved" ];
+  systemd.services.immich-server = {
+    unitConfig.RequiresMountsFor = [ "/mnt/nas" ];
+    serviceConfig.BindPaths = [
+      "/var/lib/immich/generated/thumbs:/mnt/nas/photos/thumbs"
+      "/var/lib/immich/generated/encoded-video:/mnt/nas/photos/encoded-video"
+      "/var/lib/immich/generated/profile:/mnt/nas/photos/profile"
+      "/var/lib/immich/generated/backups:/mnt/nas/photos/backups"
+    ];
   };
-  systemd.services.immich-machine-learning.unitConfig.ConditionPathExists = [
-    "/run/lacie-media-services-approved"
-  ];
-  systemd.services.redis-immich.unitConfig.ConditionPathExists = [
-    "/run/lacie-media-services-approved"
-  ];
 
   services.navidrome = {
     enable = true;
@@ -85,10 +91,7 @@
       AutoImportPlaylists = true;
     };
   };
-  systemd.services.navidrome.unitConfig = {
-    RequiresMountsFor = [ "/mnt/nas" ];
-    ConditionPathExists = [ "/run/lacie-media-services-approved" ];
-  };
+  systemd.services.navidrome.unitConfig.RequiresMountsFor = [ "/mnt/nas" ];
 
   # atuin — self-hosted shell-history sync server, same tailnet-only posture as
   # Immich/Navidrome above (no extra app-level auth; the tailnet IS the trust

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/dxvwfv9pv4hqqj0sy9b7hqjdpvh6s1zd-nixos-system-coordinator-26.11.20260616.567a49d


### PR DESCRIPTION
## What changed

- finish the LaCie-backed Immich and Navidrome integration
- keep generated Immich data on the internal SSD while originals remain on the LaCie
- replace continuously running media daemons with socket-activated public ports
- start Immich, machine learning, Redis, or Navidrome on the first client connection
- stop each stack after 15 minutes without client connections
- cap Immich's auto-detected CPU concurrency at four cores
- keep ports 2283 and 4533 stable and tailnet-only
- include the already-local flake tally and build-result cleanup commits

## Why

The one-time Google Photos/LaCie ingestion left Immich's Node worker retaining roughly 8 GiB of anonymous memory. These services are used only intermittently, so keeping the whole media stack resident around the clock wastes RAM and keeps the archive disk busier than necessary.

## Impact

A first request after idle now takes about four seconds for Immich and one second for Navidrome. Subsequent requests are immediate while the 15-minute activity window remains open. At rest, only two systemd listening sockets remain, using about 8 KiB each.

## Validation

- built the complete coordinator NixOS system
- switched the configuration on the live coordinator
- confirmed cold wake through localhost and the coordinator's Tailscale address
- confirmed Immich returned HTTP 200 and retained all 17,802 indexed assets
- confirmed Navidrome returned its expected HTTP 302
- confirmed stopping the proxy tears down Immich, ML, Redis, and Navidrome while both public sockets remain listening
- confirmed system RAM returned from 26 GiB used during the import-era process to 20 GiB used at rest
- ran the deadnix check
- ran `nix flake check --no-build` successfully