### PR TITLE
claude: retire claude-main config

### DIFF
--- a/home/dot_local/bin/resume-pdf
+++ b/home/dot_local/bin/resume-pdf
@@ -10,7 +10,7 @@ for this font, from its hhea table), 0.25in hanging bullets, link #0563c1.
 Usage:
     resume-pdf INPUT.md [-o OUTPUT.pdf] [--keep-html]
 
-Markdown grammar (see the resume-builder skill, ~/.claude-main/skills/resume-builder/SKILL.md):
+Markdown grammar (see the resume-builder skill, ~/.claude/skills/resume-builder/SKILL.md):
     # NAME                          -> centered small-caps title
     first plain line                -> centered contact line, split on " | "
     ## SECTION                      -> ruled small-caps section heading

--- a/home/home.nix
+++ b/home/home.nix
@@ -126,11 +126,6 @@ in
     "$HOME/.local/bin"
   ];
 
-  # Claude Code reads its config/creds from $CLAUDE_CONFIG_DIR (defaults to ~/.claude).
-  # modules/secrets.nix seeds the OAuth credential to ~/.claude-main, so point Claude
-  # Code there — otherwise the seeded cred lands where nothing reads it and Claude Code
-  # re-prompts for OAuth on a fresh box despite the secret being delivered.
-  home.sessionVariables.CLAUDE_CONFIG_DIR = "${config.home.homeDirectory}/.claude-main";
   # Force the file backend explicitly so gws never guesses between it and an
   # OS keyring (GNOME keyring/kwallet) — the agenix-delivered .encryption_key
   # only makes sense if gws is always in file mode. See gws-*.age in secrets.nix.
@@ -222,13 +217,13 @@ in
   home.file.".bashrc".source = link "dot_bashrc";
   home.file.".bash_profile".source = link "dot_bash_profile";
 
-  # Claude Code skills + settings (CLAUDE_CONFIG_DIR = ~/.claude-main, set above).
+  # Claude Code skills + settings in the standard user config directory.
   # Deployed as individual out-of-store symlinks — NOT a whole-dir link — so
-  # ~/.claude-main stays a real, writable directory that modules/secrets.nix can seed
+  # ~/.claude stays a real, writable directory that modules/secrets.nix can seed
   # .credentials.json into (a whole-dir symlink would push the credential into the
   # PUBLIC repo tree). Without this, a fresh box has zero skills/settings.
-  home.file.".claude-main/skills".source = link "dot_claude/skills";
-  home.file.".claude-main/settings.json".source = link "dot_claude/settings.json";
+  home.file.".claude/skills".source = link "dot_claude/skills";
+  home.file.".claude/settings.json".source = link "dot_claude/settings.json";
 
   # Same canonical skill tree, exposed to the `pi` agent (earendil-works/pi) via
   # its vendor-neutral, always-trusted Agent-Skills dir (~/.agents/skills). pi

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -40,9 +40,9 @@ in
         # agenix delivers a read-only /run/agenix symlink, but Claude must rewrite the
         # file on token refresh, so copy rather than link, and only if absent.
         system.userActivationScripts.seedClaudeCreds.text = ''
-          cred="$HOME/.claude-main/.credentials.json"
+          cred="$HOME/.claude/.credentials.json"
           if [ ! -e "$cred" ] && [ -r "${config.age.secrets.claude-credentials.path}" ]; then
-            mkdir -p "$HOME/.claude-main"
+            mkdir -p "$HOME/.claude"
             cp "${config.age.secrets.claude-credentials.path}" "$cred"
             chmod 600 "$cred"
           fi


### PR DESCRIPTION
## What changed

- remove the `CLAUDE_CONFIG_DIR=~/.claude-main` override
- deploy Claude Code skills and settings directly under `~/.claude`
- seed the managed OAuth credential into `~/.claude/.credentials.json`
- update the resume helper's skill reference to the standard path

## Why

The retired `.claude-main` profile left Claude Code split across two configuration roots. Live Claude sessions use the standard `~/.claude` directory, while Home Manager was installing the Git-backed skills and intended settings under `~/.claude-main`, so those skills were invisible.

## Impact

Claude Code now uses one standard, writable config directory for runtime state, credentials, settings, and the Git-backed skill tree. It no longer depends on a session environment override being propagated through greetd, niri, and Fish.

## Validation

- `nix flake check --no-build`
- evaluated Home Manager output confirms `~/.claude/skills` and `~/.claude/settings.json`
- evaluated session variables confirm `CLAUDE_CONFIG_DIR` is absent
- repository scan confirms no `.claude-main` references remain
