### PR TITLE
printing: enable Brother across the active fleet

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -429,6 +429,7 @@
         in
         {
           inherit (pkgs)
+            brother-print-text
             local-ai-monthly
             mactahoe-gtk-theme
             mactahoe-icon-theme
@@ -549,6 +550,52 @@
             ${./flake.nix} ${./lib} ${./modules} ${./hosts} ${./overlays} ${./home} > $out 2>&1 \
             || (cat $out; exit 1)
         '';
+
+        printing =
+          let
+            coordinator = self.nixosConfigurations.coordinator.config;
+            zenbook = self.nixosConfigurations.zenbook-duo.config;
+            activeHosts = [
+              coordinator
+              zenbook
+            ];
+            expectedPrinter = {
+              name = "Brother_HL_L2445DW";
+              description = "Brother HL-L2445DW";
+              location = "Home";
+              deviceUri = "ipp://BRW08F97E55F396.local:631/ipp/print";
+              model = "everywhere";
+              ppdOptions.PageSize = "A4";
+            };
+          in
+          assert nixpkgs.lib.all (host: host.services.printing.enable) activeHosts;
+          assert nixpkgs.lib.all (host: host.services.avahi.enable) activeHosts;
+          assert nixpkgs.lib.all (host: host.services.avahi.nssmdns4) activeHosts;
+          assert nixpkgs.lib.all (host: host.services.avahi.openFirewall) activeHosts;
+          assert nixpkgs.lib.all (
+            host: host.services.resolved.settings.Resolve.MulticastDNS == false
+          ) activeHosts;
+          assert nixpkgs.lib.all (
+            host: host.hardware.printers.ensureDefaultPrinter == expectedPrinter.name
+          ) activeHosts;
+          assert nixpkgs.lib.all (
+            host: host.hardware.printers.ensurePrinters == [ expectedPrinter ]
+          ) activeHosts;
+          assert nixpkgs.lib.all (
+            host: builtins.elem pkgs.brother-print-text host.environment.systemPackages
+          ) activeHosts;
+          pkgs.runCommand "printing"
+            {
+              nativeBuildInputs = [
+                pkgs.brother-print-text
+                pkgs.gnugrep
+              ];
+            }
+            ''
+              brother-print-text --help \
+                | grep -F 'usage: brother-print-text [--] <text...>' >/dev/null
+              touch "$out"
+            '';
 
         huggingface-cli-smoke =
           let

--- a/hosts/coordinator/default.nix
+++ b/hosts/coordinator/default.nix
@@ -23,9 +23,8 @@
     ../../modules/caddy-artifacts.nix
     ../../modules/cli-anything.nix
     ../../modules/strix.nix
-    # Desktop-only local-media plane: mDNS discovery (avahi) + AirPlay output for
-    # the JBL Authentics 200 + CUPS/driverless printing for the Brother. refs the
-    # 2026-07-24 "Chrome can't find the JBL" fix (mDNS was firewalled off).
+    # Desktop-only AirPlay output for the JBL Authentics 200. Shared mDNS and
+    # Brother printing now live fleet-wide in modules/printing.nix.
     ../../modules/desktop-media.nix
   ];
 

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -12,6 +12,7 @@
     ./secrets.nix # agenix secret delivery (gated by mySecrets.enable, default off)
     ./dotfiles-bootstrap.nix # ensure ~/mecattaf/dotfiles exists before the session
     ./artifacts.nix # myArtifacts options (+ worker VM-port window); serving plane is coordinator-only (caddy-artifacts.nix)
+    ./printing.nix # CUPS + Brother IPP/raw-text path (active fleet + future hosts)
   ];
 
   # --- identity / base ---

--- a/modules/desktop-media.nix
+++ b/modules/desktop-media.nix
@@ -1,21 +1,19 @@
 { pkgs, ... }:
-# Local-network media + printing plane for the desktop (coordinator only).
+# Local-network media plane for the desktop (coordinator only). The shared
+# Brother printing + mDNS plane lives in printing.nix.
 #
-# The two appliances this box should "just work" with:
+# The appliance this box should "just work" with:
 #   - a JBL Authentics 200  — AirPlay 2 + Chromecast, wired to enp191s0 as
 #     10.42.0.56 (see hosts/coordinator/uplink-nas.nix for the dedicated link)
-#   - a Brother HL-L2445DW  — driverless IPP, 192.168.1.38 (wifi)
-# Both are found over mDNS / DNS-SD: a multicast query to 224.0.0.251:5353.
+# It is found over mDNS / DNS-SD: a multicast query to 224.0.0.251:5353.
 #
 # Why nothing worked before this module (diagnosed 2026-07-24):
-#   1. No mDNS at all. avahi was not installed, and common.nix's firewall
+#   1. No mDNS at all. Avahi was not installed, and common.nix's firewall
 #      (enable = true, no LAN holes) dropped inbound UDP 5353. A multicast probe
 #      for _googlecast/_raop/_ipp got ZERO responders even though the JBL pings
-#      fine and its cast/airplay ports are open — Chrome's Cast picker, PipeWire's
-#      AirPlay discovery, and CUPS printer discovery all saw an empty network.
+#      fine and its cast/airplay ports are open.
 #   2. PipeWire had no RAOP (AirPlay) sender module, so a discovered JBL could
 #      not be selected as an output sink.
-#   3. No CUPS, so there was nothing to print to.
 #
 # --- Why the JBL is driven through OwnTone and not PipeWire's RAOP ---
 # (diagnosed 2026-07-25) PipeWire's libpipewire-module-raop-sink speaks the
@@ -58,21 +56,6 @@ let
   '';
 in
 {
-  # --- mDNS / DNS-SD discovery (the shared root cause) ---
-  # avahi owns :5353 and browses both interfaces; openFirewall punches UDP 5353
-  # so multicast replies reach us. Chrome does its own mDNS and only needs the
-  # port open; OwnTone + CUPS talk to the avahi daemon over D-Bus.
-  services.avahi = {
-    enable = true;
-    nssmdns4 = true; # resolve <device>.local (e.g. the printer's web UI)
-    openFirewall = true; # UDP 5353
-  };
-  # systemd-resolved also wants :5353 for its own mDNS stub; hand mDNS to avahi so
-  # the daemon binds cleanly. This only disables resolved's MULTICAST DNS — it
-  # merges with the AdGuard module's [Resolve] block (DNS/Domains) and leaves the
-  # unicast app → resolved → AdGuard → DoH path in modules/adguardhome.nix intact.
-  services.resolved.settings.Resolve.MulticastDNS = false;
-
   # --- "Office speaker" sink (front half of the bridge) ---
   # A null sink so the speaker shows up in the normal audio menu and WirePlumber
   # can remember it as default. Everything played here is captured off its
@@ -191,73 +174,6 @@ in
       '';
       Restart = "always";
       RestartSec = 2;
-    };
-  };
-
-  # --- printing (Brother) ---
-  # Modern Brother printers speak driverless IPP Everywhere, which CUPS
-  # auto-configures once avahi is up — no per-model driver needed. brlaser covers
-  # the older mono-laser models as a fallback.
-  services.printing = {
-    enable = true;
-    drivers = [ pkgs.brlaser ];
-  };
-
-  # The printer came online after the 2026-07-24 module landed: a Brother
-  # HL-L2445DW at 192.168.1.38, advertising _ipp._tcp with rp=ipp/print and
-  # URF/PWG raster, i.e. fully driverless. Discovery is NOT the problem any more —
-  # avahi sees it and cups-browsed is running.
-  #
-  # But Chrome's print dialog was still empty (2026-07-25), because discovery only
-  # produced a CUPS *temporary* queue — the on-demand kind CUPS materialises per
-  # job and tears down again. The split is visible in CUPS itself: `lpstat -e`
-  # listed Brother_HL_L2445DW while `lpstat -t` answered "No destinations added".
-  # Chrome enumerates permanent destinations, so it had nothing to show.
-  #
-  # (2026-07-25, later) With a permanent queue in place Chrome's dialog can STILL
-  # come up empty when the printer is deep-asleep: Chrome re-checks destinations
-  # at dialog-open and the sleeping Brother answers too slowly (~300ms+ RTT and
-  # sometimes not at all). Waking the printer makes it appear. If this bites too
-  # often, disable Deep Sleep in the Brother's web UI at
-  # http://BRW08F97E55F396.local.
-  #
-  # ensurePrinters runs lpadmin to create a real, persistent queue, so the printer
-  # is there at dialog-open instead of depending on discovery timing.
-  # model = "everywhere" is driverless IPP: CUPS pulls capabilities off the
-  # printer itself, so no PPD or vendor driver is pinned. Addressed by its mDNS
-  # hostname rather than the current DHCP lease so a new address cannot silently
-  # break the queue (nssmdns4 above is what resolves it).
-  #
-  # CAVEAT (2026-07-25, unresolved): ensure-printers has been observed to run,
-  # report success, and create nothing — the current permanent queue on
-  # coordinator was created by hand with the exact lpadmin invocation the unit
-  # should have run. On a fresh machine, verify the queue actually exists
-  # (`lpstat -t`) before trusting the unit.
-  hardware.printers = {
-    ensureDefaultPrinter = "Brother_HL_L2445DW";
-    ensurePrinters = [
-      {
-        name = "Brother_HL_L2445DW";
-        description = "Brother HL-L2445DW";
-        location = "Home";
-        deviceUri = "ipp://BRW08F97E55F396.local:631/ipp/print";
-        model = "everywhere";
-        ppdOptions.PageSize = "A4";
-      }
-    ];
-  };
-
-  # `lpadmin -m everywhere` has to TALK to the printer to fetch its capabilities,
-  # so nixpkgs' ensure-printers oneshot fails whenever the printer is powered off —
-  # which for a household printer is most of the time, including during the nightly
-  # fleet deploy. Retry on a slow cadence instead of leaving a failed unit behind
-  # (the 2026-07-15 auto-upgrade breakage was exactly this shape: one unrelated
-  # non-zero exit poisoning the whole fleet update).
-  systemd.services.ensure-printers = {
-    startLimitIntervalSec = 0; # never latch into start-limit-hit
-    serviceConfig = {
-      Restart = "on-failure";
-      RestartSec = "5min";
     };
   };
 }

--- a/modules/printing.nix
+++ b/modules/printing.nix
@@ -1,0 +1,70 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+# Shared home-printer plane. common.nix imports this for the active NixOS fleet
+# and future hosts; the worker identity is excluded because it is being retired
+# under #117 and must not acquire new services.
+{
+  config = lib.mkIf (config.networking.hostName != "worker") {
+    # CUPS supplies Chrome's system print dialog and the lp/lpr CLI. The Brother
+    # HL-L2445DW speaks IPP Everywhere, so the permanent queue is driverless;
+    # brlaser remains installed only as the already-proven fallback.
+    services.printing = {
+      enable = true;
+      drivers = [ pkgs.brlaser ];
+    };
+
+    # AirPrint/IPP discovery and .local resolution. systemd-resolved also wants
+    # port 5353, so let Avahi own multicast DNS while resolved continues to
+    # handle ordinary unicast DNS.
+    services.avahi = {
+      enable = true;
+      nssmdns4 = true;
+      openFirewall = true;
+    };
+    services.resolved.settings.Resolve.MulticastDNS = false;
+
+    # Discovery alone creates an on-demand temporary queue, which Chrome does
+    # not reliably enumerate. Keep one persistent A4 queue with the name already
+    # used on coordinator. The mDNS hostname survives DHCP lease changes.
+    hardware.printers = {
+      ensureDefaultPrinter = "Brother_HL_L2445DW";
+      ensurePrinters = [
+        {
+          name = "Brother_HL_L2445DW";
+          description = "Brother HL-L2445DW";
+          location = "Home";
+          deviceUri = "ipp://BRW08F97E55F396.local:631/ipp/print";
+          model = "everywhere";
+          ppdOptions.PageSize = "A4";
+        }
+      ];
+    };
+
+    # `lpadmin -m everywhere` fetches capabilities from the live printer. A
+    # sleeping/offline household printer must not permanently poison a fleet
+    # update, so retry slowly. NixOS ensure-printers has also been observed to
+    # exit successfully without creating its queue; coordinator's live queue
+    # had to be created by hand after that exact silent no-op. The explicit
+    # lpstat postcondition turns it into a visible failure and retry.
+    systemd.services.ensure-printers = {
+      startLimitIntervalSec = 0;
+      postStart = ''
+        ${pkgs.cups}/bin/lpstat -p Brother_HL_L2445DW >/dev/null
+      '';
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = "5min";
+      };
+    };
+
+    # Claude Code's bounded raw-9100 path for trivial text. It defaults to the
+    # printer's DHCP-reserved address and appends CRLF + form feed; rendered
+    # documents continue through CUPS (`lp`) instead.
+    environment.systemPackages = [ pkgs.brother-print-text ];
+  };
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -101,6 +101,10 @@ final: prev: {
   # input; this wrapper reads the coordinator's agenix token only at runtime.
   huggingface-cli = final.callPackage ../pkgs/huggingface-cli.nix { };
 
+  # Direct Brother JetDirect path for trivial text. CUPS remains the rendered
+  # document path; modules/printing.nix installs this only on the active fleet.
+  brother-print-text = final.callPackage ../pkgs/brother-print-text.nix { };
+
   # Artifact system toolchain (sovereign replacement for claude.ai Artifacts;
   # skills: md-artifact / presentation-beta / publish-artifact). Identity knobs
   # come from modules/artifacts-defaults.nix — the one edit point — passed in

--- a/pkgs/brother-print-text.nix
+++ b/pkgs/brother-print-text.nix
@@ -1,0 +1,70 @@
+{
+  coreutils,
+  netcat-openbsd,
+  writeShellApplication,
+}:
+
+writeShellApplication {
+  name = "brother-print-text";
+
+  runtimeInputs = [
+    coreutils
+    netcat-openbsd
+  ];
+
+  text = ''
+    usage() {
+      cat <<'EOF'
+    usage: brother-print-text [--] <text...>
+           printf '%s' <text> | brother-print-text
+
+    Send plain text directly to the Brother HL-L2445DW raw TCP port.
+    This path is for trivial text only; send PDF and other rendered files with lp.
+    EOF
+    }
+
+    case "''${1-}" in
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        ;;
+    esac
+
+    if (( $# == 0 )) && [[ -t 0 ]]; then
+      usage >&2
+      exit 2
+    fi
+
+    printer_host="''${BROTHER_PRINT_TEXT_HOST:-192.168.1.38}"
+    printer_port="''${BROTHER_PRINT_TEXT_PORT:-9100}"
+
+    if [[ ! "$printer_host" =~ ^[A-Za-z0-9][A-Za-z0-9._:-]*$ ]]; then
+      echo "brother-print-text: invalid printer host: $printer_host" >&2
+      exit 2
+    fi
+    if [[ ! "$printer_port" =~ ^[0-9]+$ ]]; then
+      echo "brother-print-text: invalid printer port: $printer_port" >&2
+      exit 2
+    fi
+
+    if (( $# > 0 )); then
+      payload="$*"
+    else
+      payload=$(cat)
+    fi
+    if [[ -z "$payload" ]]; then
+      echo "brother-print-text: refusing to send an empty page" >&2
+      exit 2
+    fi
+
+    printf '%s\r\n\f' "$payload" \
+      | timeout 15s nc -N -w 10 "$printer_host" "$printer_port"
+
+    printf 'sent raw text to Brother at %s:%s\n' "$printer_host" "$printer_port" >&2
+  '';
+
+  meta.mainProgram = "brother-print-text";
+}


### PR DESCRIPTION
## Summary

- move Avahi, CUPS, and the persistent driverless Brother HL-L2445DW queue out of coordinator-only `desktop-media.nix` into a shared `modules/printing.nix`
- enable the same default A4 IPP Everywhere queue on coordinator and zenbook-duo while explicitly excluding the retiring worker identity; future NixOS hosts inherit the module through `common.nix`
- add `brother-print-text`, a bounded raw-TCP/9100 helper for Claude Code and other CLI callers; it accepts arguments or stdin, appends CRLF + form feed, refuses empty jobs, and times out instead of hanging
- turn the observed `ensure-printers` silent no-op into a failed postcondition with slow retry by checking that `Brother_HL_L2445DW` actually exists after configuration
- add a flake check covering both active-host projections and the raw helper package

## Why

Printing lived inside the coordinator-only media module, so zenbook-duo had no CUPS daemon, AirPrint discovery, permanent Chrome-visible queue, or CUPS CLI. There was also no deterministic raw text sender for the future print skill. NixOS's `ensure-printers` had previously reported success without creating the coordinator queue, leaving activation apparently green but Chrome with no permanent destination.

After activation, both active NixOS hosts expose `lp`, `lpstat`, `brother-print-text`, Avahi discovery, and the same default `Brother_HL_L2445DW` queue. Rendered documents still go through CUPS; raw 9100 remains intentionally limited to trivial text. The standalone Fedora bridge is unchanged, and no worker service/package is added.

## Validation

- `nix flake check --no-build --print-build-logs`
- `nix flake check --print-build-logs`
- `nix build --no-link --print-out-paths --print-build-logs .#nixosConfigurations.coordinator.config.system.build.toplevel .#nixosConfigurations.zenbook-duo.config.system.build.toplevel`
- inspected both closures for `brother-print-text`, `lp`, `lpstat`, and `ensure-printers.service`
- evaluated coordinator + zenbook queue/Avahi/CUPS projections and confirmed worker remains disabled
- exercised argument and stdin modes against a local TCP listener; byte-compared CRLF/form-feed payloads and verified the empty-input guard

No host was switched or deployed, and no physical print job was sent.

Closes #100