### PR TITLE
feat(tally): complete flow-era coordinator readiness

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785173221,
+        "narHash": "sha256-S9GKKXql6KlBZM6lV2aTP1ZOzqDte31b8PfS9fDiWdI=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "0bfde9d6a469ae503f8a6147c2dd552856cd5999",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
     "agenix": {
       "inputs": {
         "darwin": "darwin",
@@ -1225,6 +1241,7 @@
     },
     "tally": {
       "inputs": {
+        "advisory-db": "advisory-db",
         "flake-utils": "flake-utils",
         "home-manager": "home-manager_2",
         "nixpkgs": [
@@ -1232,11 +1249,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784957750,
-        "narHash": "sha256-bwCduiLLJlHJsns5CWtCudNdwmurgJ4JDVEwRgagTiI=",
+        "lastModified": 1785302640,
+        "narHash": "sha256-kOssdUEIgsbEUh3pm8wsy0rIDKCAt7ZYICUAjJ40uYo=",
         "owner": "mecattaf",
         "repo": "tally.nix",
-        "rev": "f029be980d1cbec987b6ee01fb036d57317acf3b",
+        "rev": "6b250541af5dc11943e9f4f834c854621f9a91f9",
         "type": "github"
       },
       "original": {

--- a/flows/README.md
+++ b/flows/README.md
@@ -1,33 +1,33 @@
 # Tally flows — waves 1+2 campaign (authored 2026-07-25)
 
 Flow scripts for the post-LaCie campaign: local-model materialization (lane A) and
-the notes-reshape/drain arc (lane B), run concurrently. Authored against the
-flow-era tally.nix on its `main` (e7ae081, FS-1…FS-7 landed). **Nothing here is
-wired or scheduled yet** — `tally-flows.nix` is deliberately NOT imported, and no
-flow runs until dotfiles issue #104 (LaCie post-restore) closes and T0 below is done.
+the notes-reshape/drain arc (lane B), run concurrently. They are registered on
+coordinator against tally.nix 0.1.0 (`6b250541`) but remain unscheduled: every
+entry has `onCalendar = null` and runs only through an explicit
+`tally flow run`. Dotfiles issue #104 is closed; its materialization gate remains
+in the script as witnessed proof rather than an active blocker.
 
 Codex is the agentic harness for all implementation nodes (ruled 2026-07-25);
 Claude Code is not used as a flow node. Local quorum work goes through `local()`
-members on coordinator llama-swap; the soft-retired worker remains optional.
+members on coordinator llama-swap.
 
-## T0 — flow-era readiness (babysat, daylight; tracked as its own issue)
+## T0 — flow-era readiness record
 
-1. Bump `inputs.tally` to the flow-era rev (>= e7ae081): `nix flake lock --update-input tally`.
-2. Deploy **worker first, then coordinator**, with a manual rollback path staged.
-   Caveat #106: `nixos-rebuild --rollback` is currently broken — babysit, do not
-   let the nightly producer take this generation unattended.
-3. Add the `codex-window` pool (resource `subscription`, capacity 1, cooperative)
-   to `home/tally.nix` pools; flows here declare it.
-4. Import `flows/tally-flows.nix` next to `home/tally.nix` and verify the
-   `services.tally.flows` option surface exists on the HM module (surveyed in
-   tally.nix `nix/modules/common.nix` ~1493; confirm HM export).
-5. `tally flow check flows/<each>.js` (also runs under `nix flake check` once
-   wired). All six flows + the selector catalog already passed flow check
-   against the flow-era binary on 2026-07-25; re-run after any edit.
-6. Reconcile the 9 ORACLE-DELTAS listed in tally.nix `legacy-docs/campaign/MORNING-REPORT.md`
-   (non-blocking).
-7. Normalize the repo: resolve the uncommitted `hosts/coordinator/services.nix`
-   drift and stray `result` symlink before the input bump lands.
+- The worktree was clean, had no stray `result` symlink, and passed
+  `nix flake check` before the input bump.
+- `inputs.tally` is pinned to tally.nix 0.1.0 at `6b250541`, past the original
+  flow-era minimum `e7ae081`.
+- The Home Manager module exports `services.tally.flows`; `home/tally.nix`
+  imports this registry on coordinator only.
+- `codex-window` is a cooperative capacity-one mutex. Tally 0.1.0 has no
+  `subscription` resource class, and flows deliberately cannot lease
+  windowed-consumption budget pools.
+- Tally 0.1.0 reserves `build` for `drv()` nodes. Shell nodes use
+  `flow-build`; the nightly deploy leases both lanes to retain exclusivity.
+- The returned worker is being retired under #117. There is no worker-first
+  activation; the operator performs the coordinator switch and test drive
+  manually. This change does not deploy or switch a host.
+- The ORACLE-DELTAS reconciliation remains Tom's separate, non-blocking item.
 
 ## Run order and gating
 
@@ -35,7 +35,7 @@ members on coordinator llama-swap; the soft-retired worker remains optional.
 |---|---|---|---|
 | `allowlist-implementation` | A1 | T0 | codex |
 | `parakeet-determinism` | A2 | T0 | codex |
-| `materialize-model-weights` | A3 | #104 CLOSED (in-flow gate node) + A1 | none (pure sh) |
+| `materialize-model-weights` | A3 | A1; #104 is closed (in-flow proof remains) | none (pure sh) |
 | `docs-model-split` | A4 | A1 landed (roster reflects allowlist) | codex |
 | `issue-96-drain` | B2 | T0; final acceptance gates on notes cutover (prompt A) | codex |
 | `errata-map` | B3 | notes cutover (in-flow gate node) + A3 (local members need weights) | codex + local quorum |
@@ -57,9 +57,9 @@ Args defaults live in `tally-flows.nix`; override per run with `--args`.
 ## Notes
 
 - Pool names reference the live coordinator daemon config (`home/tally.nix`):
-  `build`, `coordinator-gpu`, plus `codex-window` added at T0. Weight downloads
-  serialize through `build` deliberately — one WAN link, and it keeps the lane
-  honest against the nightly deploy.
+  `flow-build`, `coordinator-gpu`, and `codex-window`. Weight downloads
+  serialize through `flow-build` deliberately — one WAN link — and the nightly
+  deploy leases that lane as well.
 - `materialize-model-weights` builds `.#models.<artifactId>` store paths; get the
   current id list with
   `nix eval .#legacyPackages.x86_64-linux.models --apply builtins.attrNames`.

--- a/flows/allowlist-implementation.js
+++ b/flows/allowlist-implementation.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: "allowlist-implementation",
   description: "Replace downloadAllModels with a per-host/deployment allowlist (#95 prereq) and ship the declarative hf CLI (#90)",
-  pools: ["codex-window", "build"],
+  pools: ["codex-window", "flow-build"],
   argsSchema: {
     type: "object",
     required: ["repository", "baseRev", "branch", "worktree"],
@@ -46,13 +46,13 @@ export const meta = {
     { key: "implementation", workspace, label: "implementation" }
   );
   await sh(["nix", "flake", "check", "--no-build", args.worktree], {
-    pools: ["build"],
+    pools: ["flow-build"],
     key: "flake-check",
     evidence: ["exit:0"],
     label: "flake-check"
   });
   return sh(["git", "-C", args.worktree, "log", "--oneline", `${args.baseRev}..HEAD`], {
-    pools: ["build"],
+    pools: ["flow-build"],
     key: "commit-proof",
     brief: { implementation: implementation.result },
     evidence: ["exit:0"],

--- a/flows/docs-model-split.js
+++ b/flows/docs-model-split.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: "docs-model-split",
   description: "Refresh docs/local-ai to the allowlist reality, preserve retired DS4 evidence, sunset the stale set",
-  pools: ["codex-window", "build"],
+  pools: ["codex-window", "flow-build"],
   argsSchema: {
     type: "object",
     required: ["repository", "baseRev", "branch", "worktree"],
@@ -46,7 +46,7 @@ export const meta = {
   return sh(
     ["bash", "-c", 'cd "$1" && ! grep -rn "docs/old/migration-journal/ds4-dual-node-lessons" lib/ modules/', "citation-check", args.worktree],
     {
-      pools: ["build"],
+      pools: ["flow-build"],
       key: "citation-check",
       brief: { implementation: implementation.result },
       evidence: ["exit:0"],

--- a/flows/errata-map.js
+++ b/flows/errata-map.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: "errata-map",
   description: "Map every errata candidate in the reshaped notes (annex + weak-claims + discovery sweep), quorum-verify each, emit a decision ledger for Tom",
-  pools: ["codex-window", "coordinator-gpu", "build"],
+  pools: ["codex-window", "coordinator-gpu", "flow-build"],
   argsSchema: {
     type: "object",
     required: ["notesRepo", "outDir", "maxRows"],
@@ -21,7 +21,7 @@ export const meta = {
   // against the live tree, never the snapshot.
   await sh(
     ["bash", "-c", 'test -d "$1/journal/2026/07" && git -C "$1" rev-parse --verify HEAD', "cutover-gate", args.notesRepo],
-    { pools: ["build"], key: "cutover-gate", evidence: ["exit:0"], label: "cutover-gate" }
+    { pools: ["flow-build"], key: "cutover-gate", evidence: ["exit:0"], label: "cutover-gate" }
   );
 
   // Discovery: the errata annex is the STARTING POINT, not the boundary
@@ -138,7 +138,7 @@ export const meta = {
 
   await sh(
     ["bash", "-c", 'mkdir -p "$2" && printf %s "$1" > "$2/ERRATA-LEDGER.tsv"', "ledger-writer", tsv, args.outDir],
-    { pools: ["build"], key: "write-ledger", evidence: ["exit:0"], label: "write-ledger" }
+    { pools: ["flow-build"], key: "write-ledger", evidence: ["exit:0"], label: "write-ledger" }
   );
 
   const contested = judged.filter(item => item.consensus === "CONTESTED" || item.consensus === "finish-work");

--- a/flows/issue-96-drain.js
+++ b/flows/issue-96-drain.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: "issue-96-drain",
   description: "Pointer-run HANDOFF-PROMPT-B: implement the drain/handoff/pickup skills on the utility-model seam (#96)",
-  pools: ["codex-window", "build"],
+  pools: ["codex-window", "flow-build"],
   argsSchema: {
     type: "object",
     required: ["repository", "baseRev", "branch", "worktree", "promptPath", "notesRepo"],
@@ -41,7 +41,7 @@ export const meta = {
     { key: "implementation", workspace, label: "implementation" }
   );
   await sh(["nix", "flake", "check", "--no-build", args.worktree], {
-    pools: ["build"],
+    pools: ["flow-build"],
     key: "flake-check",
     evidence: ["exit:0"],
     label: "flake-check"
@@ -51,7 +51,7 @@ export const meta = {
   const cutover = await sh(
     ["bash", "-c", 'test -d "$1/journal/2026/07" && git -C "$1" rev-parse --verify HEAD', "cutover-gate", args.notesRepo],
     {
-      pools: ["build"],
+      pools: ["flow-build"],
       key: "cutover-gate",
       settle: true,
       evidence: ["exit:0"],
@@ -59,7 +59,7 @@ export const meta = {
     }
   );
   return sh(["git", "-C", args.worktree, "log", "--oneline", `${args.baseRev}..HEAD`], {
-    pools: ["build"],
+    pools: ["flow-build"],
     key: "commit-proof",
     brief: {
       implementation: implementation.result,

--- a/flows/materialize-model-weights.js
+++ b/flows/materialize-model-weights.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: "materialize-model-weights",
   description: "Gate on #104 closing, then materialize allowlisted model weights on coordinator and worker; replay-safe per artifact",
-  pools: ["build"],
+  pools: ["flow-build"],
   argsSchema: {
     type: "object",
     required: ["coordinatorFlake", "workerFlake", "coordinatorModels", "workerModels"],
@@ -42,7 +42,7 @@ export const meta = {
       "-c",
       'test "$(gh issue view 104 -R mecattaf/dotfiles --json state -q .state)" = "CLOSED"'
     ],
-    { pools: ["build"], key: "gate-issue-104", evidence: ["exit:0"], label: "gate-issue-104" }
+    { pools: ["flow-build"], key: "gate-issue-104", evidence: ["exit:0"], label: "gate-issue-104" }
   );
 
   // Weight downloads serialize through the build lane (capacity 1) on purpose:
@@ -54,7 +54,7 @@ export const meta = {
     const built = await sh(
       ["nix", "build", `${args.coordinatorFlake}#models.${model}`, "--no-link", "--print-out-paths"],
       {
-        pools: ["build"],
+        pools: ["flow-build"],
         key: `coordinator-${model}`,
         evidence: ["exit:0"],
         label: `coordinator:${model}`
@@ -68,7 +68,7 @@ export const meta = {
     const built = await sh(
       ["nix", "build", `${args.workerFlake}#models.${model}`, "--no-link", "--print-out-paths"],
       {
-        pools: ["build"],
+        pools: ["flow-build"],
         executor: "worker",
         key: `worker-${model}`,
         evidence: ["exit:0"],
@@ -83,7 +83,7 @@ export const meta = {
   return sh(
     ["nix", "build", `${args.coordinatorFlake}#nixosConfigurations.coordinator.config.system.build.toplevel`, "--no-link"],
     {
-      pools: ["build"],
+      pools: ["flow-build"],
       key: "closure-proof",
       brief: { coordinator: coordinatorBuilt, worker: workerBuilt },
       evidence: ["exit:0"],

--- a/flows/parakeet-determinism.js
+++ b/flows/parakeet-determinism.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: "parakeet-determinism",
   description: "Pin 2-3 parakeet models as deterministic Nix fetches and add the voxtype bootstrap gate (#107, then #84 acceptance)",
-  pools: ["codex-window", "build"],
+  pools: ["codex-window", "flow-build"],
   argsSchema: {
     type: "object",
     required: ["repository", "baseRev", "branch", "worktree"],
@@ -46,13 +46,13 @@ export const meta = {
     { key: "implementation", workspace, label: "implementation" }
   );
   await sh(["nix", "flake", "check", "--no-build", args.worktree], {
-    pools: ["build"],
+    pools: ["flow-build"],
     key: "flake-check",
     evidence: ["exit:0"],
     label: "flake-check"
   });
   return sh(["git", "-C", args.worktree, "log", "--oneline", `${args.baseRev}..HEAD`], {
-    pools: ["build"],
+    pools: ["flow-build"],
     key: "commit-proof",
     brief: { implementation: implementation.result },
     evidence: ["exit:0"],

--- a/flows/tally-flows.nix
+++ b/flows/tally-flows.nix
@@ -1,16 +1,21 @@
-# DRAFT — NOT IMPORTED YET. Wired in at T0 (see flows/README.md) after the
-# flow-era tally input bump, next to home/tally.nix on coordinator. Every flow is
-# one-shot (onCalendar = null): registered and flake-check-validated, invoked
+# Imported by home/tally.nix and populated on coordinator only. Every flow is
+# one-shot (onCalendar = null): registered and generation-validated, then invoked
 # manually with `tally flow run`. Args here are the defaults; override per run
 # with --args.
-{ ... }:
+{
+  lib,
+  osConfig ? null,
+  ...
+}:
 let
+  hostName = if osConfig == null then "bridge" else osConfig.networking.hostName;
+  isCoordinator = hostName == "coordinator";
   dotfiles = "/home/tom/mecattaf/dotfiles";
   notes = "/home/tom/mecattaf/notes";
   worktrees = "/home/tom/.local/state/tally-worktrees";
 in
 {
-  services.tally.flows = {
+  services.tally.flows = lib.optionalAttrs isCoordinator {
     allowlist-implementation = {
       script = ./allowlist-implementation.js;
       onCalendar = null;

--- a/home/tally.nix
+++ b/home/tally.nix
@@ -74,7 +74,10 @@ let
 
 in
 {
-  imports = [ inputs.tally.homeManagerModules.tally ];
+  imports = [
+    inputs.tally.homeManagerModules.tally
+    ../flows/tally-flows.nix
+  ];
 
   home.packages = lib.optionals isCoordinator [
     cooldownReceiver
@@ -84,10 +87,24 @@ in
   services.tally = {
     enable = isCoordinator;
 
+    # errata-map deliberately permits a bounded 400-node review wave. Tally
+    # v0.1.0 checks declared flow width against this daemon guardrail while
+    # building the generation.
+    enqueue.fanoutCap = 400;
+
     # These are real contention lanes, not synthetic maintenance pools. All are
     # centrally owned even when their physical resource is on worker.
     pools = lib.optionalAttrs isCoordinator {
       build = {
+        resource = "build-slot";
+        capacity = 1;
+        enforce = "cooperative";
+        hardPreempt = false;
+      };
+      # "build" is reserved by Tally v0.1.0 for drv() nodes. Shell nodes in
+      # these flows use a distinct lane, and the nightly deploy leases both so
+      # it remains exclusive with either kind of flow build.
+      flow-build = {
         resource = "build-slot";
         capacity = 1;
         enforce = "cooperative";
@@ -106,6 +123,15 @@ in
         hardPreempt = false;
       };
       local-ai-review = {
+        resource = "mutex";
+        capacity = 1;
+        enforce = "cooperative";
+        hardPreempt = false;
+      };
+      # Tally v0.1.0 models a capacity-one subscription concurrency lane as a
+      # mutex; windowed-consumption budget pools are intentionally unavailable
+      # to flow nodes.
+      codex-window = {
         resource = "mutex";
         capacity = 1;
         enforce = "cooperative";
@@ -164,6 +190,7 @@ in
         enqueue = {
           pool = [
             "build"
+            "flow-build"
             "coordinator-gpu"
           ];
           argv = systemService "fleet-deploy.service";


### PR DESCRIPTION
## Summary

- bump tally.nix from f029be9 to the current 0.1.0 main at 6b250541
- wire all six one-shot flows through the Home Manager module on coordinator only
- add the cooperative capacity-one codex-window mutex and raise the bounded flow fan-out cap to 400
- migrate shell nodes from Tally 0.1.0's reserved build pool to flow-build, while making the nightly deploy lease both build lanes
- record the completed readiness state and current run gates in flows/README.md

## Tally 0.1.0 adaptation

Tally 0.1.0 has no subscription resource class, and declarative flow nodes may not use windowed-consumption budget pools. The Codex subscription concurrency lane is therefore represented by a capacity-one mutex. Tally also reserves build for drv() nodes, so ordinary shell nodes use flow-build; the nightly deploy leases both to preserve exclusivity.

## Validation

- clean pre-bump worktree with no stray result symlink
- nix flake check passed before the bump
- nix flake check passed after the bump and wiring, including the standalone bridge check
- nix build .#nixosConfigurations.coordinator.config.system.build.toplevel --no-link passed
- tally 0.1.0 flow check passed for every flows/*.js script with the rendered coordinator config and declarative args; errata-map also passed with flows/catalog.json
- coordinator evaluates exactly six flows; bridge, worker, and zenbook-duo evaluate none

## Amendments to #108

- worker-first deployment is void: the returned worker is being retired by #117, outside this PR
- activation targets coordinator only and remains a manual operator action; this PR does not deploy or switch any host
- #104 is closed and no longer blocks the materialization flow; its in-flow check remains witnessed proof
- the ORACLE-DELTAS reconciliation remains Tom's separate item and is intentionally not changed here

Closes #108
