### PR TITLE
fix(local-ai): stop persistent FastFlowLM residency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,3 @@
-All local LLM calls must go through llama-swap; stable diffusion is outside this LLM route.
+Managed local LLM and VLM calls go through llama-swap. Ad-hoc NPU inference uses
+`flm run <model>` directly; do not leave `flm serve` resident. Stable diffusion
+is outside this LLM route.

--- a/docs/local-ai/README.md
+++ b/docs/local-ai/README.md
@@ -7,11 +7,14 @@ model identity, resource class, and an explicit caller boundary.
 ## Deployment state
 
 The old all-or-nothing `downloadAllModels` gate is gone. Each Strix host has an
-explicit `services.local-models.allow` deployment list and a separate list for
-non-llama speech artifacts. Only those selections enter the system closure and
-llama-swap configuration; every other catalog row remains metadata-only. See
-the [final two-node decision](deployment-decisions-2026-07-26.md) for the exact
-placement and storage totals.
+explicit `services.local-models.allow` list for command-managed llama-swap
+deployments and a separate list for non-llama speech artifacts. FastFlowLM NPU
+rows remain runtime-appliance metadata: their existing files may stay under
+`~/.config/flm/models`, but no NixOS service starts or retains them. The exact
+per-host FLM roster is still declared in `services.npu-llm.models` and rendered
+to `/etc/local-models/fastflowlm.json`. See the
+[final two-node decision](deployment-decisions-2026-07-26.md) for placement and
+storage totals.
 
 ## Hugging Face metadata CLI
 
@@ -68,7 +71,7 @@ nix build .#checks.x86_64-linux.huggingface-cli-smoke --no-link
 | Document OCR/RAG | Qwen3-VL 8B primary, 32B refine, Qwen3 Embedding 8B, Qwen3-VL Embedding 8B | Coordinator llama.cpp ROCm behind llama-swap | Active coordinator allowlist; text and multimodal embedders are complementary. |
 | Shared text and coding | Qwen 3.6 35B Q8 with integrated MTP, Gemma 4 26B Q8 with matched MTP | Vulkan behind llama-swap on both hosts | Active on both hosts. Qwen3-Coder-Next remains cataloged only. |
 | Computer use | Fara 1.5 27B Q8_0 plus BF16 projector | ROCm behind llama-swap on both hosts | Active on both hosts. |
-| NPU utility | FastFlowLM Gemma 4 E4B and GPT-OSS 20B | Dedicated loopback peers behind llama-swap | Active on both hosts. |
+| NPU utility | FastFlowLM Gemma 4 E4B and GPT-OSS 20B | Direct, ad-hoc `flm run <model>` | FastFlowLM is installed on both hosts; no model server starts at boot and idle residency is zero. |
 | Historical SOTA | DeepSeek V4 Flash Q4 imatrix + MTP | Retired dual-node DS4 topology | Exact artifacts and benchmark evidence remain cataloged, but the deployment is retired and its roughly 157 GiB of weights are excluded from materialization. |
 | Call transcription + diarization | Microsoft VibeVoice-ASR | Future dedicated PyTorch/ROCm batch service | BF16 payload and tokenizer are Nix-rooted on coordinator; service remains future work. |
 | Text-to-speech | VibeVoice Large community mirror | Future dedicated PyTorch/ROCm batch service | BF16 payload and tokenizer are Nix-rooted on coordinator; mirror risk remains recorded. |
@@ -76,8 +79,9 @@ nix build .#checks.x86_64-linux.huggingface-cli-smoke --no-link
 
 ## Text classes
 
-- **Small and fast:** `gemma4-it:e4b` and `gpt-oss:20b` on both NPUs.
-  FastFlowLM owns these weights; llama-swap exposes both as peers.
+- **Small and fast:** `gemma4-it:e4b` and `gpt-oss:20b` remain available on
+  both NPUs through an explicit `flm run <model>`. FastFlowLM owns the runtime
+  files and releases model residency when the command exits.
 - **Daily general:** Qwen 3.6 35B-A3B UD-Q8_K_XL with integrated MTP on
   Vulkan.
 - **Historical SOTA:** DeepSeek V4 Flash Q4 imatrix plus MTP through dual-node
@@ -88,10 +92,11 @@ nix build .#checks.x86_64-linux.huggingface-cli-smoke --no-link
 
 ## Routing and scheduling boundaries
 
-Every OpenAI-compatible local LLM or VLM call enters through llama-swap. Backend
-ports are implementation details and are not caller APIs. Modality-specific
-speech services get their own declared endpoints because they are not chat
-completion servers.
+Managed OpenAI-compatible LLM and VLM calls enter through llama-swap. Its
+command-managed GPU backends retain the normal load/unload boundary. FastFlowLM
+is deliberately separate: ad-hoc NPU work invokes `flm run <model>` directly,
+and there is no persistent FLM endpoint. Modality-specific speech services keep
+their own declared endpoints.
 
 Tally schedules, serializes, and proves the monthly community review described
 in [`monthly-workflow.md`](monthly-workflow.md). It does not retrofit historical
@@ -102,13 +107,16 @@ pre-Nix notes into the current architecture.
 1. [`../../lib/local-models.nix`](../../lib/local-models.nix) owns immutable
    artifact and deployment metadata.
 2. [`../../modules/local-models.nix`](../../modules/local-models.nix) projects
-   only the explicit host allowlists into the Nix store and llama-swap.
-3. [`deployment-decisions-2026-07-26.md`](deployment-decisions-2026-07-26.md)
+   only command-managed host allowlists into the Nix store and llama-swap;
+   runtime appliances never become proxy peers.
+3. [`../../modules/npu-llm.nix`](../../modules/npu-llm.nix) validates the
+   explicit FastFlowLM roster and writes its non-resident runtime manifest.
+4. [`deployment-decisions-2026-07-26.md`](deployment-decisions-2026-07-26.md)
    is the authoritative active split and storage ledger.
-4. [`model-roster.md`](model-roster.md) is the broader human-readable catalog,
+5. [`model-roster.md`](model-roster.md) is the broader human-readable catalog,
    including deferred rows and
-   speech appliances that do not belong in the llama-swap catalog.
-5. [`tallies/`](tallies/) records accepted roster rationale. The monthly update
+   runtime and speech appliances that do not belong in the llama-swap catalog.
+6. [`tallies/`](tallies/) records accepted roster rationale. The monthly update
    bot advances its exact research-source pins in `sources.json`; its advisory
    summary remains visible in the corresponding pull request.
 

--- a/docs/local-ai/deployment-decisions-2026-07-26.md
+++ b/docs/local-ai/deployment-decisions-2026-07-26.md
@@ -1,11 +1,12 @@
 # Two-node local-AI deployment decisions
 
-Status: final selection and authorized rollout as of 2026-07-26.
+Status: final selection and authorized rollout as of 2026-07-26; FastFlowLM
+lifecycle corrected on 2026-07-29.
 
 This is the authoritative human-readable placement decision for the two Strix
-Halo machines. The executable source of truth is the per-host allowlists in
-`modules/strix.nix` and the immutable artifact metadata in
-`lib/local-models.nix`.
+Halo machines. The executable source of truth is the per-host llama-swap
+allowlists and FastFlowLM roster in `modules/strix.nix`, plus the immutable
+artifact and runtime metadata in `lib/local-models.nix`.
 
 ## Coordinator
 
@@ -18,8 +19,8 @@ Halo machines. The executable source of truth is the per-host allowlists in
 | `qwen3.6-35b-a3b` | UD-Q8_K_XL GGUF with integrated matched MTP block | Vulkan through llama-swap | 39,099,447,584 |
 | `gemma4-26b-a4b-it` | Q8_0 GGUF plus matched Q8_0 MTP head | Vulkan through llama-swap | 27,321,628,544 |
 | `fara1.5-27b` | Q8_0 GGUF plus BF16 vision projector | ROCm through llama-swap | 29,596,213,728 |
-| `gemma4-it:e4b` | FastFlowLM Gemma4 E4B NPU2 snapshot | NPU peer through llama-swap | 9,087,470,597 |
-| `gpt-oss:20b` | FastFlowLM GPT-OSS 20B NPU2 snapshot | NPU peer through llama-swap | 14,474,616,866 |
+| `gemma4-it:e4b` | FastFlowLM Gemma4 E4B NPU2 snapshot | Ad-hoc `flm run gemma4-it:e4b` | 9,087,470,597 |
+| `gpt-oss:20b` | FastFlowLM GPT-OSS 20B NPU2 snapshot | Ad-hoc `flm run gpt-oss:20b` | 14,474,616,866 |
 | Parakeet unified English 0.6B | Voxtype-managed ONNX/MIGraphX snapshot | Coordinator Voxtype user service | 2,515,028,028 |
 | VibeVoice ASR | Full BF16 long-form ASR/diarization snapshot | Nix-rooted appliance payload; runtime service is future work | 17,348,322,081 |
 | VibeVoice Large | Full BF16 multi-speaker TTS snapshot | Nix-rooted appliance payload; runtime service is future work | 18,686,995,855 |
@@ -44,8 +45,8 @@ normalized 4,096-dimensional embedding on the coordinator.
 | `qwen3.6-35b-a3b` | UD-Q8_K_XL GGUF with integrated matched MTP block | Vulkan through llama-swap | 39,099,447,584 |
 | `gemma4-26b-a4b-it` | Q8_0 GGUF plus matched Q8_0 MTP head | Vulkan through llama-swap | 27,321,628,544 |
 | `fara1.5-27b` | Q8_0 GGUF plus BF16 vision projector | ROCm through llama-swap | 29,596,213,728 |
-| `gemma4-it:e4b` | FastFlowLM Gemma4 E4B NPU2 snapshot | NPU peer through llama-swap | 9,087,470,597 |
-| `gpt-oss:20b` | FastFlowLM GPT-OSS 20B NPU2 snapshot | NPU peer through llama-swap | 14,474,616,866 |
+| `gemma4-it:e4b` | FastFlowLM Gemma4 E4B NPU2 snapshot | Ad-hoc `flm run gemma4-it:e4b` | 9,087,470,597 |
+| `gpt-oss:20b` | FastFlowLM GPT-OSS 20B NPU2 snapshot | Ad-hoc `flm run gpt-oss:20b` | 14,474,616,866 |
 
 Total model download payload: **119,579,377,319 bytes**, or **119.58 GB
 (111.37 GiB)**. Runtime caches are not included. The same runtime-tag caveat
@@ -62,10 +63,10 @@ applies to the two FastFlowLM rows.
 - FastFlowLM owns its NPU2 snapshots as native runtime data under
   `~/.config/flm/models`. In particular, GPT-OSS is an upstream Q4_1 NPU2
   package; it is an explicit runtime-format exception, not a low-bit GGUF
-  selection. Both loopback-only NPU servers remain exposed to callers solely
-  as llama-swap peers. Their download and serve units require the live XDNA
-  device at `/dev/accel/accel0`, so an IOMMU-changing deployment boots the new
-  kernel before FastFlowLM materializes its runtime-owned snapshots.
+  selection. Neither model has a NixOS serve unit or llama-swap peer. The
+  ordinary `flm run <model>` CLI is the activation boundary: it loads one model
+  for the interactive command and releases it on exit. Existing runtime files
+  remain local; a missing model is fetched explicitly with `flm pull <model>`.
 - Voxtype owns and verifies its Parakeet snapshot as mutable user data. Voxtype
   0.7.5 lists larger nominally 0.6B variants, but those are batch-only;
   `parakeet-unified-en-0.6b` is the largest registry entry compatible with the
@@ -78,9 +79,10 @@ applies to the two FastFlowLM rows.
   `amd_iommu=on`; the worker no longer takes the former iGPU-only
   `amd_iommu=off` optimization. The worker must reboot when this generation is
   first activated so amdxdna can bind with the new kernel command line.
-- All local LLM and VLM calls enter through llama-swap. A deterministic
+- Managed local LLM and VLM calls enter through llama-swap. A deterministic
   `<__media__>` marker is inherited by llama.cpp children so multimodal
-  embedding clients can address transient backends consistently.
+  embedding clients can address transient backends consistently. Ad-hoc NPU
+  inference uses FastFlowLM's CLI directly and never starts at boot.
 - GGUF and VibeVoice payloads are immutable, hash-checked Nix store paths. Only
   explicit per-host selections root them; catalog-only candidates do not
   download.

--- a/docs/local-ai/model-roster.md
+++ b/docs/local-ai/model-roster.md
@@ -11,17 +11,18 @@ entries. The active split is intentionally much narrower: see the
 membership and totals. In particular, the coder-next, uncensored, and retired
 DS4 weights are not materialized.
 
-## llama-swap catalog
+## Model and appliance catalog
 
 All llama.cpp rows use the dotfiles-pinned
 [`ggml-org/llama.cpp@571d0d5`](https://github.com/ggml-org/llama.cpp/commit/571d0d540df04f25298d0e159e520d9fc62ed121).
 The table links immutable Hugging Face revisions. A catalog row is not evidence
-that its artifacts are selected on either host.
+that its artifacts are selected on either host. The FastFlowLM rows are direct
+runtime appliances, not llama-swap deployments.
 
 | Class | Public model ID | Exact artifact source | Inference | Evidence at anchor |
 |---|---|---|---|---|
-| Small / fast | `gemma4-it:e4b` | FastFlowLM runtime tag; no HF artifact is owned by this catalog | FastFlowLM NPU peer at `fd371409…`; callers enter through llama-swap | Active on both Strix NPUs |
-| Small / fast | `gpt-oss:20b` | [`FastFlowLM/GPT-OSS-20B-NPU2@12ce92d`](https://huggingface.co/FastFlowLM/GPT-OSS-20B-NPU2/tree/12ce92d2bfa031761ab876b3b845a7dabeab1d98) via FastFlowLM runtime pull | FastFlowLM NPU peer; callers enter through llama-swap | Active on both Strix NPUs |
+| Small / fast | `gemma4-it:e4b` | FastFlowLM runtime tag; no HF artifact is owned by this catalog | Ad-hoc `flm run gemma4-it:e4b` | Available on both Strix NPUs with zero boot residency |
+| Small / fast | `gpt-oss:20b` | [`FastFlowLM/GPT-OSS-20B-NPU2@12ce92d`](https://huggingface.co/FastFlowLM/GPT-OSS-20B-NPU2/tree/12ce92d2bfa031761ab876b3b845a7dabeab1d98) via FastFlowLM runtime pull | Ad-hoc `flm run gpt-oss:20b` | Available on both Strix NPUs with zero boot residency |
 | General | `qwen3.6-35b-a3b` | [`unsloth/Qwen3.6-35B-A3B-MTP-GGUF@5bc3e23`](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF/tree/5bc3e238d916f48a861bac2f8a1990a0e9b7e98d), `Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf` | llama.cpp Vulkan with integrated matched MTP | Exact Strix Halo benchmark: 46.33 tok/s decode and 1045 tok/s 512-token prefill |
 | Coding candidate | `qwen3-coder-next` | [`unsloth/Qwen3-Coder-Next-GGUF@ce09c67`](https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/tree/ce09c67b53bc8739eef83fe67b2f5d293c270632), `Qwen3-Coder-Next-UD-Q4_K_XL.gguf` | llama.cpp Vulkan | Catalog-only historical candidate; its low-bit artifact is excluded from both hosts by the active Q8 policy |
 | Coding | `gemma4-26b-a4b-it` | [`unsloth/gemma-4-26B-A4B-it-GGUF@c099eb4`](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/tree/c099eb48e663fd284577b04978a94ffccb261841), `gemma-4-26B-A4B-it-Q8_0.gguf` plus `MTP/mtp-gemma-4-26B-A4B-it-Q8_0.gguf` | llama.cpp Vulkan with matched Q8 MTP | Active non-QAT instruction checkpoint; Google's QAT identity was dropped because that release is Q4_0-only |
@@ -40,7 +41,7 @@ LFS SHA-256/OIDs, SRI hashes, base/fine-tune revisions, host placement, runtime
 arguments, benchmark IDs, and evidence classes in
 [`../../lib/local-models.nix`](../../lib/local-models.nix).
 
-## Speech appliances outside llama-swap
+## Other appliances outside llama-swap
 
 These identities do not enter llama-swap because their APIs and runtimes are
 modality-specific. VibeVoice payloads are hash-pinned in the Nix store;
@@ -87,6 +88,8 @@ MIGraphX variant but does not replace that journal check.
   not a permanently co-resident second server.
 - The text-only and multimodal embedders remain separate model IDs so callers
   can choose benchmark strength or mixed-modal retrieval explicitly.
+- FastFlowLM models are ad-hoc CLI workloads. Do not configure `flm serve`
+  units or add their model IDs as llama-swap peers.
 - DeepSeek V4's dual-node DS4 row is historical evidence, not a runnable roster
   member. The DS4 package remains installed, but its weights are not materialized.
 - Audio, image, and video generation remain parked and have no roster entries.

--- a/docs/local-ai/tallies/2026-07-26.md
+++ b/docs/local-ai/tallies/2026-07-26.md
@@ -14,9 +14,10 @@ catalog rows remain evidence only; host allowlists are the download boundary.
   lower-bit llama.cpp selections.
 - Both hosts enable the XDNA2 NPU and translated IOMMU mode. The worker gives
   up its former iGPU-only optimization for a uniform accelerator surface.
-- Every local LLM/VLM endpoint remains behind llama-swap. Speech runtimes keep
-  their modality-specific service boundary; Stable Diffusion remains outside
-  the local-LLM route.
+- Managed local LLM/VLM endpoints remain behind llama-swap. FastFlowLM NPU
+  models are direct, ad-hoc `flm run` workloads with no persistent endpoint.
+  Speech runtimes keep their modality-specific service boundary; Stable
+  Diffusion remains outside the local-LLM route.
 
 ## Accepted active llama.cpp identities
 
@@ -32,8 +33,9 @@ catalog rows remain evidence only; host allowlists are the download boundary.
 
 ## Special managed models
 
-- FastFlowLM owns `gemma4-it:e4b` and `gpt-oss:20b` on each host. Bootstrap is
-  idempotent runtime data, while callers use their llama-swap peer IDs.
+- FastFlowLM owns `gemma4-it:e4b` and `gpt-oss:20b` runtime files on each host.
+  Callers summon one model with `flm run <model>`; neither has a boot service or
+  llama-swap peer.
 - Voxtype owns `parakeet-unified-en-0.6b` on the coordinator. It is the largest
   registry choice compatible with the enabled streaming pipeline and is
   verified before service startup.

--- a/flake.nix
+++ b/flake.nix
@@ -691,8 +691,18 @@
           let
             coordinator = self.nixosConfigurations.coordinator.config;
             worker = self.nixosConfigurations.worker.config;
+            zenbook = self.nixosConfigurations.zenbook-duo.config;
             coordinatorSettings = coordinator.services.llama-swap.settings;
             workerSettings = worker.services.llama-swap.settings;
+            findPiWrapper =
+              hostConfig:
+              nixpkgs.lib.findFirst (package: nixpkgs.lib.getName package == "pi")
+                (throw "evaluated host has no declarative Pi wrapper")
+                hostConfig.home-manager.users.tom.home.packages;
+            coordinatorPi = findPiWrapper coordinator;
+            zenbookPi = findPiWrapper zenbook;
+            coordinatorFlmManifest = coordinator.environment.etc."local-models/fastflowlm.json".source;
+            workerFlmManifest = worker.environment.etc."local-models/fastflowlm.json".source;
             modelPackagePaths = map toString (builtins.attrValues localModelStore.packages);
             coordinatorExtraDependencies = map toString coordinator.system.extraDependencies;
             workerExtraDependencies = map toString worker.system.extraDependencies;
@@ -739,9 +749,12 @@
               "artifacts"
             ];
           assert
+            builtins.attrNames self.nixosConfigurations.coordinator.options.services.npu-llm == [
+              "enable"
+              "models"
+            ];
+          assert
             coordinator.services.local-models.allow == [
-              "flm-gemma4-it-e4b"
-              "flm-gpt-oss-20b"
               "qwen36-35b-a3b-mtp-ud-q8-k-xl"
               "gemma4-26b-a4b-it-mtp-q8-0"
               "fara15-27b-q8-0"
@@ -752,8 +765,6 @@
             ];
           assert
             worker.services.local-models.allow == [
-              "flm-gemma4-it-e4b"
-              "flm-gpt-oss-20b"
               "qwen36-35b-a3b-mtp-ud-q8-k-xl"
               "gemma4-26b-a4b-it-mtp-q8-0"
               "fara15-27b-q8-0"
@@ -791,17 +802,7 @@
               "gemma4-26b-a4b-it"
               "qwen3.6-35b-a3b"
             ];
-          assert
-            coordinatorSettings.peers == {
-              flm-gemma4 = {
-                proxy = "http://127.0.0.1:52625";
-                models = [ "gemma4-it:e4b" ];
-              };
-              flm-gpt-oss = {
-                proxy = "http://127.0.0.1:52626";
-                models = [ "gpt-oss:20b" ];
-              };
-            };
+          assert coordinatorSettings.peers == { };
           assert workerSettings.peers == coordinatorSettings.peers;
           assert coordinator.systemd.services.llama-swap.environment.LLAMA_MEDIA_MARKER == "<__media__>";
           assert worker.systemd.services.llama-swap.environment.LLAMA_MEDIA_MARKER == "<__media__>";
@@ -810,16 +811,34 @@
           assert nixpkgs.lib.elem "amd_iommu=on" coordinator.boot.kernelParams;
           assert nixpkgs.lib.elem "amd_iommu=on" worker.boot.kernelParams;
           assert !(nixpkgs.lib.elem "amd_iommu=off" worker.boot.kernelParams);
-          assert coordinator.systemd.services ? "flm-model-bootstrap";
-          assert worker.systemd.services ? "flm-model-bootstrap";
-          assert coordinator.systemd.services ? "flm-serve-gemma4-it-e4b";
-          assert coordinator.systemd.services ? "flm-serve-gpt-oss-20b";
-          assert worker.systemd.services ? "flm-serve-gemma4-it-e4b";
-          assert worker.systemd.services ? "flm-serve-gpt-oss-20b";
+          assert
+            coordinator.services.npu-llm.models == [
+              "gemma4-it:e4b"
+              "gpt-oss:20b"
+            ];
+          assert worker.services.npu-llm.models == coordinator.services.npu-llm.models;
+          assert nixpkgs.lib.all (unit: !(nixpkgs.lib.hasPrefix "flm-" unit)) (
+            builtins.attrNames coordinator.systemd.services
+          );
+          assert nixpkgs.lib.all (unit: !(nixpkgs.lib.hasPrefix "flm-" unit)) (
+            builtins.attrNames worker.systemd.services
+          );
+          assert nixpkgs.lib.all (
+            unit: !(nixpkgs.lib.hasPrefix "flm-" unit)
+          ) coordinator.systemd.services.llama-swap.wants;
+          assert nixpkgs.lib.all (
+            unit: !(nixpkgs.lib.hasPrefix "flm-" unit)
+          ) coordinator.systemd.services.llama-swap.after;
+          assert nixpkgs.lib.any (
+            package: nixpkgs.lib.getName package == "fastflowlm"
+          ) coordinator.environment.systemPackages;
+          assert !(localModelCatalog.deployments."flm-gemma4-it-e4b" ? peer);
+          assert !(localModelCatalog.deployments."flm-gpt-oss-20b" ? peer);
           assert !(nixpkgs.lib.hasInfix "-hf" (builtins.toJSON coordinatorSettings));
           assert !(nixpkgs.lib.hasInfix "-hf" (builtins.toJSON workerSettings));
           assert
             localModelCatalog.backendKinds == {
+              appliances = [ "npu" ];
               local = [
                 "rocm"
                 "vulkan"
@@ -827,7 +846,6 @@
                 "vllm"
                 "mlx"
               ];
-              peers = [ "npu" ];
             };
           assert
             builtins.attrNames renderedBackends == [
@@ -857,6 +875,27 @@
           assert nixpkgs.lib.elem "HF_HUB_OFFLINE=1" renderedBackends.mlx.env;
           assert builtins.hasAttr "mlx-lm" inputs.nix-strix-halo.packages.${system};
           pkgs.runCommand "local-model-routing" { } ''
+            ${pkgs.jq}/bin/jq -e '
+              .schema == 1
+              and .runtime == "fastflowlm"
+              and .lifecycle == "ad-hoc"
+              and .persistentServer == false
+              and (.models | map(.tag)) == ["gemma4-it:e4b", "gpt-oss:20b"]
+              and (.models | map(.command)) == [
+                ["flm", "run", "gemma4-it:e4b"],
+                ["flm", "run", "gpt-oss:20b"]
+              ]
+            ' ${coordinatorFlmManifest} >/dev/null
+            ${pkgs.diffutils}/bin/cmp ${coordinatorFlmManifest} ${workerFlmManifest}
+
+            ${pkgs.gnugrep}/bin/grep -F 'export LLAMA_SWAP_PORT=9292' ${coordinatorPi}/bin/pi >/dev/null
+            ${pkgs.gnugrep}/bin/grep -F -- '-e ${pkgs.pi-llama-swap-extension}' \
+              ${coordinatorPi}/bin/pi >/dev/null
+            if ${pkgs.gnugrep}/bin/grep -F -- '${pkgs.pi-llama-swap-extension}' \
+              ${zenbookPi}/bin/pi >/dev/null; then
+              echo "Pi loaded the llama-swap provider on a host without llama-swap" >&2
+              exit 1
+            fi
             touch "$out"
           '';
       }

--- a/home/dot_local/bin/new-terminal
+++ b/home/dot_local/bin/new-terminal
@@ -14,11 +14,13 @@
 #     subprocess in the spawn path, so every Mod+Shift+Return is instant and
 #     always a BRAND-NEW independent session (two presses in the same second
 #     never collide, so kitty never mirrors an existing session). The richer
-#     LLM title (#38) is now applied ASYNCHRONOUSLY and purely COSMETICALLY by
-#     `zmx-retitle` after the window is already up: it retitles the kitty
+#     Optional LLM title enrichment (#38) is applied ASYNCHRONOUSLY and purely
+#     COSMETICALLY by `zmx-retitle` after the window is already up: it retitles the kitty
 #     window only (zmx has no rename/display-name concept — the session name
 #     IS its identity) and silently no-ops on any failure. It NEVER changes
-#     the session name and NEVER delays the launch.
+#     the session name and NEVER delays the launch. It is disabled by default
+#     now that FastFlowLM models are ad-hoc `flm run` workloads rather than
+#     persistent llama-swap peers.
 #   - elsewhere (worker / zenbook thin-client): open a new kitty that
 #     immediately SSHs to coordinator via the `desk` fish function; niri's
 #     window-rule renders the white "remote" border once desk sets the title.
@@ -93,7 +95,7 @@ sock="unix:@zmx-${sess}"
 # the name, retitles the kitty window. On ANY failure — flm down, ZMX_TITLE=0,
 # no kitten — it silently no-ops, leaving the natural terminal title. It NEVER
 # touches the zmx session name.
-if [[ "${ZMX_TITLE:-1}" == "1" ]]; then
+if [[ "${ZMX_TITLE:-0}" == "1" ]]; then
     setsid "$(dirname "$0")/zmx-retitle" "$sock" "$sess" "${cwd:-$HOME}" \
         </dev/null >/dev/null 2>&1 &
 fi

--- a/home/dot_local/bin/zmx-retitle
+++ b/home/dot_local/bin/zmx-retitle
@@ -15,7 +15,7 @@
 # kitty window title. `set-window-title` is PERMANENT (no --temporary), so the
 # shell won't stomp it, and it propagates to the wayland/OS title niri shows.
 #
-# Env: ZMX_TITLE=0 disables titling entirely (matches `new-terminal`).
+# Env: ZMX_TITLE=1 opts into a separately started, short-lived FLM server.
 set -u
 
 sock="${1-}"
@@ -23,7 +23,7 @@ fallback="${2-}"
 cwd="${3:-$HOME}"
 
 [ -n "$sock" ] || exit 0
-[ "${ZMX_TITLE:-1}" = "1" ] || exit 0
+[ "${ZMX_TITLE:-0}" = "1" ] || exit 0
 command -v kitten >/dev/null 2>&1 || exit 0
 
 here="$(cd "$(dirname "$0")" 2>/dev/null && pwd)" || exit 0

--- a/home/dot_local/bin/zmx-title
+++ b/home/dot_local/bin/zmx-title
@@ -15,13 +15,15 @@
 # can never change behavior when the task-model is unavailable — "titling off"
 # === today's shipped `<cwd-basename>-<HHMMSS>` naming.
 #
-# Task model: the coordinator's NPU-backed FastFlowLM model, reached only
-# through llama-swap's OpenAI-compatible API. Host/port/model/URL are overridable:
-#   LLAMA_SWAP_HOST  (default 127.0.0.1)
-#   LLAMA_SWAP_PORT  (default 9292)
-#   FLM_TITLE_MODEL  (default gemma4-it:e4b, the llama-swap peer model ID)
-#   LLAMA_SWAP_URL   (default http://$LLAMA_SWAP_HOST:$LLAMA_SWAP_PORT/v1/chat/completions)
-#   ZMX_TITLE        (set to 0 to disable titling entirely)
+# Automatic NPU titling is disabled by default: FastFlowLM models are no longer
+# persistent llama-swap peers. Ad-hoc inference uses `flm run <model>`. An
+# operator may temporarily run `flm serve gemma4-it:e4b --port 52625` and opt
+# this cosmetic client in with ZMX_TITLE=1. Host/port/model/URL are overridable:
+#   FLM_TITLE_HOST   (default 127.0.0.1)
+#   FLM_TITLE_PORT   (default 52625)
+#   FLM_TITLE_MODEL  (default gemma4-it:e4b)
+#   FLM_TITLE_URL    (default http://$FLM_TITLE_HOST:$FLM_TITLE_PORT/v1/chat/completions)
+#   ZMX_TITLE        (set to 1 only while a short-lived FLM server is intended)
 #   ZMX_TITLE_TIMEOUT (default 3 — hard wall-clock cap, seconds)
 set -u
 
@@ -31,14 +33,14 @@ shift 2>/dev/null || true
 emit_fallback() { printf '%s\n' "$fallback"; exit 0; }
 
 # Kill switch + hard dependencies. Any miss → deterministic name.
-[ "${ZMX_TITLE:-1}" = "1" ] || emit_fallback
+[ "${ZMX_TITLE:-0}" = "1" ] || emit_fallback
 command -v curl >/dev/null 2>&1 || emit_fallback
 command -v jq   >/dev/null 2>&1 || emit_fallback
 
-host="${LLAMA_SWAP_HOST:-127.0.0.1}"
-port="${LLAMA_SWAP_PORT:-9292}"
+host="${FLM_TITLE_HOST:-127.0.0.1}"
+port="${FLM_TITLE_PORT:-52625}"
 model="${FLM_TITLE_MODEL:-gemma4-it:e4b}"
-url="${LLAMA_SWAP_URL:-http://$host:$port/v1/chat/completions}"
+url="${FLM_TITLE_URL:-http://$host:$port/v1/chat/completions}"
 timeout="${ZMX_TITLE_TIMEOUT:-3}"
 
 # Gather content: positional args, plus stdin if something is piped in. Bounded

--- a/home/pi.nix
+++ b/home/pi.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  osConfig ? null,
   pkgs,
   ...
 }:
@@ -35,8 +36,14 @@
 # (`packages`/`extensions` arrays, loaded only in trusted project dirs). Reach for
 # the latter to scope an extension to one repo instead of the whole fleet.
 #
-# NOT host-gated: like claude-code, pi is a general dev tool every host runs.
 let
+  # Embedded home-manager exposes the host's evaluated NixOS config here. Only
+  # load the local provider where that host actually runs llama-swap; Pi itself
+  # remains available everywhere. The standalone bridge has no osConfig.
+  llamaSwap =
+    if osConfig == null then null else lib.attrByPath [ "services" "llama-swap" ] null osConfig;
+  hasLocalLlamaSwap = llamaSwap != null && llamaSwap.enable;
+
   # ── extension roster ─────────────────────────────────────────────────────
   # One entry per extension — the whole "standard": a name, an `enable` toggle,
   # and an immutable `src`. Add a package by adding a stanza; disable one by
@@ -47,7 +54,7 @@ let
     # roster served on this box (see modules/llama-swap.nix) into pi as a
     # first-class provider. https://pi.dev/packages/@danielmeneses/pi-llama-swap
     pi-llama-swap = {
-      enable = true;
+      enable = hasLocalLlamaSwap;
       src = pkgs.pi-llama-swap-extension;
     };
   };
@@ -72,6 +79,14 @@ let
         exec ${pi}/bin/pi "$@"
         ;;
     esac
+    # The extension's upstream default is :8080; our one caller-facing local
+    # LLM endpoint comes from this host's service config. Preserve an explicit
+    # caller override for diagnostics and remote endpoints.
+    ${lib.optionalString hasLocalLlamaSwap ''
+      if test -z "''${LLAMA_SWAP_URL-}" && test -z "''${LLAMA_SWAP_PORT-}"; then
+        export LLAMA_SWAP_PORT=${toString llamaSwap.port}
+      fi
+    ''}
     exec ${pi}/bin/pi ${lib.escapeShellArgs loadArgs} "$@"
   '';
 in

--- a/home/voxtype.nix
+++ b/home/voxtype.nix
@@ -63,7 +63,7 @@ in
   # The selected model is the only entry in Voxtype 0.7.5's registry marked as
   # compatible with its cache-aware live-streaming pipeline. Bootstrap it through
   # Voxtype's own idempotent downloader before the daemon starts, mirroring the
-  # intentional runtime-pull boundary used by FastFlowLM.
+  # runtime-owned model-data boundary used by FastFlowLM.
   systemd.user.services.voxtype = lib.mkIf (hostName == "coordinator") {
     Service = {
       # `setup --download` also persists its selected model to the default

--- a/lib/local-model-backends.nix
+++ b/lib/local-model-backends.nix
@@ -6,5 +6,5 @@
     "vllm"
     "mlx"
   ];
-  peers = [ "npu" ];
+  appliances = [ "npu" ];
 }

--- a/lib/local-models.nix
+++ b/lib/local-models.nix
@@ -200,24 +200,6 @@ let
     };
   };
 
-  peerType = types.submodule {
-    options = {
-      name = mkOption {
-        type = types.str;
-        description = "llama-swap peer ID.";
-      };
-      proxy = mkOption {
-        type = types.str;
-        description = "OpenAI-compatible upstream base URL.";
-      };
-      systemdUnit = mkOption {
-        type = nullableString;
-        default = null;
-        description = "Optional local backend unit ordered before llama-swap.";
-      };
-    };
-  };
-
   benchmarkType = types.submodule {
     options = {
       sourceRepo = mkOption { type = types.str; };
@@ -243,7 +225,7 @@ let
     options = {
       model = mkOption {
         type = types.str;
-        description = "Model ID presented through llama-swap.";
+        description = "Public model ID exposed by the selected runtime.";
       };
       role = mkOption {
         type = types.enum [
@@ -267,7 +249,7 @@ let
         ];
       };
       backend = mkOption {
-        type = types.enum (backendKinds.local ++ backendKinds.peers);
+        type = types.enum (backendKinds.local ++ backendKinds.appliances);
       };
       hosts = mkOption {
         type = types.nonEmptyListOf (
@@ -287,10 +269,6 @@ let
         default = { };
       };
       runtime = mkOption { type = runtimeType; };
-      peer = mkOption {
-        type = types.nullOr peerType;
-        default = null;
-      };
       benchmark = mkOption {
         type = types.nullOr benchmarkType;
         default = null;
@@ -851,14 +829,9 @@ let
                 repository = "https://github.com/FastFlowLM/FastFlowLM";
                 commit = "fd371409897d7c0abb4de4dbc5098b9b43c094ff";
               };
-              peer = {
-                name = "flm-gemma4";
-                proxy = "http://127.0.0.1:52625";
-                systemdUnit = "flm-serve-gemma4-it-e4b.service";
-              };
               evidence = "matched-local";
               hardware = "Strix Halo XDNA2 NPU; amdxdna/XRT from nix-amd-ai";
-              notes = "Multimodal utility lane on both Strix hosts. FastFlowLM owns these weights via runtime flm pull; callers still enter through llama-swap.";
+              notes = "Ad-hoc multimodal utility model on both Strix hosts. FastFlowLM owns these weights; `flm run gemma4-it:e4b` loads them only for the interactive command.";
             };
 
             flm-gpt-oss-20b = {
@@ -874,14 +847,9 @@ let
                 repository = "https://huggingface.co/FastFlowLM/GPT-OSS-20B-NPU2";
                 commit = "12ce92d2bfa031761ab876b3b845a7dabeab1d98";
               };
-              peer = {
-                name = "flm-gpt-oss";
-                proxy = "http://127.0.0.1:52626";
-                systemdUnit = "flm-serve-gpt-oss-20b.service";
-              };
               evidence = "api-only";
               hardware = "Strix Halo XDNA2 NPU; amdxdna/XRT from nix-amd-ai";
-              notes = "Second NPU reasoning lane on both Strix hosts; FastFlowLM tag gpt-oss:20b, Q4_1 NPU2 snapshot.";
+              notes = "Ad-hoc NPU reasoning model on both Strix hosts; `flm run gpt-oss:20b` loads the Q4_1 NPU2 snapshot only for the interactive command.";
             };
 
             qwen36-35b-a3b-mtp-ud-q8-k-xl = {

--- a/modules/llama-swap.nix
+++ b/modules/llama-swap.nix
@@ -7,8 +7,9 @@
 # Native llama-swap control plane for the two Strix Halo nodes.
 #
 # This module owns only the proxy package, lifecycle, state, and network
-# boundary. local-models.nix owns the typed roster, backend commands, peers, and
-# guarded weight materialization. The proxy itself is a small, always-on Go
+# boundary. local-models.nix owns the typed roster, backend commands, and
+# guarded weight materialization. Runtime appliances such as FastFlowLM stay
+# outside this control plane. The proxy itself is a small, always-on Go
 # process and consumes no GPU. Tally remains the admission controller for the
 # per-box GPU pools; llama-swap supplies the one stable API door and load/unload
 # mechanism.

--- a/modules/local-models.nix
+++ b/modules/local-models.nix
@@ -24,23 +24,6 @@ let
   canonicalModelIds = map (deployment: deployment.model) canonicalList;
   selectedDeployments = lib.filterAttrs (name: _: lib.elem name cfg.allow) catalog.deployments;
   selectedList = builtins.attrValues selectedDeployments;
-  peerDeployments = lib.filter (deployment: deployment.peer != null) selectedList;
-  gpuDeployments = lib.filterAttrs (_: deployment: deployment.peer == null) selectedDeployments;
-
-  peerNames = lib.unique (map (deployment: deployment.peer.name) peerDeployments);
-  peers = lib.genAttrs peerNames (
-    peerName:
-    let
-      members = lib.filter (deployment: deployment.peer.name == peerName) peerDeployments;
-    in
-    {
-      proxy = (builtins.head members).peer.proxy;
-      models = map (deployment: deployment.model) members;
-    }
-  );
-  peerUnits = lib.unique (
-    lib.filter (unit: unit != null) (map (deployment: deployment.peer.systemdUnit) peerDeployments)
-  );
 
   modelRenderers = import ../lib/local-model-runtime.nix {
     inherit lib;
@@ -56,9 +39,7 @@ let
 
   referencedArtifactIds =
     deployment: lib.filter (artifactId: artifactId != null) (builtins.attrValues deployment.artifacts);
-  deploymentArtifactIds = lib.unique (
-    lib.concatMap referencedArtifactIds (builtins.attrValues gpuDeployments)
-  );
+  deploymentArtifactIds = lib.unique (lib.concatMap referencedArtifactIds selectedList);
   hostArtifactIds = lib.unique (deploymentArtifactIds ++ cfg.artifacts);
   hostArtifactPackages = map (
     artifactId: modelStore.materialized.${artifactId}.package
@@ -110,18 +91,11 @@ let
       };
     };
 
-  gpuModels = lib.mapAttrs' renderModel gpuDeployments;
+  localModels = lib.mapAttrs' renderModel selectedDeployments;
 
   artifactIds = builtins.attrNames catalog.artifacts;
   deploymentIds = builtins.attrNames catalog.deployments;
   artifactRows = builtins.attrValues catalog.artifacts;
-  peerProxyFor =
-    peerName:
-    lib.unique (
-      map (deployment: deployment.peer.proxy) (
-        lib.filter (deployment: deployment.peer != null && deployment.peer.name == peerName) deploymentList
-      )
-    );
   manifest = (pkgs.formats.json { }).generate "local-model-catalog.json" catalog;
   artifactEtc = lib.listToAttrs (
     map (artifactId: {
@@ -140,12 +114,9 @@ let
     {
       assertion = lib.all (
         deployment:
-        if deployment.peer == null then
-          lib.elem deployment.backend catalog.backendKinds.local
-        else
-          lib.elem deployment.backend catalog.backendKinds.peers
+        lib.elem deployment.backend (catalog.backendKinds.local ++ catalog.backendKinds.appliances)
       ) deploymentList;
-      message = "Local deployments must use rendered backends and peers must use peer-only backends.";
+      message = "Every deployment must use a declared local or appliance backend.";
     }
     {
       assertion = lib.all (
@@ -172,26 +143,22 @@ let
     {
       assertion = lib.all (
         deployment:
-        if deployment.peer == null then
+        if lib.elem deployment.backend catalog.backendKinds.local then
           deployment.artifacts.model != null
         else
           referencedArtifactIds deployment == [ ]
       ) deploymentList;
-      message = "Local GPU deployments require a model artifact; external peers must not root artifacts.";
+      message = "Managed local deployments require a model artifact; runtime appliances must not root artifacts.";
     }
     {
       assertion = builtins.length canonicalModelIds == builtins.length (lib.unique canonicalModelIds);
-      message = "Canonical llama-swap model IDs must be unique per host.";
+      message = "Canonical public model IDs must be unique per host.";
     }
     {
       assertion = lib.all (
         deployment: lib.all (arg: !(lib.hasInfix "-hf" arg)) deployment.runtime.args
       ) deploymentList;
       message = "Runtime model downloads (-hf) are forbidden; use pinned store artifacts.";
-    }
-    {
-      assertion = lib.all (peerName: builtins.length (peerProxyFor peerName) == 1) peerNames;
-      message = "All deployments on one llama-swap peer must use the same proxy URL.";
     }
     {
       assertion = lib.all (
@@ -211,9 +178,12 @@ let
     }
     {
       assertion = lib.all (
-        deployment: deployment.status == "canonical" && lib.elem host deployment.hosts
+        deployment:
+        deployment.status == "canonical"
+        && lib.elem host deployment.hosts
+        && lib.elem deployment.backend catalog.backendKinds.local
       ) selectedList;
-      message = "Every allowed local-model deployment must be canonical and assigned to this host.";
+      message = "Every allowed local-model deployment must be a canonical managed backend assigned to this host.";
     }
     {
       assertion = builtins.length cfg.artifacts == builtins.length (lib.unique cfg.artifacts);
@@ -235,7 +205,8 @@ in
       default = [ ];
       description = ''
         Canonical deployment IDs to materialize and expose through llama-swap
-        on this host. Catalog entries not named here remain metadata-only.
+        on this host. Runtime appliances such as FastFlowLM stay outside this
+        list and are invoked through their own explicit CLI.
       '';
     };
 
@@ -261,16 +232,13 @@ in
     services.llama-swap.settings =
       assert catalogValid;
       {
-        inherit peers;
-        models = gpuModels;
+        models = localModels;
+        # Runtime appliances are deliberately not represented as proxy peers.
+        peers = { };
       };
 
     # Only the explicit per-host deployment/artifact lists root weight FODs.
     system.extraDependencies = hostArtifactPackages;
 
-    systemd.services.llama-swap = lib.mkIf (peerUnits != [ ]) {
-      wants = peerUnits;
-      after = peerUnits;
-    };
   };
 }

--- a/modules/npu-llm.nix
+++ b/modules/npu-llm.nix
@@ -4,169 +4,72 @@
   pkgs,
   ...
 }:
-# NPU-served local-LLM runtimes on both Strix Halo hosts.
+# Declarative FastFlowLM roster for ad-hoc NPU inference.
 #
-# Each declared FastFlowLM tag gets its own loopback-only `flm serve` unit and
-# fixed port. llama-swap is the only caller-facing endpoint; these native peers
-# stay implementation details. Separate units are necessary because one FLM
-# server accepts exactly one model tag.
-#
-# The amdxdna driver, XRT userspace, and the `flm` binary itself all come from
-# hardware.amd-npu (nix-amd-ai) — upstream ships no serve unit or model option,
-# so this module only adds model choices, serve units, and a declarative
-# bootstrap. Weights are multi-GB and are pulled at RUNTIME into the serving
-# user's ~/.config/flm/models — deliberately NEVER into the nix store.
+# This module deliberately creates no systemd units and performs no activation
+# pull. The ordinary `flm run <model>` command owns load/use/unload; `flm pull
+# <model>` remains an explicit operator action when runtime-owned files are
+# absent. Nix owns only the allowed model identities and an inspectable manifest.
 let
   cfg = config.services.npu-llm;
-  inherit (lib)
-    mkEnableOption
-    mkOption
-    mkIf
-    types
-    ;
-  safeUnitName = tag: lib.replaceStrings [ ":" "." "/" ] [ "-" "-" "-" ] tag;
-  modelType = types.submodule {
-    options = {
-      tag = mkOption {
-        type = types.str;
-        description = "FastFlowLM model tag, as printed by `flm list`.";
-      };
-      port = mkOption {
-        type = types.port;
-        description = "Loopback port for this model's dedicated FLM server.";
-      };
-    };
-  };
-  runtimeEnvironment = {
-    # System units do not inherit login-session plugin-discovery paths.
-    XILINX_XRT = config.environment.sessionVariables.XILINX_XRT or "";
-    XRT_PATH = config.environment.sessionVariables.XRT_PATH or "";
-    FLM_DISABLE_UPDATE_CHECK = "1";
-  };
-  bootstrap = pkgs.writeShellScript "flm-model-bootstrap" (
-    lib.concatMapStringsSep "\n" (
-      model: "${pkgs.fastflowlm}/bin/flm pull ${lib.escapeShellArg model.tag}"
-    ) cfg.models
+  catalog = import ../lib/local-models.nix { inherit lib; };
+  host = config.networking.hostName;
+  catalogModels = map (deployment: deployment.model) (
+    lib.filter (
+      deployment:
+      deployment.status == "canonical" && deployment.backend == "npu" && lib.elem host deployment.hosts
+    ) (builtins.attrValues catalog.deployments)
   );
+  manifest = (pkgs.formats.json { }).generate "fastflowlm-models.json" {
+    schema = 1;
+    runtime = "fastflowlm";
+    lifecycle = "ad-hoc";
+    persistentServer = false;
+    models = map (tag: {
+      inherit tag;
+      command = [
+        "flm"
+        "run"
+        tag
+      ];
+    }) cfg.models;
+  };
 in
 {
   options.services.npu-llm = {
-    enable = mkEnableOption "the FastFlowLM `flm serve` NPU model runtime";
+    enable = lib.mkEnableOption "the declarative ad-hoc FastFlowLM NPU roster";
 
-    models = mkOption {
-      type = types.listOf modelType;
+    models = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
-        FastFlowLM model tags to download and serve on the NPU. Every entry gets
-        an idempotent runtime pull and a dedicated loopback endpoint.
+        FastFlowLM model tags approved for ad-hoc `flm run` use on this host.
+        This option never starts, serves, or downloads a model.
       '';
-    };
-
-    user = mkOption {
-      type = types.str;
-      description = ''
-        User `flm serve` runs as. Its ~/.config/flm/models holds the pulled
-        weights, and it must be in the video/render groups for NPU access (the
-        unit adds those as SupplementaryGroups regardless).
-      '';
-    };
-
-    host = mkOption {
-      type = types.str;
-      default = "127.0.0.1";
-      description = "Bind address for `flm serve`. Localhost keeps it on-box only.";
-    };
-
-    powerMode = mkOption {
-      type = types.enum [
-        "powersaver"
-        "balanced"
-        "performance"
-        "turbo"
-      ];
-      default = "performance";
-      description = "`flm --pmode` NPU power profile.";
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = config.hardware.amd-npu.enable && config.hardware.amd-npu.enableFastFlowLM;
-        message = "services.npu-llm requires hardware.amd-npu.enable + enableFastFlowLM (which provide the amdxdna NPU stack, XRT, and the `flm` binary).";
+        message = "services.npu-llm requires the amdxdna NPU stack and FastFlowLM CLI.";
       }
       {
         assertion = cfg.models != [ ];
-        message = "services.npu-llm.models must contain at least one model.";
+        message = "services.npu-llm.models must contain at least one tag.";
       }
       {
-        assertion =
-          builtins.length cfg.models == builtins.length (lib.unique (map (model: model.tag) cfg.models));
-        message = "services.npu-llm.models must use unique model tags.";
+        assertion = builtins.length cfg.models == builtins.length (lib.unique cfg.models);
+        message = "services.npu-llm.models must not contain duplicate tags.";
       }
       {
-        assertion =
-          builtins.length cfg.models == builtins.length (lib.unique (map (model: model.port) cfg.models));
-        message = "services.npu-llm.models must use unique ports.";
+        assertion = lib.sort builtins.lessThan cfg.models == lib.sort builtins.lessThan catalogModels;
+        message = "services.npu-llm.models must exactly match this host's canonical NPU catalog rows.";
       }
     ];
 
-    systemd.services = {
-      # Pull sequentially so first boot never has two FLM writers racing in the
-      # same per-user model registry. Re-evaluation is cheap because pull is
-      # idempotent and validates already-present snapshots.
-      flm-model-bootstrap = {
-        description = "Download the declared FastFlowLM NPU models";
-        after = [ "network-online.target" ];
-        wants = [ "network-online.target" ];
-        # A switch cannot retrofit IOMMU state into the running kernel. Defer
-        # both downloads and serving until the XDNA device is actually usable;
-        # the condition is evaluated again normally on the next boot.
-        unitConfig.ConditionPathExists = "/dev/accel/accel0";
-        environment = runtimeEnvironment;
-        path = [
-          pkgs.fastflowlm
-          "/run/current-system/sw"
-        ];
-        serviceConfig = {
-          Type = "oneshot";
-          User = cfg.user;
-          ExecStart = bootstrap;
-          RemainAfterExit = true;
-          TimeoutStartSec = "infinity";
-        };
-      };
-    }
-    // lib.listToAttrs (
-      map (model: {
-        name = "flm-serve-${safeUnitName model.tag}";
-        value = {
-          description = "FastFlowLM NPU model server (${model.tag})";
-          after = [ "flm-model-bootstrap.service" ];
-          requires = [ "flm-model-bootstrap.service" ];
-          wantedBy = [ "multi-user.target" ];
-          unitConfig.ConditionPathExists = "/dev/accel/accel0";
-          # `flm` and XRT reach the system profile via hardware.amd-npu.
-          path = [
-            pkgs.fastflowlm
-            "/run/current-system/sw"
-          ];
-          environment = runtimeEnvironment;
-          serviceConfig = {
-            Type = "simple";
-            User = cfg.user;
-            SupplementaryGroups = [
-              "video"
-              "render"
-            ];
-            ExecStart = "${pkgs.fastflowlm}/bin/flm serve ${model.tag} --host ${cfg.host} --port ${toString model.port} --pmode ${cfg.powerMode}";
-            Restart = "on-failure";
-            RestartSec = "5s";
-            KillSignal = "SIGINT";
-            LimitMEMLOCK = "infinity";
-          };
-        };
-      }) cfg.models
-    );
+    environment.systemPackages = [ pkgs.fastflowlm ];
+    environment.etc."local-models/fastflowlm.json".source = manifest;
   };
 }

--- a/modules/strix.nix
+++ b/modules/strix.nix
@@ -21,7 +21,7 @@
     ./llama-swap.nix
     # Typed model catalog, guarded store materialization, and host projections.
     ./local-models.nix
-    # FastFlowLM peers and their idempotent runtime model pulls.
+    # Deterministic FastFlowLM roster only; ad-hoc `flm run`, with no daemon.
     ./npu-llm.nix
   ];
 
@@ -40,8 +40,6 @@
     # per-host rows enter the system closure and llama-swap configuration.
     services.local-models = {
       allow = [
-        "flm-gemma4-it-e4b"
-        "flm-gpt-oss-20b"
         "qwen36-35b-a3b-mtp-ud-q8-k-xl"
         "gemma4-26b-a4b-it-mtp-q8-0"
         "fara15-27b-q8-0"
@@ -73,16 +71,9 @@
 
     services.npu-llm = {
       enable = true;
-      user = "tom";
       models = [
-        {
-          tag = "gemma4-it:e4b";
-          port = 52625;
-        }
-        {
-          tag = "gpt-oss:20b";
-          port = 52626;
-        }
+        "gemma4-it:e4b"
+        "gpt-oss:20b"
       ];
     };
 


### PR DESCRIPTION
## What changed

- remove FastFlowLM deployments from `services.local-models.allow`, llama-swap peers, and llama-swap systemd dependencies
- replace the two boot-enabled `flm serve` units and bootstrap unit with a declarative, non-resident `services.npu-llm.models` roster
- render the approved FLM tags and their ordinary `flm run <model>` commands to `/etc/local-models/fastflowlm.json`
- keep FastFlowLM installed on both Strix hosts without pulling, serving, or loading a model during activation
- disable automatic terminal-title NPU calls by default; the deterministic title fallback remains unchanged
- point Pi's llama-swap extension at the declared port 9292 and load it only on hosts that actually run llama-swap
- update the local-AI catalog, lifecycle documentation, and evaluation assertions

## Root cause

Every declared FLM model had `wantedBy = [ "multi-user.target" ]`, so NixOS started both servers at boot and after switches. The local-model projection also registered both as llama-swap peers and added their units to llama-swap's `Wants=` and `After=`. Because FastFlowLM eagerly loads weights, those independent paths kept roughly 23–28 GiB resident while idle.

The Pi regression was separate: the extension defaults to port 8080, while this fleet declares llama-swap on port 9292. Port 8080 returned the reported 404.

## Impact

After activation and reboot, there are no `flm-*` systemd units and no FLM llama-swap peers, so idle NPU model residency is zero. Existing runtime-owned model files remain under `~/.config/flm/models`. Ad-hoc NPU inference stays the native path:

```console
flm run gemma4-it:e4b
flm run gpt-oss:20b
```

Managed GPU models continue through llama-swap. The #96 utility-model design must follow this corrected boundary and must not recreate an FLM peer or persistent daemon.

## Validation

- `nix build .#checks.x86_64-linux.local-model-routing --no-link --print-build-logs`
- `nix flake check --no-build --show-trace`
- Bash syntax validation for the three terminal-title scripts
- generated coordinator Pi wrapper executed against the live llama-swap service with `pi --help`: exit 0 and no startup error
- evaluation confirms the FLM manifest contains exactly `gemma4-it:e4b` and `gpt-oss:20b`, llama-swap peers are empty, and neither host has an `flm-*` unit

Closes #116