### PR TITLE
fix(home-manager): restore tom@bridge evaluation and refresh host inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,21 @@ image), harnessRPM (COPR packages), chezmoi-templated dotfiles, and zirconium.
 
 ## Hosts
 
+The flake exports exactly three NixOS host configurations:
+
 | Host | Hardware | Role |
 |---|---|---|
 | `coordinator` | Framework Desktop, AMD Strix Halo | controller node, daily driver |
 | `worker` | Framework Desktop, AMD Strix Halo | soft-retired tailnet worker; optional LLM and microVM capacity |
-| `dell-xps` | Dell XPS 13 (2022), Intel | thin-client laptop |
 | `zenbook-duo` | ASUS Zenbook Duo, Intel | thin-client laptop (historical first-flash runbook: [docs/old/zenbook-duo-flash.md](docs/old/zenbook-duo-flash.md)) |
 
+The two Framework desktops have a direct TB5 link; active fleet routing uses
+their tailnet hostnames. `tom@bridge` is a separate standalone Home Manager
+output for a live Fedora host, not a fourth NixOS host.
+
 ```
-flake.nix        four hosts wired through one mkHost; tom@bridge = home-manager-only
-                 bridge for a live Fedora host (Phase 0)
+flake.nix        three NixOS hosts wired through one mkHost; tom@bridge is a
+                 separate standalone Home Manager output for live Fedora
 modules/         common.nix (every host) + strix.nix (AMD Strix Halo pair)
 hosts/           one module per machine
 home/            home-manager: typed nix (home.nix, nvim.nix) + RAW out-of-store

--- a/flake.nix
+++ b/flake.nix
@@ -476,6 +476,21 @@
 
       # The RAW out-of-store dotfiles are never checked at switch, so check them here.
       checks.${system} = {
+        home-bridge =
+          let
+            bridge = self.homeConfigurations."tom@bridge";
+            bridgeConfig = bridge.config;
+          in
+          assert bridgeConfig.home.username == "tom";
+          assert bridgeConfig.programs.atuin.settings.auto_sync == false;
+          assert nixpkgs.lib.hasInfix "No host-specific niri config on bridge."
+            bridgeConfig.xdg.configFile."niri-local.kdl".text;
+          assert bridgeConfig.services.tally.enable == false;
+          assert bridgeConfig.programs.voxtype.enable == false;
+          assert !(bridgeConfig.systemd.user.services ? ntm);
+          assert !(bridgeConfig.systemd.user.services ? wayvnc);
+          bridge.activationPackage;
+
         fleet-connectivity =
           let
             coordinator = self.nixosConfigurations.coordinator.config;

--- a/hosts/coordinator/disko.nix
+++ b/hosts/coordinator/disko.nix
@@ -1,8 +1,8 @@
 {
   # Coordinator install target — the internal WD_BLACK SN7100 1TB NVMe, VERIFIED on
-  # the live machine 2026-07-05 (`lsblk`: nvme0n1, 931.5G). Flashed LAST, driven from
-  # the dell-xps. Same layout as the worker: 1G ESP + ext4 root (ext4 over the old
-  # placeholder's xfs — the two Strix boxes stay replicas).
+  # the live machine 2026-07-05 (`lsblk`: nvme0n1, 931.5G). Flashed LAST during
+  # the initial fleet bring-up. Same layout as the worker: 1G ESP + ext4 root
+  # (ext4 over the old placeholder's xfs — the two Strix boxes stay replicas).
   # ⚠️ DESTRUCTIVE: wipes /dev/nvme0n1. Run the TASK-39 secrets/state export first.
   disko.devices.disk.main = {
     type = "disk";

--- a/modules/mesh-registry.nix
+++ b/modules/mesh-registry.nix
@@ -1,5 +1,6 @@
-# The device mesh — ONE source of truth for the hosts, consumed by both the SSH
-# trust plumbing (modules/mesh.nix) and the Remmina VNC profiles (home/remote.nix).
+# The device mesh — ONE source of truth for the three NixOS hosts, consumed by
+# both the SSH trust plumbing (modules/mesh.nix) and the Remmina VNC profiles
+# (home/remote.nix).
 #
 # Per host: `aliases` (every name/IP the host answers to) and two PUBLIC keys that
 # are safe to commit. Fill them in once, AFTER a host's first boot:


### PR DESCRIPTION
## Summary

- add `checks.x86_64-linux.home-bridge`, returning the standalone activation package after asserting bridge-safe niri, Atuin, Tally, Voxtype, NTM, and remote-access behavior
- document exactly three NixOS hosts while keeping `tom@bridge` separate, and identify the Framework desktop link as TB5
- remove stale active Dell inventory references without changing historical material or advancing worker retirement

## Context

The current base already contains the null-safe `hostName` use for `niri-local.kdl`, landed with the Voxtype migration for #84, and the old asr-rs block no longer exists. I audited every module imported by `home/home.nix`; the remaining direct `osConfig` dereferences are behind null-safe host gates. Evaluating the full activation package and the new bridge assertions demonstrates those paths remain unreachable for standalone Home Manager.

## Validation

```text
$ nix eval --raw --no-write-lock-file '.#homeConfigurations."tom@bridge".activationPackage.drvPath'
/nix/store/r7agf7lvsnmnvaz9i33l0slygr02sl4s-home-manager-generation.drv

$ nix flake check --no-build --no-write-lock-file
checking derivation checks.x86_64-linux.home-bridge...
derivation evaluated to /nix/store/r7agf7lvsnmnvaz9i33l0slygr02sl4s-home-manager-generation.drv
all checks passed!

$ nix eval --raw --no-write-lock-file '.#nixosConfigurations.coordinator.config.system.build.toplevel.drvPath'
/nix/store/xvp44j2iczb1ligxw3sram1n5nwn41rr-nixos-system-coordinator-26.11.20260723.e2587ca.drv

$ nix eval --raw --no-write-lock-file '.#nixosConfigurations.worker.config.system.build.toplevel.drvPath'
/nix/store/xw3lfygqy7z8ly25brd3jjrdyq0jl9gi-nixos-system-worker-26.11.20260723.e2587ca.drv

$ nix eval --raw --no-write-lock-file '.#nixosConfigurations.zenbook-duo.config.system.build.toplevel.drvPath'
/nix/store/qnfivlkwbwslaf92icik7yp1nhxhyiq6-nixos-system-zenbook-duo-26.11.20260723.e2587ca.drv

$ rg -n --glob '!docs/old/**' 'dell-xps|four hosts|4 hosts|TB4' README.md modules hosts docs
# no output (exit 1: no stale active-inventory matches)
```

Closes #103