### PR TITLE
feat(academic-ocr): add coordinator tally pipeline

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -414,6 +414,7 @@
         in
         {
           inherit (pkgs)
+            academic-ocr
             brother-print-text
             local-ai-monthly
             mactahoe-gtk-theme

--- a/flows/academic-assemble.js
+++ b/flows/academic-assemble.js
@@ -1,0 +1,352 @@
+export const meta = {
+  name: "academic-assemble",
+  description: "Assemble canonical academic OCR artifacts, chunk, embed, index, and receipt",
+  pools: ["academic-ocr-cpu", "coordinator-gpu"],
+  argsSchema: {
+    type: "object",
+    required: [
+      "paper",
+      "pages",
+      "protocols",
+      "driver",
+      "outputDir",
+      "receiptPath",
+      "chunkWords",
+      "embedding"
+    ],
+    properties: {
+      paper: {
+        type: "object",
+        required: ["paperId", "title", "sourceUrl", "sourceSha256"],
+        properties: {
+          paperId: {
+            type: "string",
+            pattern: "^[A-Za-z0-9._-]+$",
+            minLength: 1,
+            maxLength: 80
+          },
+          title: { type: "string", minLength: 1, maxLength: 500 },
+          sourceUrl: { type: "string", pattern: "^https://" },
+          sourceSha256: { type: "string", pattern: "^[0-9a-f]{64}$" }
+        },
+        additionalProperties: false
+      },
+      pages: {
+        type: "array",
+        minItems: 1,
+        maxItems: 100,
+        items: {
+          type: "object",
+          required: [
+            "paperId",
+            "pageNumber",
+            "status",
+            "resolution",
+            "inputVariant",
+            "chosenArtifactPath",
+            "textDigest",
+            "disagreementPermille",
+            "agreementProtocols",
+            "attemptCount",
+            "proof"
+          ],
+          properties: {
+            paperId: { type: "string", minLength: 1 },
+            pageNumber: { type: "integer", minimum: 1 },
+            status: { enum: ["converged", "arbitrated"] },
+            resolution: { enum: ["tier", "mutation", "arbiter"] },
+            inputVariant: { type: "string", minLength: 1 },
+            chosenArtifactPath: { type: "string", pattern: "^/" },
+            textDigest: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" },
+            disagreementPermille: {
+              anyOf: [
+                { type: "integer", minimum: 0, maximum: 1000 },
+                { type: "null" }
+              ]
+            },
+            agreementProtocols: {
+              type: "array",
+              uniqueItems: true,
+              items: { type: "string", minLength: 1 }
+            },
+            attemptCount: { type: "integer", minimum: 1 },
+            proof: {
+              type: "object",
+              required: ["taskUuid", "witnessSeq"],
+              properties: {
+                taskUuid: { type: "string", minLength: 1 },
+                witnessSeq: { type: "integer", minimum: 1 }
+              },
+              additionalProperties: false
+            }
+          },
+          additionalProperties: false
+        }
+      },
+      protocols: {
+        type: "array",
+        minItems: 2,
+        maxItems: 4,
+        items: {
+          type: "object",
+          required: ["id", "tier"],
+          properties: {
+            id: { type: "string", minLength: 1 },
+            tier: { enum: ["cheap", "standard", "specialist"] }
+          },
+          additionalProperties: false
+        }
+      },
+      driver: {
+        type: "object",
+        required: ["adapter", "program", "runtimeMaxSec"],
+        properties: {
+          adapter: { type: "string", minLength: 1 },
+          program: { type: "string", pattern: "^/" },
+          runtimeMaxSec: { type: "integer", minimum: 1 }
+        },
+        additionalProperties: false
+      },
+      outputDir: { type: "string", pattern: "^/" },
+      receiptPath: { type: "string", pattern: "^/" },
+      chunkWords: { type: "integer", minimum: 64, maximum: 2048 },
+      embedding: {
+        type: "object",
+        required: ["endpoint", "model", "batchSize", "dimensions"],
+        properties: {
+          endpoint: { const: "http://localhost:9292" },
+          model: { const: "qwen3-embedding-8b" },
+          batchSize: { type: "integer", minimum: 1, maximum: 64 },
+          dimensions: { const: 4096 }
+        },
+        additionalProperties: false
+      }
+    },
+    additionalProperties: false
+  },
+  maxNodes: 6,
+  selectors: []
+};
+
+const digestSchema = { type: "string", pattern: "^sha256:[0-9a-f]{64}$" };
+
+const assembleSchema = {
+  type: "object",
+  required: [
+    "paperId",
+    "artifactPath",
+    "artifactDigest",
+    "paperPath",
+    "paperDigest",
+    "pageCount"
+  ],
+  properties: {
+    paperId: { type: "string", minLength: 1 },
+    artifactPath: { type: "string", pattern: "^/" },
+    artifactDigest: digestSchema,
+    paperPath: { type: "string", pattern: "^/" },
+    paperDigest: digestSchema,
+    pageCount: { type: "integer", minimum: 1 }
+  },
+  additionalProperties: false
+};
+
+const chunkSchema = {
+  type: "object",
+  required: ["paperId", "artifactPath", "artifactDigest", "chunkCount", "embeddingModel"],
+  properties: {
+    paperId: { type: "string", minLength: 1 },
+    artifactPath: { type: "string", pattern: "^/" },
+    artifactDigest: digestSchema,
+    chunkCount: { type: "integer", minimum: 1 },
+    embeddingModel: { const: "qwen3-embedding-8b" }
+  },
+  additionalProperties: false
+};
+
+const embeddingSchema = {
+  type: "object",
+  required: [
+    "paperId",
+    "artifactPath",
+    "artifactDigest",
+    "vectorCount",
+    "dimensions",
+    "model"
+  ],
+  properties: {
+    paperId: { type: "string", minLength: 1 },
+    artifactPath: { type: "string", pattern: "^/" },
+    artifactDigest: digestSchema,
+    vectorCount: { type: "integer", minimum: 1 },
+    dimensions: { const: 4096 },
+    model: { const: "qwen3-embedding-8b" }
+  },
+  additionalProperties: false
+};
+
+const indexSchema = {
+  type: "object",
+  required: ["paperId", "artifactPath", "artifactDigest", "chunkCount", "indexKind"],
+  properties: {
+    paperId: { type: "string", minLength: 1 },
+    artifactPath: { type: "string", pattern: "^/" },
+    artifactDigest: digestSchema,
+    chunkCount: { type: "integer", minimum: 1 },
+    indexKind: { const: "sqlite-vec+fts5" }
+  },
+  additionalProperties: false
+};
+
+const receiptSchema = {
+  type: "object",
+  required: ["status", "paperId", "artifactPath", "artifactDigest"],
+  properties: {
+    status: { enum: ["complete", "failed"] },
+    paperId: { type: "string", minLength: 1 },
+    artifactPath: { type: "string", pattern: "^/" },
+    artifactDigest: digestSchema
+  },
+  additionalProperties: false
+};
+
+function node(action, brief, artifactPath, pools, key, resultSchema) {
+  return job({
+    argv: [args.driver.program, action],
+    adapter: args.driver.adapter,
+    pools,
+    priority: "low",
+    runtimeMaxSec: args.driver.runtimeMaxSec,
+    evidence: ["exit:0", `artifact:${artifactPath}`, "hash:sha256"],
+    brief: { action, ...brief, artifactPath },
+    key,
+    label: `academic-${action}-${args.paper.paperId}`,
+    resultSchema
+  });
+}
+
+function witnessed(result) {
+  return {
+    result: result.result,
+    proof: { taskUuid: result.taskUuid, witnessSeq: result.witnessSeq }
+  };
+}
+
+(async () => {
+  let stage = "assemble";
+  try {
+    const canonicalManifest = `${args.outputDir}/canonical/manifest.json`;
+    const assembled = await node(
+      "assemble",
+      {
+        paper: args.paper,
+        pages: args.pages,
+        outputDir: args.outputDir
+      },
+      canonicalManifest,
+      ["academic-ocr-cpu"],
+      "assemble",
+      assembleSchema
+    );
+
+    stage = "chunk";
+    const chunksPath = `${args.outputDir}/chunks.json`;
+    const chunked = await node(
+      "chunk",
+      {
+        paperId: args.paper.paperId,
+        paperPath: assembled.result.paperPath,
+        chunkWords: args.chunkWords,
+        embeddingModel: args.embedding.model
+      },
+      chunksPath,
+      ["academic-ocr-cpu"],
+      "chunk",
+      chunkSchema
+    );
+
+    stage = "embed";
+    const embeddingsPath = `${args.outputDir}/embeddings.json`;
+    const embedded = await node(
+      "embed",
+      {
+        paperId: args.paper.paperId,
+        chunksPath: chunked.result.artifactPath,
+        embedding: args.embedding
+      },
+      embeddingsPath,
+      ["coordinator-gpu"],
+      "embed",
+      embeddingSchema
+    );
+
+    stage = "index";
+    const indexPath = `${args.outputDir}/index/papers.db`;
+    const indexed = await node(
+      "index",
+      {
+        paperId: args.paper.paperId,
+        chunksPath: chunked.result.artifactPath,
+        embeddingsPath: embedded.result.artifactPath
+      },
+      indexPath,
+      ["academic-ocr-cpu"],
+      "index",
+      indexSchema
+    );
+
+    stage = "receipt";
+    const receipt = await node(
+      "receipt",
+      {
+        paper: args.paper,
+        pages: args.pages,
+        protocols: args.protocols,
+        outputDir: args.outputDir,
+        stages: {
+          assemble: witnessed(assembled),
+          chunk: witnessed(chunked),
+          embed: witnessed(embedded),
+          index: witnessed(indexed)
+        }
+      },
+      args.receiptPath,
+      ["academic-ocr-cpu"],
+      "receipt",
+      receiptSchema
+    );
+
+    return {
+      schemaVersion: 1,
+      status: "complete",
+      paperId: args.paper.paperId,
+      receiptPath: receipt.result.artifactPath,
+      receiptDigest: receipt.result.artifactDigest,
+      stages: {
+        assemble: witnessed(assembled),
+        chunk: witnessed(chunked),
+        embed: witnessed(embedded),
+        index: witnessed(indexed),
+        receipt: witnessed(receipt)
+      }
+    };
+  } catch (error) {
+    await node(
+      "failure",
+      {
+        paper: args.paper,
+        error: {
+          stage,
+          name: error && error.name ? String(error.name) : "Error",
+          code: error && error.code ? String(error.code) : null,
+          message: error && error.message ? String(error.message) : String(error)
+        }
+      },
+      args.receiptPath,
+      ["academic-ocr-cpu"],
+      "failure",
+      receiptSchema
+    );
+    throw error;
+  }
+})();

--- a/flows/tally-flows.nix
+++ b/flows/tally-flows.nix
@@ -3,8 +3,10 @@
 # manually with `tally flow run`. Args here are the defaults; override per run
 # with --args.
 {
+  inputs,
   lib,
   osConfig,
+  pkgs,
   ...
 }:
 let
@@ -13,6 +15,69 @@ let
   dotfiles = "/home/tom/mecattaf/dotfiles";
   notes = "/home/tom/mecattaf/notes";
   worktrees = "/home/tom/.local/state/tally-worktrees";
+
+  academicState = "/home/tom/.local/state/academic-ocr";
+  fixedPapers = builtins.fromJSON (builtins.readFile ../pkgs/academic-ocr/fixed-papers.json);
+  turner = fixedPapers.turner;
+  turnerId = turner.paperId;
+  turnerSha = turner.sourceSha256;
+  turnerBlob = "${academicState}/blobs/sha256/${turnerSha}.pdf";
+  turnerRun = "${academicState}/runs/${turnerId}-${builtins.substring 0 12 turnerSha}";
+  turnerPages = map (pageNumber: {
+    paperId = turnerId;
+    inherit pageNumber;
+    sourcePath = turnerBlob;
+  }) (lib.range 1 5);
+  academicProtocols = [
+    {
+      id = "poppler-text";
+      tier = "cheap";
+    }
+    {
+      id = "mupdf-text";
+      tier = "cheap";
+    }
+    {
+      id = "qwen3-vl-8b-ocr";
+      tier = "standard";
+    }
+    {
+      id = "qwen3-vl-32b-ocr";
+      tier = "specialist";
+    }
+  ];
+  academicDriver = {
+    adapter = "ocr-driver";
+    program = "${pkgs.academic-ocr}/bin/academic-ocr-driver";
+    runtimeMaxSec = 1800;
+  };
+
+  # Keep the pinned upstream control program. Only the ruled physical pool name
+  # changes at build time; no forked JavaScript source lives in dotfiles.
+  academicOcrFlow = pkgs.runCommand "academic-ocr-flow.js" { } ''
+    substitute ${inputs.tally}/examples/flows/academic-ocr.js "$out" \
+      --replace-fail '"ocr-gpu"' '"coordinator-gpu"'
+  '';
+
+  sampleSelections = map (pageNumber: {
+    paperId = turnerId;
+    inherit pageNumber;
+    status = "converged";
+    resolution = "tier";
+    inputVariant = "original";
+    chosenArtifactPath = "${turnerRun}/ocr/${turnerId}/page-${toString pageNumber}/qwen3-vl-8b-ocr/original.json";
+    textDigest = "sha256:${builtins.hashString "sha256" "turner-page-${toString pageNumber}-sample"}";
+    disagreementPermille = 0;
+    agreementProtocols = [
+      "qwen3-vl-32b-ocr"
+      "qwen3-vl-8b-ocr"
+    ];
+    attemptCount = 4;
+    proof = {
+      taskUuid = "00000000-0000-4000-8000-000000000124";
+      witnessSeq = pageNumber;
+    };
+  }) (lib.range 1 5);
 in
 {
   services.tally.flows = lib.optionalAttrs isCoordinator {
@@ -88,6 +153,47 @@ in
         notesRepo = notes;
         outDir = "${notes}/july23-notes-reshape";
         maxRows = 60;
+      };
+    };
+
+    academic-ocr = {
+      script = academicOcrFlow;
+      onCalendar = null;
+      maxNodes = 1700;
+      args = {
+        pages = turnerPages;
+        protocols = academicProtocols;
+        driver = academicDriver;
+        outputDir = "${turnerRun}/ocr";
+        rasterDpi = 400;
+        maxMutationIterations = 3;
+        maxDisagreementPermille = 375;
+      };
+    };
+
+    academic-assemble = {
+      script = ./academic-assemble.js;
+      onCalendar = null;
+      maxNodes = 6;
+      args = {
+        paper = {
+          paperId = turnerId;
+          title = turner.title;
+          sourceUrl = turner.sourceUrl;
+          sourceSha256 = turnerSha;
+        };
+        pages = sampleSelections;
+        protocols = academicProtocols;
+        driver = academicDriver;
+        outputDir = "${turnerRun}/package";
+        receiptPath = "${turnerRun}/receipt.json";
+        chunkWords = 512;
+        embedding = {
+          endpoint = "http://localhost:9292";
+          model = "qwen3-embedding-8b";
+          batchSize = 16;
+          dimensions = 4096;
+        };
       };
     };
   };

--- a/home/tally.nix
+++ b/home/tally.nix
@@ -74,6 +74,7 @@ in
   ];
 
   home.packages = lib.optionals isCoordinator [
+    pkgs.academic-ocr
     cooldownReceiver
     pkgs.local-ai-monthly
   ];
@@ -81,10 +82,11 @@ in
   services.tally = {
     enable = isCoordinator;
 
-    # errata-map deliberately permits a bounded 400-node review wave. Tally
-    # v0.1.0 checks declared flow width against this daemon guardrail while
-    # building the generation.
-    enqueue.fanoutCap = 400;
+    # The upstream academic OCR mutation ladder has a ruled 1,700-node ceiling:
+    # 100 pages × four protocols × four inputs, plus 100 arbiters. The fixed
+    # supervised Turner and Fosfuri runs are only 5 and 18 pages respectively,
+    # but the checked script keeps that complete schema bound as its fail-safe.
+    enqueue.fanoutCap = 1700;
 
     # These are real contention lanes, not synthetic maintenance pools.
     pools = lib.optionalAttrs isCoordinator {
@@ -109,6 +111,12 @@ in
         enforce = "cooperative";
         hardPreempt = false;
       };
+      academic-ocr-cpu = {
+        resource = "cpu-slot";
+        capacity = 2;
+        enforce = "cooperative";
+        hardPreempt = false;
+      };
       local-ai-review = {
         resource = "mutex";
         capacity = 1;
@@ -129,6 +137,15 @@ in
     # All jobs execute locally on coordinator; no daemonless SSH executor is
     # part of the active topology.
     executors = { };
+
+    adapters = lib.optionalAttrs isCoordinator {
+      ocr-driver = inputs.tally.lib.adapters.mkAdapter {
+        argv = [ ];
+        scrape.finalMessage = inputs.tally.lib.adapters.mkScrapeCapture {
+          pattern = "^TALLY_FINAL_MESSAGE=(.*)$";
+        };
+      };
+    };
 
     # One low-priority durable row replaces the old 02:00/03:30/04:30/06:00 chain.
     # It holds the build and coordinator GPU lanes end-to-end, making the measured

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -127,4 +127,8 @@ final: prev: {
   # Monthly local-AI update bot: deterministic Git/HF preparation, one Pi
   # judgment, deterministic verification/publication. Tally leases only Pi.
   local-ai-monthly = final.callPackage ../pkgs/local-ai-monthly { };
+
+  # Bounded academic OCR appliance: deterministic PDF mechanics, the tally
+  # mutation-ladder driver, and canonical/chunk/embed/index receipt stages.
+  academic-ocr = final.callPackage ../pkgs/academic-ocr { };
 }

--- a/pkgs/academic-ocr/README.md
+++ b/pkgs/academic-ocr/README.md
@@ -1,0 +1,96 @@
+# Academic OCR
+
+This package implements the bounded coordinator-only slice in dotfiles issue
+`#124`. It keeps all source blobs, renders, protocol artifacts, canonical files,
+chunks, embeddings, the disposable SQLite index, and receipts below:
+
+```text
+~/.local/state/academic-ocr/
+```
+
+It never writes to `~/mecattaf/notes`. Promotion into notes is a later,
+supervised operator decision. The fixed `turner` and `fosfuri` profiles carry
+the two ruled db IDs, source URLs, hashes, and page counts. In particular, the
+Fosfuri profile keeps db ID `96b65260-610c-4404-a08f-98b0e3ebc6d9` even though
+its source filename contains the unrelated UUID `491cfaeb-…`.
+
+## Programs
+
+- `academic-ocr-prepare` fetches and verifies the PDF, performs the page
+  census, renders the immutable 200 DPI page inputs, and prints the absolute
+  path of the OCR flow-args manifest.
+- `academic-ocr-driver` is the direct tally adapter program. Its `recognize`
+  and `arbitrate` actions implement the upstream mutation-ladder contract; the
+  other actions implement the second flow's bounded stages.
+- `academic-ocr-plan-assemble` extracts the final value from a completed OCR
+  flow JSONL log, retains it as `ocr-result.json`, and prints the second flow's
+  args path.
+- `academic-ocr-signature` exposes the deterministic 32-component text
+  signature used by recognition artifacts.
+
+## Supervised two-flow sequence
+
+These commands describe the operator phase for both fixed papers. Do not run
+them merely to validate the package or generation.
+
+```bash
+run_paper() {
+  local profile=$1 ocr_args run_dir config ocr_flow assemble_args assemble_flow
+  ocr_args=$(academic-ocr-prepare --paper "$profile")
+  run_dir=$(dirname "$ocr_args")
+  config=${XDG_CONFIG_HOME:-$HOME/.config}/tally/config.json
+  ocr_flow=$(jq -r '.flows["academic-ocr"].script' "$config")
+
+  tally flow check "$ocr_flow" --args "$(<"$ocr_args")"
+  tally flow run "$ocr_flow" \
+    --flow-run-id "$(</proc/sys/kernel/random/uuid)" \
+    --args "$(<"$ocr_args")" \
+    --max-nodes 1700 \
+    | tee "$run_dir/ocr-flow.jsonl"
+
+  assemble_args=$(
+    academic-ocr-plan-assemble \
+      --ocr-args "$ocr_args" \
+      --flow-log "$run_dir/ocr-flow.jsonl"
+  )
+  assemble_flow=$(jq -r '.flows["academic-assemble"].script' "$config")
+
+  tally flow check "$assemble_flow" --args "$(<"$assemble_args")"
+  tally flow run "$assemble_flow" \
+    --flow-run-id "$(</proc/sys/kernel/random/uuid)" \
+    --args "$(<"$assemble_args")" \
+    --max-nodes 6 \
+    | tee "$run_dir/assemble-flow.jsonl"
+}
+
+run_paper turner
+run_paper fosfuri
+```
+
+The success receipt lands at:
+
+```text
+<run-dir>/receipt.json
+```
+
+For the fixed Turner input, `<run-dir>` is
+`~/.local/state/academic-ocr/runs/fa3c575a-3089-4d27-957f-ba7d697b8737-aa9db49df221`;
+for Fosfuri it is
+`~/.local/state/academic-ocr/runs/96b65260-610c-4404-a08f-98b0e3ebc6d9-909a82261bc9`.
+The durable rebuild inputs named in the receipt are `canonical/paper.md` and
+`chunks.json`. `embeddings.json` and the SQLite `sqlite-vec` + FTS5 index at
+`index/papers.db` are disposable; rerun the embedding and index nodes from the
+retained chunks when rebuilding them.
+
+## Protocol and inference boundary
+
+The cheap tier is `pdftotext` plus `mutool`, both of which exit nonzero for
+empty or near-empty extraction. The standard and specialist tiers are
+`qwen3-vl-8b-ocr` and `qwen3-vl-32b-ocr`. The embedding node uses
+`qwen3-embedding-8b`. Every model request goes through the OpenAI-compatible
+llama-swap endpoint at `http://localhost:9292`, with temperature zero for OCR.
+
+Package builds run ShellCheck and generated fixture tests entirely offline.
+The tests cover both mechanical engines, fail-closed scan handling, signature
+agreement/disagreement, a stubbed VLM/embedding boundary, canonical assembly,
+chunking, SQLite index construction, receipt emission, and args planning.

--- a/pkgs/academic-ocr/chunk.awk
+++ b/pkgs/academic-ocr/chunk.awk
@@ -1,0 +1,109 @@
+# Deterministic Markdown chunker used by the narrow Bash driver action. It
+# writes chunk bodies as files and a tab-separated metadata manifest; Bash owns
+# the JSON output shape and hashing. A chunk never crosses a heading boundary.
+
+function flush_chunk(    path) {
+  if (chunk_words == 0) {
+    return
+  }
+  chunk_count++
+  path = sprintf("%s/chunk-%04d.txt", out_dir, chunk_count)
+  printf "%s", chunk_text > path
+  close(path)
+  gsub(/\t/, " ", chunk_section)
+  printf "%d\t%d\t%d\t%d\t%d\t%d\t%s\n", \
+    chunk_count, chunk_start, chunk_end, chunk_page_start, chunk_page_end, \
+    chunk_words, chunk_section >> manifest
+  close(manifest)
+  chunk_text = ""
+  chunk_words = 0
+  chunk_start = 0
+  chunk_end = 0
+  chunk_page_start = current_page
+  chunk_page_end = current_page
+  chunk_section = current_section
+}
+
+function begin_chunk() {
+  if (chunk_words == 0) {
+    chunk_start = body_offset
+    chunk_page_start = current_page
+    chunk_page_end = current_page
+    chunk_section = current_section
+  }
+}
+
+function add_words(line,    words, count, word_index, candidate) {
+  count = split(line, words, /[[:space:]]+/)
+  for (word_index = 1; word_index <= count; word_index++) {
+    if (words[word_index] == "") {
+      continue
+    }
+    if (chunk_words >= target_words) {
+      flush_chunk()
+    }
+    begin_chunk()
+    candidate = chunk_words == 0 ? words[word_index] : " " words[word_index]
+    chunk_text = chunk_text candidate
+    chunk_words++
+    chunk_end = body_offset + length(line)
+    chunk_page_end = current_page
+  }
+  chunk_text = chunk_text "\n"
+}
+
+BEGIN {
+  manifest = out_dir "/manifest.tsv"
+  current_page = 1
+  current_section = ""
+  in_frontmatter = 0
+  body_offset = 0
+}
+
+{
+  line = $0
+  if (NR == 1 && line == "---") {
+    in_frontmatter = 1
+    next
+  }
+  if (in_frontmatter) {
+    if (line == "---") {
+      in_frontmatter = 0
+    }
+    next
+  }
+
+  if (match(line, /^<!--[[:space:]]*page:([0-9][0-9][0-9])[[:space:]]*-->$/, page_match)) {
+    current_page = page_match[1] + 0
+    body_offset += length(line) + 1
+    next
+  }
+
+  if (match(line, /^#{1,4}[[:space:]]+(.+)$/, heading_match)) {
+    flush_chunk()
+    current_section = heading_match[1]
+    add_words(line)
+    body_offset += length(line) + 1
+    next
+  }
+
+  if (line == "") {
+    if (chunk_words > 0) {
+      chunk_text = chunk_text "\n"
+      chunk_end = body_offset
+    }
+    body_offset++
+    next
+  }
+
+  line_words = split(line, scratch, /[[:space:]]+/)
+  if (chunk_words > 0 && chunk_words + line_words > target_words) {
+    flush_chunk()
+  }
+  add_words(line)
+  body_offset += length(line) + 1
+}
+
+END {
+  flush_chunk()
+}

--- a/pkgs/academic-ocr/default.nix
+++ b/pkgs/academic-ocr/default.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  symlinkJoin,
+  writeShellApplication,
+  bash,
+  coreutils,
+  curl,
+  findutils,
+  gawk,
+  glibc,
+  gnugrep,
+  gnused,
+  ghostscript,
+  imagemagick,
+  jq,
+  mupdf-headless,
+  poppler-utils,
+  sqlite,
+  sqlite-vec,
+}:
+let
+  chunkAwk = builtins.path {
+    path = ./chunk.awk;
+    name = "academic-ocr-chunk.awk";
+  };
+  fixtureDir = builtins.path {
+    path = ./tests/fixtures;
+    name = "academic-ocr-fixtures";
+  };
+  fixedPapers = builtins.path {
+    path = ./fixed-papers.json;
+    name = "academic-ocr-fixed-papers.json";
+  };
+  shellRuntime = [
+    bash
+    coreutils
+    findutils
+    gawk
+    gnugrep
+    gnused
+    jq
+  ];
+
+  signature = writeShellApplication {
+    name = "academic-ocr-signature";
+    runtimeInputs = shellRuntime ++ [ glibc.bin ];
+    text = builtins.readFile ./signature.sh;
+  };
+
+  driver = writeShellApplication {
+    name = "academic-ocr-driver";
+    runtimeInputs = shellRuntime ++ [
+      curl
+      imagemagick
+      mupdf-headless
+      poppler-utils
+      signature
+      sqlite
+    ];
+    text = ''
+      export ACADEMIC_OCR_CHUNK_AWK=${lib.escapeShellArg chunkAwk}
+      export ACADEMIC_OCR_SQLITE_VEC=${lib.escapeShellArg "${sqlite-vec}/lib/vec0.so"}
+      ${builtins.readFile ./driver.sh}
+    '';
+  };
+
+  prepare = writeShellApplication {
+    name = "academic-ocr-prepare";
+    runtimeInputs = shellRuntime ++ [
+      curl
+      driver
+      poppler-utils
+    ];
+    text = ''
+      export ACADEMIC_OCR_DRIVER_PATH=${lib.escapeShellArg "${driver}/bin/academic-ocr-driver"}
+      export ACADEMIC_OCR_PAPER_CATALOG=${lib.escapeShellArg fixedPapers}
+      ${builtins.readFile ./prepare.sh}
+    '';
+  };
+
+  planAssemble = writeShellApplication {
+    name = "academic-ocr-plan-assemble";
+    runtimeInputs = shellRuntime ++ [ driver ];
+    text = ''
+      export ACADEMIC_OCR_DRIVER_PATH=${lib.escapeShellArg "${driver}/bin/academic-ocr-driver"}
+      ${builtins.readFile ./plan-assemble.sh}
+    '';
+  };
+
+  fakeCurl = writeShellApplication {
+    name = "academic-ocr-fake-curl";
+    runtimeInputs = shellRuntime;
+    text = builtins.readFile ./tests/fake-curl.sh;
+  };
+
+  tests = writeShellApplication {
+    name = "academic-ocr-tests";
+    runtimeInputs = shellRuntime ++ [
+      driver
+      fakeCurl
+      ghostscript
+      planAssemble
+      prepare
+      signature
+      sqlite
+    ];
+    text = ''
+      export ACADEMIC_OCR_FIXTURES=${lib.escapeShellArg fixtureDir}
+      export ACADEMIC_OCR_FAKE_CURL=${lib.escapeShellArg "${fakeCurl}/bin/academic-ocr-fake-curl"}
+      export ACADEMIC_OCR_PAPER_CATALOG=${lib.escapeShellArg fixedPapers}
+      export ACADEMIC_OCR_SQLITE_VEC=${lib.escapeShellArg "${sqlite-vec}/lib/vec0.so"}
+      exec ${bash}/bin/bash ${./tests/test-workflow.sh}
+    '';
+  };
+in
+symlinkJoin {
+  name = "academic-ocr-1.0.0";
+  paths = [
+    driver
+    planAssemble
+    prepare
+    signature
+  ];
+  postBuild = ''
+    ${tests}/bin/academic-ocr-tests
+  '';
+
+  passthru = {
+    inherit tests;
+  };
+
+  meta = {
+    description = "Deterministic preparation and tally-flow driver for academic OCR";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "academic-ocr-prepare";
+  };
+}

--- a/pkgs/academic-ocr/driver.sh
+++ b/pkgs/academic-ocr/driver.sh
@@ -1,0 +1,1047 @@
+set -euo pipefail
+
+ocr_prompt='Transcribe this scanned academic page to clean GitHub-flavored Markdown. Preserve heading levels, paragraphs, footnotes, and tables (as markdown tables). Use $...$ / $$...$$ for math. Do not add commentary. If part is illegible write [illegible].'
+llama_swap_url=${ACADEMIC_OCR_LLAMA_SWAP_URL:-http://localhost:9292}
+curl_cmd=${ACADEMIC_OCR_CURL:-curl}
+chunk_awk=${ACADEMIC_OCR_CHUNK_AWK:?ACADEMIC_OCR_CHUNK_AWK is not set}
+sqlite_vec=${ACADEMIC_OCR_SQLITE_VEC:?ACADEMIC_OCR_SQLITE_VEC is not set}
+state_base=${XDG_STATE_HOME:-${HOME:?HOME is not set}/.local/state}
+state_root=${ACADEMIC_OCR_STATE_ROOT:-$state_base/academic-ocr}
+
+usage() {
+  printf 'usage: academic-ocr-driver <recognize|arbitrate|assemble|chunk|embed|index|receipt|failure>\n' >&2
+  exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+action=$1
+case $action in
+  recognize|arbitrate|assemble|chunk|embed|index|receipt|failure) ;;
+  *) usage ;;
+esac
+
+die() {
+  printf 'academic-ocr-driver: %s\n' "$*" >&2
+  exit 1
+}
+
+die_code() {
+  local code=$1
+  shift
+  printf 'academic-ocr-driver: %s\n' "$*" >&2
+  exit "$code"
+}
+
+[[ $state_root = /* && $state_root != / ]] || die 'data root must be an absolute non-root path'
+state_root=$(realpath -m -- "$state_root")
+notes_root=$(realpath -m -- "${HOME:?HOME is not set}/mecattaf/notes")
+case $state_root in
+  "$notes_root"|"$notes_root"/*) die 'data root must not be inside ~/mecattaf/notes' ;;
+esac
+
+brief_path=${TALLY_BRIEF:-}
+[[ -n $brief_path && -f $brief_path ]] || die 'TALLY_BRIEF must name a readable JSON file'
+jq -e 'type == "object"' "$brief_path" >/dev/null || die 'TALLY_BRIEF is not a JSON object'
+brief_action=$(jq -er '.action' "$brief_path") || die 'brief has no action'
+[[ $brief_action == "$action" ]] || die "brief action $brief_action does not match argv action $action"
+
+work_dir=$(mktemp -d)
+cleanup() {
+  if [[ -d $work_dir ]]; then
+    rm -r -- "$work_dir"
+  fi
+}
+trap cleanup EXIT
+
+is_absolute_path() {
+  [[ $1 = /* && $1 != *$'\n'* && $1 != *$'\r'* ]]
+}
+
+require_absolute_path() {
+  local label=$1 path=$2
+  is_absolute_path "$path" || die "$label must be an absolute single-line path"
+}
+
+require_state_path() {
+  local label=$1 path=$2 resolved
+  require_absolute_path "$label" "$path"
+  resolved=$(realpath -m -- "$path")
+  case $resolved in
+    "$state_root"/*) ;;
+    *) die "$label escapes the academic OCR data root" ;;
+  esac
+}
+
+require_paper_id() {
+  [[ $1 =~ ^[A-Za-z0-9._-]+$ ]] || die 'paperId contains unsafe characters'
+}
+
+sha_prefixed() {
+  printf 'sha256:%s\n' "$(sha256sum "$1" | awk '{print $1}')"
+}
+
+atomic_move() {
+  local source=$1 destination=$2
+  chmod 0644 "$source"
+  mv -f -- "$source" "$destination"
+}
+
+emit_artifact_fields() {
+  local artifact=$1 filter=$2
+  printf 'TALLY_FINAL_MESSAGE='
+  jq -c "$filter" "$artifact"
+}
+
+normalize_text() {
+  local source=$1 destination=$2
+  tr -d '\f' < "$source" \
+    | sed 's/[[:space:]]\+$//' \
+    | gawk '
+        /^[[:space:]]*$/ {
+          blanks++
+          if (blanks <= 1) print ""
+          next
+        }
+        {
+          blanks = 0
+          print
+        }
+      ' > "$destination"
+  if [[ -s $destination ]] && [[ $(tail -c 1 "$destination" | wc -l) -eq 0 ]]; then
+    printf '\n' >> "$destination"
+  fi
+}
+
+require_substantive_text() {
+  local text_file=$1 protocol=$2
+  local alnum_count word_count
+  alnum_count=$(tr -cd '[:alnum:]' < "$text_file" | wc -c)
+  word_count=$(wc -w < "$text_file")
+  if (( alnum_count < 32 || word_count < 6 )); then
+    die_code 20 "$protocol extraction is empty or near-empty ($alnum_count alphanumeric characters, $word_count words)"
+  fi
+}
+
+require_pdf() {
+  local source=$1 magic
+  [[ -f $source ]] || die "source PDF is missing: $source"
+  magic=$(head -c 5 "$source" || true)
+  [[ $magic == '%PDF-' ]] || die "source does not have PDF magic bytes: $source"
+}
+
+render_page() {
+  local source=$1 page=$2 dpi=$3 destination=$4 prefix
+  prefix="$work_dir/render-$RANDOM"
+  pdftoppm \
+    -f "$page" \
+    -l "$page" \
+    -r "$dpi" \
+    -png \
+    -singlefile \
+    "$source" \
+    "$prefix" >/dev/null 2>&1 || die "failed to render page $page at $dpi DPI"
+  [[ -f $prefix.png ]] || die "page renderer produced no PNG for page $page"
+  mv -- "$prefix.png" "$destination"
+}
+
+prepare_raster() {
+  local source=$1 page=$2 artifact=$3
+  local input_id mutation_kind destination base cached dpi zones_count
+  input_id=$(jq -er '.input.id' "$brief_path")
+  mutation_kind=$(jq -er '.input.mutation.kind' "$brief_path")
+  destination=${artifact%.json}.png
+  mkdir -p "$(dirname "$destination")"
+  base="$work_dir/base.png"
+
+  case $mutation_kind in
+    none)
+      cached="${source%.pdf}.pages/200dpi/$(printf 'page-%04d.png' "$page")"
+      if [[ -f $cached ]]; then
+        cp --reflink=auto -- "$cached" "$base"
+      else
+        render_page "$source" "$page" 200 "$base"
+      fi
+      ;;
+    rerasterize)
+      dpi=$(jq -er '.input.mutation.dpi | select(type == "number" and . >= 200 and . <= 1200)' "$brief_path") \
+        || die 'rerasterize mutation has an invalid DPI'
+      render_page "$source" "$page" "$dpi" "$base"
+      ;;
+    crop-hot-zones)
+      render_page "$source" "$page" 200 "$base"
+      zones_count=$(jq -er '.input.mutation.zones | length' "$brief_path") \
+        || die 'crop-hot-zones mutation has no zones array'
+      if (( zones_count == 0 )); then
+        magick "$base" -fuzz 3% -trim +repage "$work_dir/mutated.png" \
+          || die 'ImageMagick whitespace crop failed'
+      else
+        read -r image_width image_height < <(magick identify -format '%w %h' "$base")
+        read -r min_x min_y max_x max_y < <(
+          jq -r '
+            [
+              ([.input.mutation.zones[].x] | min),
+              ([.input.mutation.zones[].y] | min),
+              ([.input.mutation.zones[] | .x + .width] | max),
+              ([.input.mutation.zones[] | .y + .height] | max)
+            ] | @tsv
+          ' "$brief_path"
+        )
+        crop_x=$(( min_x * image_width / 10000 ))
+        crop_y=$(( min_y * image_height / 10000 ))
+        crop_right=$(( (max_x * image_width + 9999) / 10000 ))
+        crop_bottom=$(( (max_y * image_height + 9999) / 10000 ))
+        (( crop_x < 0 )) && crop_x=0
+        (( crop_y < 0 )) && crop_y=0
+        (( crop_right > image_width )) && crop_right=$image_width
+        (( crop_bottom > image_height )) && crop_bottom=$image_height
+        crop_width=$(( crop_right - crop_x ))
+        crop_height=$(( crop_bottom - crop_y ))
+        (( crop_width > 0 && crop_height > 0 )) || die 'hot-zone crop is empty'
+        magick "$base" -crop "${crop_width}x${crop_height}+${crop_x}+${crop_y}" +repage "$work_dir/mutated.png" \
+          || die 'ImageMagick hot-zone crop failed'
+      fi
+      base="$work_dir/mutated.png"
+      ;;
+    deskew)
+      render_page "$source" "$page" 200 "$base"
+      correction=$(jq -er '.input.mutation.correctionMilliDegrees | select(type == "number" and . >= -45000 and . <= 45000)' "$brief_path") \
+        || die 'deskew mutation has an invalid correction'
+      degrees=$(gawk -v milli="$correction" 'BEGIN { printf "%.3f", milli / 1000 }')
+      magick "$base" -background white -rotate "$degrees" "$work_dir/mutated.png" \
+        || die 'ImageMagick deskew rotation failed'
+      base="$work_dir/mutated.png"
+      ;;
+    *)
+      die "unsupported input mutation: $mutation_kind"
+      ;;
+  esac
+
+  [[ -s $base ]] || die "mutation $input_id produced an empty raster"
+  raster_tmp="$work_dir/final-raster.png"
+  cp --reflink=auto -- "$base" "$raster_tmp"
+  atomic_move "$raster_tmp" "$destination"
+  printf '%s\n' "$destination"
+}
+
+strip_markdown_fence() {
+  local source=$1 destination=$2
+  sed \
+    -e '1{/^```\(markdown\)\{0,1\}[[:space:]]*$/d;}' \
+    -e '${/^```[[:space:]]*$/d;}' \
+    "$source" > "$destination"
+}
+
+require_local_llama_swap() {
+  local endpoint=$1
+  case $endpoint in
+    http://localhost:9292) ;;
+    *) die "inference endpoint must be llama-swap on localhost:9292, got $endpoint" ;;
+  esac
+}
+
+run_vlm() {
+  local raster=$1 model=$2 output=$3
+  local b64_file payload response content
+  require_local_llama_swap "$llama_swap_url"
+  b64_file="$work_dir/page.b64"
+  payload="$work_dir/chat-request.json"
+  response="$work_dir/chat-response.json"
+  base64 -w 0 "$raster" > "$b64_file"
+  jq -Rs \
+    --arg model "$model" \
+    --arg prompt "$ocr_prompt" \
+    '{
+      model: $model,
+      temperature: 0,
+      max_tokens: 4096,
+      messages: [{
+        role: "user",
+        content: [
+          {type: "text", text: $prompt},
+          {type: "image_url", image_url: {url: ("data:image/png;base64," + .)}}
+        ]
+      }]
+    }' "$b64_file" > "$payload"
+  "$curl_cmd" \
+    --fail \
+    --retry 1 \
+    --retry-all-errors \
+    --show-error \
+    --silent \
+    --max-time 900 \
+    --header 'Content-Type: application/json' \
+    --data-binary "@$payload" \
+    "$llama_swap_url/v1/chat/completions" > "$response" \
+    || die "llama-swap request failed for $model"
+  jq -e '.choices[0].message.content | type == "string" and length > 0' "$response" >/dev/null \
+    || die "llama-swap returned no text content for $model"
+  content="$work_dir/vlm-content.md"
+  jq -jr '.choices[0].message.content' "$response" > "$content"
+  strip_markdown_fence "$content" "$work_dir/vlm-unfenced.md"
+  normalize_text "$work_dir/vlm-unfenced.md" "$output"
+}
+
+recognize() {
+  local paper_id page_number source_path protocol_id protocol_tier input_id artifact_path
+  local text_raw text_file raster_path engine_input engine_page confidence engine_version
+  paper_id=$(jq -er '.page.paperId' "$brief_path")
+  page_number=$(jq -er '.page.pageNumber | select(type == "number" and . >= 1)' "$brief_path")
+  source_path=$(jq -er '.page.sourcePath' "$brief_path")
+  protocol_id=$(jq -er '.protocol.id' "$brief_path")
+  protocol_tier=$(jq -er '.protocol.tier' "$brief_path")
+  input_id=$(jq -er '.input.id' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  require_state_path sourcePath "$source_path"
+  require_state_path artifactPath "$artifact_path"
+  require_paper_id "$paper_id"
+  [[ $protocol_id =~ ^[A-Za-z0-9._-]+$ ]] || die 'protocolId contains unsafe characters'
+  require_pdf "$source_path"
+  mkdir -p "$(dirname "$artifact_path")"
+
+  case $protocol_id:$protocol_tier in
+    poppler-text:cheap|mupdf-text:cheap|qwen3-vl-8b-ocr:standard|qwen3-vl-32b-ocr:specialist) ;;
+    *) die "unsupported protocol/tier pair: $protocol_id/$protocol_tier" ;;
+  esac
+
+  text_raw="$work_dir/raw.txt"
+  text_file="$work_dir/text.md"
+  raster_path=''
+  engine_input=$source_path
+  engine_page=$page_number
+
+  if [[ $protocol_id == qwen3-vl-* || $input_id != original ]]; then
+    raster_path=$(prepare_raster "$source_path" "$page_number" "$artifact_path")
+  fi
+  if [[ $protocol_id == poppler-text || $protocol_id == mupdf-text ]]; then
+    if [[ $input_id != original ]]; then
+      # The ladder's transformed input is intentionally a raster. Neither
+      # ruled mechanical engine performs OCR, so treating it as text evidence
+      # would be false convergence. Fail this protocol/input pair closed.
+      die_code 20 "$protocol_id cannot extract a text layer from raster mutation $input_id"
+    fi
+    if [[ $protocol_id == poppler-text ]]; then
+      pdftotext -f "$engine_page" -l "$engine_page" -layout "$engine_input" - > "$text_raw" 2> "$work_dir/engine.err" \
+        || die 'pdftotext failed'
+      engine_version=$(pdftotext -v 2>&1 | head -n 1)
+    else
+      mutool draw -q -F txt -o "$text_raw" "$engine_input" "$engine_page" 2> "$work_dir/engine.err" \
+        || die 'mutool text extraction failed'
+      engine_version=$(mutool -v 2>&1 | head -n 1)
+    fi
+    normalize_text "$text_raw" "$text_file"
+    require_substantive_text "$text_file" "$protocol_id"
+    confidence=1000
+  else
+    run_vlm "$raster_path" "$protocol_id" "$text_file"
+    require_substantive_text "$text_file" "$protocol_id"
+    engine_version=$protocol_id
+    if [[ $protocol_id == qwen3-vl-8b-ocr ]]; then
+      confidence=900
+    else
+      confidence=850
+    fi
+  fi
+
+  signature=$(academic-ocr-signature "$text_file")
+  text_digest=$(sha_prefixed "$text_file")
+  source_digest=$(sha_prefixed "$source_path")
+  if [[ -n $raster_path ]]; then
+    input_path=$raster_path
+  else
+    input_path=$source_path
+  fi
+  input_digest=$(sha_prefixed "$input_path")
+  prompt_digest=$(printf '%s' "$ocr_prompt" | sha256sum | awk '{print "sha256:" $1}')
+  artifact_tmp=$(mktemp "$(dirname "$artifact_path")/.recognition.XXXXXX")
+  jq -n \
+    --arg paperId "$paper_id" \
+    --argjson pageNumber "$page_number" \
+    --arg protocolId "$protocol_id" \
+    --arg protocolTier "$protocol_tier" \
+    --arg inputVariant "$input_id" \
+    --arg artifactPath "$artifact_path" \
+    --arg sourcePath "$source_path" \
+    --arg sourceDigest "$source_digest" \
+    --arg inputPath "$input_path" \
+    --arg inputDigest "$input_digest" \
+    --arg textDigest "$text_digest" \
+    --arg engineVersion "$engine_version" \
+    --arg endpoint "$llama_swap_url" \
+    --arg promptDigest "$prompt_digest" \
+    --argjson signature "$signature" \
+    --argjson confidencePermille "$confidence" \
+    --argjson input "$(jq -c '.input' "$brief_path")" \
+    --rawfile text "$text_file" \
+    '{
+      schemaVersion: 1,
+      action: "recognize",
+      paperId: $paperId,
+      pageNumber: $pageNumber,
+      protocolId: $protocolId,
+      protocolTier: $protocolTier,
+      inputVariant: $inputVariant,
+      input: $input,
+      artifactPath: $artifactPath,
+      sourcePath: $sourcePath,
+      inputPath: $inputPath,
+      text: $text,
+      textDigest: $textDigest,
+      signature: $signature,
+      confidencePermille: $confidencePermille,
+      hotZones: [],
+      skewMilliDegrees: 0,
+      provenance: {
+        sourceDigest: $sourceDigest,
+        inputDigest: $inputDigest,
+        engine: $engineVersion,
+        endpoint: (if ($protocolId | startswith("qwen3-vl-")) then $endpoint else null end),
+        promptDigest: (if ($protocolId | startswith("qwen3-vl-")) then $promptDigest else null end)
+      }
+    }' > "$artifact_tmp"
+  atomic_move "$artifact_tmp" "$artifact_path"
+  emit_artifact_fields "$artifact_path" '{
+    paperId,
+    pageNumber,
+    protocolId,
+    inputVariant,
+    artifactPath,
+    textDigest,
+    signature,
+    confidencePermille,
+    hotZones,
+    skewMilliDegrees
+  }'
+}
+
+arbitrate() {
+  local paper_id page_number artifact_path selected_path text_digest artifact_tmp
+  paper_id=$(jq -er '.page.paperId' "$brief_path")
+  page_number=$(jq -er '.page.pageNumber | select(type == "number" and . >= 1)' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  require_state_path artifactPath "$artifact_path"
+  require_paper_id "$paper_id"
+  mkdir -p "$(dirname "$artifact_path")"
+
+  mapfile -t candidate_paths < <(
+    jq -r '.attempts[] | select(.verdict == "pass") | .artifactPath // empty' "$brief_path" | sort -u
+  )
+  basis_paths=()
+  for candidate in "${candidate_paths[@]}"; do
+    require_state_path candidateArtifactPath "$candidate"
+    [[ -f $candidate ]] || continue
+    mapfile -t expected_digests < <(
+      jq -r --arg path "$candidate" '
+        .attempts[]
+        | select(.verdict == "pass" and .artifactPath == $path)
+        | .textDigest
+      ' "$brief_path" | sort -u
+    )
+    (( ${#expected_digests[@]} == 1 )) || die "candidate has ambiguous evidence: $candidate"
+    jq -e \
+      --arg paper "$paper_id" \
+      --argjson page "$page_number" \
+      --arg digest "${expected_digests[0]}" \
+      '.paperId == $paper
+        and .pageNumber == $page
+        and .textDigest == $digest
+        and (.text | type == "string" and length > 0)' \
+      "$candidate" >/dev/null || die "candidate artifact has the wrong identity: $candidate"
+    basis_paths+=("$candidate")
+  done
+  (( ${#basis_paths[@]} > 0 )) || die 'arbiter has no successful artifact basis'
+
+  selected_path=$(jq -sr '
+    def rank:
+      if .protocolId == "qwen3-vl-32b-ocr" then 0
+      elif .protocolId == "qwen3-vl-8b-ocr" then 1
+      elif .protocolId == "poppler-text" then 2
+      elif .protocolId == "mupdf-text" then 3
+      else 4 end;
+    sort_by([rank, -(.text | length), .artifactPath]) | .[0].artifactPath
+  ' "${basis_paths[@]}")
+  [[ -f $selected_path ]] || die 'arbiter selection did not resolve to an artifact'
+  jq -jr '.text' "$selected_path" > "$work_dir/arbitrated.md"
+  require_substantive_text "$work_dir/arbitrated.md" arbiter
+  text_digest=$(sha_prefixed "$work_dir/arbitrated.md")
+  selected_digest=$(jq -er '.textDigest' "$selected_path")
+  [[ $text_digest == "$selected_digest" ]] || die 'selected artifact text digest does not verify'
+  basis_json=$(printf '%s\n' "${basis_paths[@]}" | jq -Rsc 'split("\n")[:-1]')
+
+  artifact_tmp=$(mktemp "$(dirname "$artifact_path")/.arbiter.XXXXXX")
+  jq -n \
+    --arg paperId "$paper_id" \
+    --argjson pageNumber "$page_number" \
+    --arg artifactPath "$artifact_path" \
+    --arg selectedArtifactPath "$selected_path" \
+    --arg textDigest "$text_digest" \
+    --argjson basis "$basis_json" \
+    --rawfile text "$work_dir/arbitrated.md" \
+    '{
+      schemaVersion: 1,
+      action: "arbitrate",
+      paperId: $paperId,
+      pageNumber: $pageNumber,
+      artifactPath: $artifactPath,
+      text: $text,
+      textDigest: $textDigest,
+      basis: $basis,
+      selectedArtifactPath: $selectedArtifactPath,
+      provenance: {strategy: "specialist-first-then-longest"}
+    }' > "$artifact_tmp"
+  atomic_move "$artifact_tmp" "$artifact_path"
+  emit_artifact_fields "$artifact_path" '{paperId, pageNumber, artifactPath, textDigest, basis}'
+}
+
+assemble() {
+  local paper_id title source_url source_sha output_dir artifact_path canonical_dir pages_dir
+  paper_id=$(jq -er '.paper.paperId' "$brief_path")
+  title=$(jq -er '.paper.title' "$brief_path")
+  source_url=$(jq -er '.paper.sourceUrl' "$brief_path")
+  source_sha=$(jq -er '.paper.sourceSha256 | select(test("^[0-9a-f]{64}$"))' "$brief_path")
+  output_dir=$(jq -er '.outputDir' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  require_state_path outputDir "$output_dir"
+  require_state_path artifactPath "$artifact_path"
+  require_paper_id "$paper_id"
+  [[ $artifact_path == "$output_dir/canonical/manifest.json" ]] || die 'assemble artifactPath is not the canonical manifest path'
+  canonical_dir="$output_dir/canonical"
+  pages_dir="$canonical_dir/pages"
+  mkdir -p "$pages_dir"
+
+  page_manifest="$work_dir/page-manifest.json"
+  printf '{"pages":[]}\n' > "$page_manifest"
+  paper_tmp="$work_dir/paper.md"
+  title_yaml=$(jq -nr --arg value "$title" '$value | tojson')
+  url_yaml=$(jq -nr --arg value "$source_url" '$value | tojson')
+  {
+    printf '%s\n' '---'
+    printf 'uuid: %s\n' "$paper_id"
+    printf 'title: %s\n' "$title_yaml"
+    printf 'sha256: %s\n' "$source_sha"
+    printf 'source_url: %s\n' "$url_yaml"
+    printf '%s\n\n' '---'
+  } > "$paper_tmp"
+
+  expected_page=1
+  while IFS= read -r selection; do
+    page_number=$(jq -er '.pageNumber' <<< "$selection")
+    selected_paper=$(jq -er '.paperId' <<< "$selection")
+    chosen_path=$(jq -er '.chosenArtifactPath' <<< "$selection")
+    chosen_digest=$(jq -er '.textDigest' <<< "$selection")
+    [[ $selected_paper == "$paper_id" ]] || die "page $page_number belongs to the wrong paper"
+    (( page_number == expected_page )) || die "page selection is not contiguous at page $page_number"
+    require_state_path chosenArtifactPath "$chosen_path"
+    [[ -f $chosen_path ]] || die "chosen page artifact is missing: $chosen_path"
+    jq -e \
+      --arg paper "$paper_id" \
+      --argjson page "$page_number" \
+      '.paperId == $paper and .pageNumber == $page and (.text | type == "string")' \
+      "$chosen_path" >/dev/null || die "chosen artifact identity mismatch: $chosen_path"
+    jq -jr '.text' "$chosen_path" > "$work_dir/page.md"
+    actual_digest=$(sha_prefixed "$work_dir/page.md")
+    [[ $actual_digest == "$chosen_digest" ]] || die "page $page_number digest does not verify"
+
+    page_md=$(printf '%s/%03d.md' "$pages_dir" "$page_number")
+    page_json=$(printf '%s/%03d.json' "$pages_dir" "$page_number")
+    page_tmp=$(mktemp "$pages_dir/.page-md.XXXXXX")
+    cp -- "$work_dir/page.md" "$page_tmp"
+    atomic_move "$page_tmp" "$page_md"
+    artifact_sha=$(sha256sum "$chosen_path" | awk '{print $1}')
+    meta_tmp=$(mktemp "$pages_dir/.page-meta.XXXXXX")
+    jq -n \
+      --argjson selection "$selection" \
+      --arg artifactSha256 "$artifact_sha" \
+      --arg canonicalPath "$page_md" \
+      '{
+        schemaVersion: 1,
+        pageNumber: $selection.pageNumber,
+        canonicalPath: $canonicalPath,
+        chosenArtifactPath: $selection.chosenArtifactPath,
+        chosenArtifactSha256: $artifactSha256,
+        textDigest: $selection.textDigest,
+        resolution: $selection.resolution,
+        inputVariant: $selection.inputVariant,
+        disagreementPermille: $selection.disagreementPermille,
+        agreementProtocols: $selection.agreementProtocols,
+        attemptCount: $selection.attemptCount,
+        proof: $selection.proof
+      }' > "$meta_tmp"
+    atomic_move "$meta_tmp" "$page_json"
+    page_md_digest=$(sha_prefixed "$page_md")
+    page_meta_digest=$(sha_prefixed "$page_json")
+    jq \
+      --argjson pageNumber "$page_number" \
+      --arg markdownPath "$page_md" \
+      --arg markdownDigest "$page_md_digest" \
+      --arg metadataPath "$page_json" \
+      --arg metadataDigest "$page_meta_digest" \
+      '.pages += [{
+        pageNumber: $pageNumber,
+        markdownPath: $markdownPath,
+        markdownDigest: $markdownDigest,
+        metadataPath: $metadataPath,
+        metadataDigest: $metadataDigest
+      }]' "$page_manifest" > "$work_dir/page-manifest.next"
+    mv -f -- "$work_dir/page-manifest.next" "$page_manifest"
+
+    {
+      printf '<!-- page:%03d -->\n' "$page_number"
+      cat "$work_dir/page.md"
+      printf '\n'
+    } >> "$paper_tmp"
+    expected_page=$((expected_page + 1))
+  done < <(jq -c '.pages | sort_by(.pageNumber)[]' "$brief_path")
+  page_count=$((expected_page - 1))
+  (( page_count > 0 )) || die 'assemble received no page selections'
+
+  paper_path="$canonical_dir/paper.md"
+  paper_atomic=$(mktemp "$canonical_dir/.paper.XXXXXX")
+  cp -- "$paper_tmp" "$paper_atomic"
+  atomic_move "$paper_atomic" "$paper_path"
+  paper_digest=$(sha_prefixed "$paper_path")
+  source_path="$output_dir/source.json"
+  source_tmp=$(mktemp "$output_dir/.source.XXXXXX")
+  jq -n \
+    --arg paperId "$paper_id" \
+    --arg title "$title" \
+    --arg sourceUrl "$source_url" \
+    --arg sourceSha256 "$source_sha" \
+    --argjson pageCount "$page_count" \
+    '{
+      schemaVersion: 1,
+      uuid: $paperId,
+      title: $title,
+      sourceUrl: $sourceUrl,
+      sha256: $sourceSha256,
+      pageCount: $pageCount
+    }' > "$source_tmp"
+  atomic_move "$source_tmp" "$source_path"
+  source_digest=$(sha_prefixed "$source_path")
+
+  manifest_tmp=$(mktemp "$canonical_dir/.manifest.XXXXXX")
+  jq -n \
+    --slurpfile pageManifest "$page_manifest" \
+    --arg paperId "$paper_id" \
+    --arg paperPath "$paper_path" \
+    --arg paperDigest "$paper_digest" \
+    --arg sourcePath "$source_path" \
+    --arg sourceDigest "$source_digest" \
+    '{
+      schemaVersion: 1,
+      paperId: $paperId,
+      paperPath: $paperPath,
+      paperDigest: $paperDigest,
+      sourcePath: $sourcePath,
+      sourceDigest: $sourceDigest,
+      pages: $pageManifest[0].pages
+    }' > "$manifest_tmp"
+  atomic_move "$manifest_tmp" "$artifact_path"
+  artifact_digest=$(sha_prefixed "$artifact_path")
+  printf 'TALLY_FINAL_MESSAGE='
+  jq -cn \
+    --arg paperId "$paper_id" \
+    --arg artifactPath "$artifact_path" \
+    --arg artifactDigest "$artifact_digest" \
+    --arg paperPath "$paper_path" \
+    --arg paperDigest "$paper_digest" \
+    --argjson pageCount "$page_count" \
+    '{paperId: $paperId, artifactPath: $artifactPath, artifactDigest: $artifactDigest, paperPath: $paperPath, paperDigest: $paperDigest, pageCount: $pageCount}'
+}
+
+chunk() {
+  local paper_id paper_path artifact_path target_words embedding_model
+  paper_id=$(jq -er '.paperId' "$brief_path")
+  paper_path=$(jq -er '.paperPath' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  target_words=$(jq -er '.chunkWords | select(type == "number" and . >= 64 and . <= 2048)' "$brief_path")
+  embedding_model=$(jq -er '.embeddingModel' "$brief_path")
+  require_state_path paperPath "$paper_path"
+  require_state_path artifactPath "$artifact_path"
+  require_paper_id "$paper_id"
+  [[ -f $paper_path ]] || die "canonical paper is missing: $paper_path"
+  mkdir -p "$(dirname "$artifact_path")"
+  chunks_dir="$work_dir/chunks"
+  mkdir -p "$chunks_dir"
+  gawk \
+    -v out_dir="$chunks_dir" \
+    -v target_words="$target_words" \
+    -f "$chunk_awk" \
+    "$paper_path"
+  [[ -s $chunks_dir/manifest.tsv ]] || die 'chunker produced no chunks'
+
+  title_literal=$(sed -n 's/^title: //p' "$paper_path" | head -n 1)
+  title=$(jq -er '.' <<< "$title_literal" 2>/dev/null || printf 'Untitled')
+  chunks_json="$work_dir/chunks.json"
+  jq -n \
+    --arg paperUuid "$paper_id" \
+    --arg sourceMd "$paper_path" \
+    --arg chunker "academic-ocr.awk-word-chunker(chunk_size=$target_words)" \
+    --arg embeddingModel "$embedding_model" \
+    '{
+      schema_version: 1,
+      paper_uuid: $paperUuid,
+      source_md: $sourceMd,
+      chunker: $chunker,
+      embed_model_version: $embeddingModel,
+      chunks: []
+    }' > "$chunks_json"
+
+  chunk_count=0
+  while IFS=$'\t' read -r index start end page_start page_end word_count section; do
+    chunk_file=$(printf '%s/chunk-%04d.txt' "$chunks_dir" "$index")
+    [[ -s $chunk_file ]] || die "chunk body is missing: $chunk_file"
+    content_hash=$(sha256sum "$chunk_file" | awk '{print substr($1, 1, 12)}')
+    chunk_id=$(printf '%s\0%s\0%s\0%s' "$paper_id" "$index" "$content_hash" "$embedding_model" \
+      | sha256sum | awk '{print substr($1, 1, 16)}')
+    if [[ -n $section ]]; then
+      prefix="[$title] | [$section]"
+    else
+      prefix="[$title]"
+    fi
+    chunk_object=$(jq -n \
+      --arg id "$chunk_id" \
+      --rawfile text "$chunk_file" \
+      --arg prefix "$prefix" \
+      --arg section "$section" \
+      --arg modelVersion "$embedding_model" \
+      --argjson pageStart "$page_start" \
+      --argjson pageEnd "$page_end" \
+      --argjson start "$start" \
+      --argjson end "$end" \
+      --argjson tokenCount "$word_count" \
+      '{
+        id: $id,
+        text: $text,
+        prefix: $prefix,
+        embed_text: ($prefix + "\n" + $text),
+        section: $section,
+        page_start: $pageStart,
+        page_end: $pageEnd,
+        start: $start,
+        end: $end,
+        token_count: $tokenCount,
+        model_version: $modelVersion
+      }')
+    jq --argjson chunk "$chunk_object" '.chunks += [$chunk]' "$chunks_json" > "$work_dir/chunks.next"
+    mv -f -- "$work_dir/chunks.next" "$chunks_json"
+    chunk_count=$((chunk_count + 1))
+  done < "$chunks_dir/manifest.tsv"
+  (( chunk_count > 0 )) || die 'chunk manifest was empty'
+
+  artifact_tmp=$(mktemp "$(dirname "$artifact_path")/.chunks.XXXXXX")
+  cp -- "$chunks_json" "$artifact_tmp"
+  atomic_move "$artifact_tmp" "$artifact_path"
+  artifact_digest=$(sha_prefixed "$artifact_path")
+  printf 'TALLY_FINAL_MESSAGE='
+  jq -cn \
+    --arg paperId "$paper_id" \
+    --arg artifactPath "$artifact_path" \
+    --arg artifactDigest "$artifact_digest" \
+    --arg embeddingModel "$embedding_model" \
+    --argjson chunkCount "$chunk_count" \
+    '{paperId: $paperId, artifactPath: $artifactPath, artifactDigest: $artifactDigest, chunkCount: $chunkCount, embeddingModel: $embeddingModel}'
+}
+
+embed() {
+  local paper_id chunks_path artifact_path endpoint model batch_size dimensions chunk_count
+  paper_id=$(jq -er '.paperId' "$brief_path")
+  chunks_path=$(jq -er '.chunksPath' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  endpoint=$(jq -er '.embedding.endpoint' "$brief_path")
+  model=$(jq -er '.embedding.model' "$brief_path")
+  batch_size=$(jq -er '.embedding.batchSize | select(type == "number" and . >= 1 and . <= 64)' "$brief_path")
+  dimensions=$(jq -er '.embedding.dimensions | select(. == 4096)' "$brief_path")
+  require_state_path chunksPath "$chunks_path"
+  require_state_path artifactPath "$artifact_path"
+  require_paper_id "$paper_id"
+  require_local_llama_swap "$endpoint"
+  [[ $model == qwen3-embedding-8b ]] || die "unsupported embedding model: $model"
+  [[ -f $chunks_path ]] || die "chunks are missing: $chunks_path"
+  chunk_count=$(jq -er '.chunks | length | select(. > 0)' "$chunks_path") || die 'chunks file has no chunks'
+  mkdir -p "$(dirname "$artifact_path")"
+
+  embeddings_json="$work_dir/embeddings.json"
+  chunks_digest=$(sha_prefixed "$chunks_path")
+  jq -n \
+    --arg paperId "$paper_id" \
+    --arg chunksPath "$chunks_path" \
+    --arg chunksDigest "$chunks_digest" \
+    --arg model "$model" \
+    --arg endpoint "$endpoint" \
+    --argjson dimensions "$dimensions" \
+    '{
+      schema_version: 1,
+      paper_uuid: $paperId,
+      chunks_path: $chunksPath,
+      chunks_digest: $chunksDigest,
+      model: $model,
+      endpoint: $endpoint,
+      dimensions: $dimensions,
+      vectors: []
+    }' > "$embeddings_json"
+
+  for ((start = 0; start < chunk_count; start += batch_size)); do
+    end=$((start + batch_size))
+    (( end > chunk_count )) && end=$chunk_count
+    request="$work_dir/embed-request-$start.json"
+    response="$work_dir/embed-response-$start.json"
+    jq \
+      --arg model "$model" \
+      --argjson start "$start" \
+      --argjson end "$end" \
+      '{model: $model, input: [.chunks[$start:$end][] | .embed_text]}' \
+      "$chunks_path" > "$request"
+    "$curl_cmd" \
+      --fail \
+      --retry 1 \
+      --retry-all-errors \
+      --show-error \
+      --silent \
+      --max-time 900 \
+      --header 'Content-Type: application/json' \
+      --data-binary "@$request" \
+      "$endpoint/v1/embeddings" > "$response" \
+      || die "llama-swap embedding request failed for chunks $start through $((end - 1))"
+    expected_batch=$((end - start))
+    jq -e \
+      --argjson count "$expected_batch" \
+      --argjson dimensions "$dimensions" '
+        (.data | length) == $count
+        and ([.data[].index] | sort == [range(0; $count)])
+        and all(.data[]; (.embedding | type == "array" and length == $dimensions))
+      ' "$response" >/dev/null || die "embedding response for batch $start has the wrong shape"
+    jq -n \
+      --slurpfile response "$response" \
+      --slurpfile chunks "$chunks_path" \
+      --argjson start "$start" '
+        [$response[0].data[]
+          | {id: $chunks[0].chunks[$start + .index].id, embedding: .embedding}
+        ]
+      ' > "$work_dir/embed-batch.json"
+    jq --slurpfile batch "$work_dir/embed-batch.json" '.vectors += $batch[0]' "$embeddings_json" > "$work_dir/embeddings.next"
+    mv -f -- "$work_dir/embeddings.next" "$embeddings_json"
+  done
+  jq -e --argjson count "$chunk_count" '.vectors | length == $count' "$embeddings_json" >/dev/null \
+    || die 'embedding artifact is incomplete'
+
+  artifact_tmp=$(mktemp "$(dirname "$artifact_path")/.embeddings.XXXXXX")
+  cp -- "$embeddings_json" "$artifact_tmp"
+  atomic_move "$artifact_tmp" "$artifact_path"
+  artifact_digest=$(sha_prefixed "$artifact_path")
+  printf 'TALLY_FINAL_MESSAGE='
+  jq -cn \
+    --arg paperId "$paper_id" \
+    --arg artifactPath "$artifact_path" \
+    --arg artifactDigest "$artifact_digest" \
+    --arg model "$model" \
+    --argjson vectorCount "$chunk_count" \
+    --argjson dimensions "$dimensions" \
+    '{paperId: $paperId, artifactPath: $artifactPath, artifactDigest: $artifactDigest, vectorCount: $vectorCount, dimensions: $dimensions, model: $model}'
+}
+
+index_artifacts() {
+  local paper_id chunks_path embeddings_path artifact_path chunk_count vector_count
+  paper_id=$(jq -er '.paperId' "$brief_path")
+  chunks_path=$(jq -er '.chunksPath' "$brief_path")
+  embeddings_path=$(jq -er '.embeddingsPath' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  require_state_path chunksPath "$chunks_path"
+  require_state_path embeddingsPath "$embeddings_path"
+  require_state_path artifactPath "$artifact_path"
+  require_paper_id "$paper_id"
+  [[ -f $chunks_path ]] || die "chunks are missing: $chunks_path"
+  [[ -f $embeddings_path ]] || die "embeddings are missing: $embeddings_path"
+  case $chunks_path:$embeddings_path in
+    *[!A-Za-z0-9_./:-]*) die 'index input paths contain unsupported characters' ;;
+  esac
+  chunk_count=$(jq -er '.chunks | length | select(. > 0)' "$chunks_path") || die 'chunks file has no chunks'
+  vector_count=$(jq -er '.vectors | length | select(. > 0)' "$embeddings_path") || die 'embeddings file has no vectors'
+  (( chunk_count == vector_count )) || die 'chunk/vector count mismatch'
+  mkdir -p "$(dirname "$artifact_path")"
+  database_tmp=$(mktemp "$(dirname "$artifact_path")/.papers.XXXXXX.db")
+
+  sqlite3 -cmd ".load $sqlite_vec" "$database_tmp" >/dev/null <<SQL
+.bail on
+PRAGMA journal_mode = DELETE;
+PRAGMA synchronous = FULL;
+CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE chunks (
+  rowid INTEGER PRIMARY KEY,
+  id TEXT NOT NULL UNIQUE,
+  uuid TEXT NOT NULL,
+  page_start INTEGER NOT NULL,
+  page_end INTEGER NOT NULL,
+  section TEXT NOT NULL,
+  text TEXT NOT NULL,
+  embed_text TEXT NOT NULL
+);
+CREATE VIRTUAL TABLE chunks_fts USING fts5(id UNINDEXED, text, tokenize = 'unicode61');
+CREATE VIRTUAL TABLE chunks_vec USING vec0(embedding float[4096]);
+WITH
+  chunk_rows AS (
+    SELECT key, value FROM json_each(CAST(readfile('$chunks_path') AS TEXT), '$.chunks')
+  )
+INSERT INTO chunks (rowid, id, uuid, page_start, page_end, section, text, embed_text)
+SELECT
+  CAST(c.key AS INTEGER) + 1,
+  json_extract(c.value, '$.id'),
+  '$paper_id',
+  json_extract(c.value, '$.page_start'),
+  json_extract(c.value, '$.page_end'),
+  json_extract(c.value, '$.section'),
+  json_extract(c.value, '$.text'),
+  json_extract(c.value, '$.embed_text')
+FROM chunk_rows AS c
+ORDER BY CAST(c.key AS INTEGER);
+WITH vector_rows AS (
+  SELECT value FROM json_each(CAST(readfile('$embeddings_path') AS TEXT), '$.vectors')
+)
+INSERT INTO chunks_vec (rowid, embedding)
+SELECT
+  c.rowid,
+  json_extract(v.value, '$.embedding')
+FROM chunks AS c
+JOIN vector_rows AS v ON json_extract(v.value, '$.id') = c.id
+ORDER BY c.rowid;
+INSERT INTO chunks_fts (rowid, id, text) SELECT rowid, id, text FROM chunks ORDER BY rowid;
+INSERT INTO metadata VALUES ('schema_version', '1');
+INSERT INTO metadata VALUES ('paper_uuid', '$paper_id');
+INSERT INTO metadata VALUES ('chunks_sha256', '$(sha256sum "$chunks_path" | awk '{print $1}')');
+INSERT INTO metadata VALUES ('embeddings_sha256', '$(sha256sum "$embeddings_path" | awk '{print $1}')');
+VACUUM;
+SQL
+  integrity=$(sqlite3 -cmd ".load $sqlite_vec" "$database_tmp" 'PRAGMA integrity_check;')
+  [[ $integrity == ok ]] || die "SQLite integrity check failed: $integrity"
+  indexed_count=$(sqlite3 -cmd ".load $sqlite_vec" "$database_tmp" 'SELECT count(*) FROM chunks;')
+  fts_count=$(sqlite3 -cmd ".load $sqlite_vec" "$database_tmp" 'SELECT count(*) FROM chunks_fts;')
+  vector_indexed_count=$(sqlite3 -cmd ".load $sqlite_vec" "$database_tmp" 'SELECT count(*) FROM chunks_vec;')
+  (( indexed_count == chunk_count && fts_count == chunk_count && vector_indexed_count == chunk_count )) \
+    || die 'SQLite indexes are incomplete'
+  atomic_move "$database_tmp" "$artifact_path"
+  artifact_digest=$(sha_prefixed "$artifact_path")
+  printf 'TALLY_FINAL_MESSAGE='
+  jq -cn \
+    --arg paperId "$paper_id" \
+    --arg artifactPath "$artifact_path" \
+    --arg artifactDigest "$artifact_digest" \
+    --argjson chunkCount "$chunk_count" \
+    '{paperId: $paperId, artifactPath: $artifactPath, artifactDigest: $artifactDigest, chunkCount: $chunkCount, indexKind: "sqlite-vec+fts5"}'
+}
+
+receipt() {
+  local paper_id artifact_path output_dir
+  paper_id=$(jq -er '.paper.paperId' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  output_dir=$(jq -er '.outputDir' "$brief_path")
+  require_state_path artifactPath "$artifact_path"
+  require_state_path outputDir "$output_dir"
+  require_paper_id "$paper_id"
+  [[ $artifact_path == "$(dirname "$output_dir")/receipt.json" || $artifact_path == "$output_dir/receipt.json" ]] \
+    || die 'receipt path is outside the run/package boundary'
+  mkdir -p "$(dirname "$artifact_path")"
+  generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  converged_count=$(jq '[.pages[] | select(.status == "converged")] | length' "$brief_path")
+  arbitrated_count=$(jq '[.pages[] | select(.status == "arbitrated")] | length' "$brief_path")
+  page_count=$(jq '.pages | length' "$brief_path")
+  receipt_tmp=$(mktemp "$(dirname "$artifact_path")/.receipt.XXXXXX")
+  jq -n \
+    --slurpfile brief "$brief_path" \
+    --arg generatedAt "$generated_at" \
+    --argjson pageCount "$page_count" \
+    --argjson convergedCount "$converged_count" \
+    --argjson arbitratedCount "$arbitrated_count" '
+      {
+        schema_version: 1,
+        status: "complete",
+        generated_at: $generatedAt,
+        paper: $brief[0].paper,
+        protocols: $brief[0].protocols,
+        ocr: {
+          page_count: $pageCount,
+          converged_count: $convergedCount,
+          arbitrated_count: $arbitratedCount,
+          pages: $brief[0].pages
+        },
+        stages: $brief[0].stages,
+        artifacts: {
+          canonical_manifest: {
+            path: $brief[0].stages.assemble.result.artifactPath,
+            digest: $brief[0].stages.assemble.result.artifactDigest
+          },
+          paper_markdown: {
+            path: $brief[0].stages.assemble.result.paperPath,
+            digest: $brief[0].stages.assemble.result.paperDigest
+          },
+          chunks: {
+            path: $brief[0].stages.chunk.result.artifactPath,
+            digest: $brief[0].stages.chunk.result.artifactDigest
+          },
+          embeddings: {
+            path: $brief[0].stages.embed.result.artifactPath,
+            digest: $brief[0].stages.embed.result.artifactDigest,
+            model: $brief[0].stages.embed.result.model
+          },
+          disposable_index: {
+            path: $brief[0].stages.index.result.artifactPath,
+            digest: $brief[0].stages.index.result.artifactDigest,
+            kind: $brief[0].stages.index.result.indexKind
+          }
+        },
+        rebuild: {
+          durable_inputs: [
+            $brief[0].stages.assemble.result.paperPath,
+            $brief[0].stages.chunk.result.artifactPath
+          ],
+          embedding_model: $brief[0].stages.embed.result.model,
+          index_is_disposable: true
+        }
+      }
+    ' > "$receipt_tmp"
+  atomic_move "$receipt_tmp" "$artifact_path"
+  artifact_digest=$(sha_prefixed "$artifact_path")
+  printf 'TALLY_FINAL_MESSAGE='
+  jq -cn \
+    --arg paperId "$paper_id" \
+    --arg artifactPath "$artifact_path" \
+    --arg artifactDigest "$artifact_digest" \
+    '{status: "complete", paperId: $paperId, artifactPath: $artifactPath, artifactDigest: $artifactDigest}'
+}
+
+failure() {
+  local paper_id artifact_path generated_at receipt_tmp
+  paper_id=$(jq -er '.paper.paperId' "$brief_path")
+  artifact_path=$(jq -er '.artifactPath' "$brief_path")
+  require_state_path artifactPath "$artifact_path"
+  require_paper_id "$paper_id"
+  mkdir -p "$(dirname "$artifact_path")"
+  generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  receipt_tmp=$(mktemp "$(dirname "$artifact_path")/.receipt-failure.XXXXXX")
+  jq -n \
+    --slurpfile brief "$brief_path" \
+    --arg generatedAt "$generated_at" '{
+      schema_version: 1,
+      status: "failed",
+      generated_at: $generatedAt,
+      paper: $brief[0].paper,
+      error: $brief[0].error
+    }' > "$receipt_tmp"
+  atomic_move "$receipt_tmp" "$artifact_path"
+  artifact_digest=$(sha_prefixed "$artifact_path")
+  printf 'TALLY_FINAL_MESSAGE='
+  jq -cn \
+    --arg paperId "$paper_id" \
+    --arg artifactPath "$artifact_path" \
+    --arg artifactDigest "$artifact_digest" \
+    '{status: "failed", paperId: $paperId, artifactPath: $artifactPath, artifactDigest: $artifactDigest}'
+}
+
+case $action in
+  recognize) recognize ;;
+  arbitrate) arbitrate ;;
+  assemble) assemble ;;
+  chunk) chunk ;;
+  embed) embed ;;
+  index) index_artifacts ;;
+  receipt) receipt ;;
+  failure) failure ;;
+esac

--- a/pkgs/academic-ocr/fixed-papers.json
+++ b/pkgs/academic-ocr/fixed-papers.json
@@ -1,0 +1,16 @@
+{
+  "turner": {
+    "paperId": "fa3c575a-3089-4d27-957f-ba7d697b8737",
+    "title": "Betwixt and Between: The Liminal Period in Rites de Passage",
+    "sourceUrl": "https://assets.mecattaf.dev/pdf/Victor-Turner-Betwixt-and-Between_fa3c575a-3089-4d27-957f-ba7d697b8737.pdf",
+    "sourceSha256": "aa9db49df2216d7455fe0e81af561e05682e8fb68fe72a7e0de00a45b3af6265",
+    "expectedPages": 5
+  },
+  "fosfuri": {
+    "paperId": "96b65260-610c-4404-a08f-98b0e3ebc6d9",
+    "title": "The Licensing Dilemma: Understanding the Determinants of the Rate of Technology Licensing",
+    "sourceUrl": "https://assets.mecattaf.dev/pdf/Strategic%20Management%20Journal%20-%202006%20-%20Fosfuri%20-%20The%20licensing%20dilemma%20%20understanding%20the%20determinants%20of%20the%20rate%20of_491cfaeb-197d-4b1f-a510-261c480a7d22.pdf",
+    "sourceSha256": "909a82261bc9e0c3b2feaf9b9e93bcefc969919d935fd96734e215d002fdeb2b",
+    "expectedPages": 18
+  }
+}

--- a/pkgs/academic-ocr/plan-assemble.sh
+++ b/pkgs/academic-ocr/plan-assemble.sh
@@ -1,0 +1,129 @@
+set -euo pipefail
+
+ocr_args=''
+flow_log=''
+output=''
+
+usage() {
+  printf 'usage: academic-ocr-plan-assemble --ocr-args PATH --flow-log PATH [--output PATH]\n' >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --ocr-args)
+      [[ $# -ge 2 ]] || usage
+      ocr_args=$2
+      shift 2
+      ;;
+    --flow-log)
+      [[ $# -ge 2 ]] || usage
+      flow_log=$2
+      shift 2
+      ;;
+    --output)
+      [[ $# -ge 2 ]] || usage
+      output=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+die() {
+  printf 'academic-ocr-plan-assemble: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $ocr_args ]] || die "OCR args are not a file: $ocr_args"
+[[ -f $flow_log ]] || die "flow log is not a file: $flow_log"
+run_dir=$(dirname "$ocr_args")
+source_manifest="$run_dir/source.json"
+[[ -f $source_manifest ]] || die "source manifest is missing: $source_manifest"
+if [[ -z $output ]]; then
+  output="$run_dir/assemble-args.json"
+fi
+[[ $output = /* ]] || die 'output must be an absolute path'
+
+ocr_result_tmp=$(mktemp "$run_dir/.ocr-result.XXXXXX")
+cleanup() {
+  if [[ -e $ocr_result_tmp ]]; then
+    rm -f -- "$ocr_result_tmp"
+  fi
+}
+trap cleanup EXIT
+
+jq -sc '
+  [ .[]
+    | select(.type == "flow-report")
+    | select(.report.flowName == "academic-ocr")
+    | .report.finalValue
+  ]
+  | last // error("no completed academic-ocr flow-report in log")
+  | select(.schemaVersion == 1)
+  | select(.pageCount == (.pages | length))
+' "$flow_log" > "$ocr_result_tmp"
+jq -e '.pages | length > 0' "$ocr_result_tmp" >/dev/null \
+  || die 'OCR result has no pages'
+jq -e --slurpfile source "$source_manifest" '
+  . as $result
+  | $source[0] as $paper
+  | $result.pageCount == $paper.pageCount
+    and ([ $result.pages[].paperId ] | all(. == $paper.paperId))
+    and ([ $result.pages[].pageNumber ] | sort == [range(1; $paper.pageCount + 1)])
+' "$ocr_result_tmp" >/dev/null \
+  || die 'OCR result does not match the prepared paper identity and page census'
+
+ocr_result="$run_dir/ocr-result.json"
+chmod 0444 "$ocr_result_tmp"
+mv -f -- "$ocr_result_tmp" "$ocr_result"
+
+driver_path=${ACADEMIC_OCR_DRIVER_PATH:?ACADEMIC_OCR_DRIVER_PATH is not set}
+output_dir="$run_dir/package"
+receipt_path="$run_dir/receipt.json"
+output_tmp=$(mktemp "$run_dir/.assemble-args.XXXXXX")
+jq -n \
+  --slurpfile source "$source_manifest" \
+  --slurpfile ocr "$ocr_result" \
+  --slurpfile ocrArgs "$ocr_args" \
+  --arg program "$driver_path" \
+  --arg outputDir "$output_dir" \
+  --arg receiptPath "$receipt_path" \
+  '{
+    paper: {
+      paperId: $source[0].paperId,
+      title: $source[0].title,
+      sourceUrl: $source[0].sourceUrl,
+      sourceSha256: $source[0].sourceSha256
+    },
+    pages: $ocr[0].pages,
+    protocols: $ocrArgs[0].protocols,
+    driver: {
+      adapter: "ocr-driver",
+      program: $program,
+      runtimeMaxSec: 1800
+    },
+    outputDir: $outputDir,
+    receiptPath: $receiptPath,
+    chunkWords: 512,
+    embedding: {
+      endpoint: "http://localhost:9292",
+      model: "qwen3-embedding-8b",
+      batchSize: 16,
+      dimensions: 4096
+    }
+  }' > "$output_tmp"
+
+jq -e '
+  .paper.paperId != ""
+  and (.paper.sourceSha256 | test("^[0-9a-f]{64}$"))
+  and (.pages | length > 0)
+' "$output_tmp" >/dev/null || die 'generated assemble args are invalid'
+chmod 0444 "$output_tmp"
+mv -f -- "$output_tmp" "$output"
+printf '%s\n' "$output"

--- a/pkgs/academic-ocr/prepare.sh
+++ b/pkgs/academic-ocr/prepare.sh
@@ -1,0 +1,281 @@
+set -euo pipefail
+
+paper_catalog=${ACADEMIC_OCR_PAPER_CATALOG:?ACADEMIC_OCR_PAPER_CATALOG is not set}
+paper_profile=turner
+url_override=''
+sha_override=''
+paper_id_override=''
+title_override=''
+expected_pages_override=''
+source_file=''
+state_base=${XDG_STATE_HOME:-${HOME:?HOME is not set}/.local/state}
+state_root="$state_base/academic-ocr"
+runtime_max_sec=1800
+
+usage() {
+  cat >&2 <<'EOF'
+usage: academic-ocr-prepare [options]
+
+Options:
+  --paper NAME             fixed paper profile: turner or fosfuri (default: turner)
+  --url URL                override the profile's public PDF URL
+  --sha256 HEX             expected PDF sha256
+  --paper-id ID            safe paper/database identifier
+  --title TITLE            canonical title
+  --expected-pages N       expected page count; 0 disables the exact check
+  --state-root PATH        data root (default: $XDG_STATE_HOME/academic-ocr)
+  --source-file PATH       offline/local source instead of HTTP fetch
+  --runtime-max-sec N      per OCR child deadline written to flow args
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --paper)
+      [[ $# -ge 2 ]] || usage
+      paper_profile=$2
+      shift 2
+      ;;
+    --url)
+      [[ $# -ge 2 ]] || usage
+      url_override=$2
+      shift 2
+      ;;
+    --sha256)
+      [[ $# -ge 2 ]] || usage
+      sha_override=$2
+      shift 2
+      ;;
+    --paper-id)
+      [[ $# -ge 2 ]] || usage
+      paper_id_override=$2
+      shift 2
+      ;;
+    --title)
+      [[ $# -ge 2 ]] || usage
+      title_override=$2
+      shift 2
+      ;;
+    --expected-pages)
+      [[ $# -ge 2 ]] || usage
+      expected_pages_override=$2
+      shift 2
+      ;;
+    --state-root)
+      [[ $# -ge 2 ]] || usage
+      state_root=$2
+      shift 2
+      ;;
+    --source-file)
+      [[ $# -ge 2 ]] || usage
+      source_file=$2
+      shift 2
+      ;;
+    --runtime-max-sec)
+      [[ $# -ge 2 ]] || usage
+      runtime_max_sec=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      printf 'academic-ocr-prepare: unknown option: %s\n' "$1" >&2
+      usage
+      ;;
+  esac
+done
+
+die() {
+  printf 'academic-ocr-prepare: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ -f $paper_catalog ]] || die "fixed-paper catalog is missing: $paper_catalog"
+profile_json=$(jq -cer --arg profile "$paper_profile" '
+  .[$profile]
+  | select(type == "object")
+  | select(.paperId | type == "string")
+  | select(.title | type == "string")
+  | select(.sourceUrl | type == "string")
+  | select(.sourceSha256 | type == "string")
+  | select(.expectedPages | type == "number")
+' "$paper_catalog") || die "unknown or invalid fixed-paper profile: $paper_profile"
+
+url=${url_override:-$(jq -r '.sourceUrl' <<< "$profile_json")}
+expected_sha=${sha_override:-$(jq -r '.sourceSha256' <<< "$profile_json")}
+paper_id=${paper_id_override:-$(jq -r '.paperId' <<< "$profile_json")}
+title=${title_override:-$(jq -r '.title' <<< "$profile_json")}
+expected_pages=${expected_pages_override:-$(jq -r '.expectedPages' <<< "$profile_json")}
+
+[[ $expected_sha =~ ^[0-9a-f]{64}$ ]] || die 'sha256 must be 64 lowercase hexadecimal characters'
+[[ $paper_id =~ ^[A-Za-z0-9._-]+$ ]] || die 'paper-id contains unsafe characters'
+[[ -n $title ]] || die 'title must not be empty'
+[[ $expected_pages =~ ^[0-9]+$ ]] || die 'expected-pages must be a non-negative integer'
+[[ $runtime_max_sec =~ ^[1-9][0-9]*$ ]] || die 'runtime-max-sec must be positive'
+[[ $state_root = /* && $state_root != / ]] || die 'state-root must be an absolute non-root path'
+state_root=$(realpath -m -- "$state_root")
+notes_root=$(realpath -m -- "${HOME:?HOME is not set}/mecattaf/notes")
+case $state_root in
+  "$notes_root"|"$notes_root"/*) die 'state-root must not be inside ~/mecattaf/notes' ;;
+esac
+[[ $url == https://* ]] || die 'source URL must use https'
+if [[ -n $source_file ]]; then
+  [[ -f $source_file ]] || die "source-file is not a regular file: $source_file"
+fi
+
+curl_cmd=${ACADEMIC_OCR_CURL:-curl}
+driver_path=${ACADEMIC_OCR_DRIVER_PATH:?ACADEMIC_OCR_DRIVER_PATH is not set}
+blob_dir="$state_root/blobs/sha256"
+blob_path="$blob_dir/$expected_sha.pdf"
+render_dir="$blob_dir/$expected_sha.pages/200dpi"
+run_dir="$state_root/runs/$paper_id-${expected_sha:0:12}"
+source_manifest="$run_dir/source.json"
+ocr_args="$run_dir/ocr-args.json"
+mkdir -p "$blob_dir" "$render_dir" "$run_dir"
+
+tmp_download=''
+cleanup() {
+  if [[ -n $tmp_download && -e $tmp_download ]]; then
+    rm -f -- "$tmp_download"
+  fi
+}
+trap cleanup EXIT
+
+verify_pdf() {
+  local candidate=$1
+  local actual_sha magic
+  actual_sha=$(sha256sum "$candidate" | awk '{print $1}')
+  [[ $actual_sha == "$expected_sha" ]] || die "sha256 mismatch: expected $expected_sha, got $actual_sha"
+  magic=$(head -c 5 "$candidate" || true)
+  [[ $magic == '%PDF-' ]] || die 'source does not have PDF magic bytes'
+}
+
+if [[ -e $blob_path ]]; then
+  [[ -f $blob_path ]] || die "content-addressed blob path is not a regular file: $blob_path"
+  verify_pdf "$blob_path"
+else
+  tmp_download=$(mktemp "$blob_dir/.academic-ocr-download.XXXXXX")
+  if [[ -n $source_file ]]; then
+    cp --reflink=auto -- "$source_file" "$tmp_download"
+  else
+    "$curl_cmd" \
+      --fail \
+      --location \
+      --proto '=https' \
+      --retry 2 \
+      --retry-all-errors \
+      --show-error \
+      --silent \
+      --output "$tmp_download" \
+      "$url"
+  fi
+  verify_pdf "$tmp_download"
+  chmod 0444 "$tmp_download"
+  mv -n -- "$tmp_download" "$blob_path"
+  tmp_download=''
+  verify_pdf "$blob_path"
+fi
+
+page_count=$(pdfinfo "$blob_path" | awk '$1 == "Pages:" { print $2; exit }')
+[[ $page_count =~ ^[1-9][0-9]*$ ]] || die 'pdfinfo did not return a positive page count'
+(( page_count <= 100 )) || die "page count $page_count exceeds the OCR flow bound of 100"
+if (( expected_pages > 0 && page_count != expected_pages )); then
+  die "page-count mismatch: expected $expected_pages, got $page_count"
+fi
+
+png_magic='89504e470d0a1a0a'
+for ((page = 1; page <= page_count; page++)); do
+  page_path=$(printf '%s/page-%04d.png' "$render_dir" "$page")
+  if [[ -f $page_path ]]; then
+    actual_magic=$(head -c 8 "$page_path" | od -An -tx1 | tr -d ' \n')
+    [[ $actual_magic == "$png_magic" ]] || die "cached render has invalid PNG magic: $page_path"
+    continue
+  fi
+  render_tmp_dir=$(mktemp -d "$render_dir/.page-${page}.XXXXXX")
+  render_prefix="$render_tmp_dir/render"
+  if ! pdftoppm \
+    -f "$page" \
+    -l "$page" \
+    -r 200 \
+    -png \
+    -singlefile \
+    "$blob_path" \
+    "$render_prefix" >/dev/null 2>&1; then
+    rm -r -- "$render_tmp_dir"
+    die "pdftoppm failed to render page $page"
+  fi
+  render_tmp="$render_prefix.png"
+  if [[ ! -f $render_tmp ]]; then
+    rm -r -- "$render_tmp_dir"
+    die "pdftoppm did not render page $page"
+  fi
+  actual_magic=$(head -c 8 "$render_tmp" | od -An -tx1 | tr -d ' \n')
+  [[ $actual_magic == "$png_magic" ]] || die "rendered page $page is not PNG"
+  chmod 0444 "$render_tmp"
+  mv -n -- "$render_tmp" "$page_path"
+  rm -r -- "$render_tmp_dir"
+done
+
+source_tmp=$(mktemp "$run_dir/.source.XXXXXX")
+jq -n \
+  --arg paperId "$paper_id" \
+  --arg title "$title" \
+  --arg sourceUrl "$url" \
+  --arg sourceSha256 "$expected_sha" \
+  --arg blobPath "$blob_path" \
+  --arg renderDir "$render_dir" \
+  --argjson pageCount "$page_count" \
+  '{
+    schemaVersion: 1,
+    paperId: $paperId,
+    title: $title,
+    sourceUrl: $sourceUrl,
+    sourceSha256: $sourceSha256,
+    blobPath: $blobPath,
+    renderDpi: 200,
+    renderDir: $renderDir,
+    pageCount: $pageCount
+  }' > "$source_tmp"
+chmod 0444 "$source_tmp"
+mv -f -- "$source_tmp" "$source_manifest"
+
+pages=$(jq -cn \
+  --arg paperId "$paper_id" \
+  --arg sourcePath "$blob_path" \
+  --argjson count "$page_count" \
+  '[range(1; $count + 1) | {
+    paperId: $paperId,
+    pageNumber: .,
+    sourcePath: $sourcePath
+  }]')
+
+args_tmp=$(mktemp "$run_dir/.ocr-args.XXXXXX")
+jq -n \
+  --argjson pages "$pages" \
+  --arg program "$driver_path" \
+  --arg outputDir "$run_dir/ocr" \
+  --argjson runtimeMaxSec "$runtime_max_sec" \
+  '{
+    pages: $pages,
+    protocols: [
+      {id: "poppler-text", tier: "cheap"},
+      {id: "mupdf-text", tier: "cheap"},
+      {id: "qwen3-vl-8b-ocr", tier: "standard"},
+      {id: "qwen3-vl-32b-ocr", tier: "specialist"}
+    ],
+    driver: {
+      adapter: "ocr-driver",
+      program: $program,
+      runtimeMaxSec: $runtimeMaxSec
+    },
+    outputDir: $outputDir,
+    rasterDpi: 400,
+    maxMutationIterations: 3,
+    maxDisagreementPermille: 375
+  }' > "$args_tmp"
+chmod 0444 "$args_tmp"
+mv -f -- "$args_tmp" "$ocr_args"
+
+printf '%s\n' "$ocr_args"

--- a/pkgs/academic-ocr/signature.sh
+++ b/pkgs/academic-ocr/signature.sh
@@ -1,0 +1,67 @@
+set -euo pipefail
+
+usage() {
+  printf 'usage: academic-ocr-signature <text-file|->\n' >&2
+  exit 2
+}
+
+[[ $# -eq 1 ]] || usage
+input=$1
+if [[ $input != "-" ]]; then
+  [[ -f $input ]] || {
+    printf 'academic-ocr-signature: input is not a file: %s\n' "$input" >&2
+    exit 2
+  }
+fi
+
+# Text is normalized before shingling so line-wrap hyphenation, punctuation,
+# case, and whitespace do not turn ordinary OCR jitter into disagreement.
+# Thirty-two seeded MinHash components make the flow's positional mismatch
+# score approximate trigram Jaccard distance while staying inside uint16.
+sed ':join;$!{N;b join};s/-\n[[:space:]]*//g' "$input" \
+  | iconv -c -f UTF-8 -t ASCII//TRANSLIT \
+  | tr '[:upper:]' '[:lower:]' \
+  | tr -cs '[:alnum:]' '\n' \
+  | gawk '
+      NF { token[++count] = $0 }
+      END {
+        if (count == 0) {
+          print "academic-ocr-signature: normalized text is empty" > "/dev/stderr"
+          exit 20
+        }
+
+        alphabet = " abcdefghijklmnopqrstuvwxyz0123456789"
+        modulus = 65521
+        for (slot = 1; slot <= 32; slot++) {
+          a[slot] = ((slot * 2003 + 12345) % (modulus - 1)) + 1
+          b[slot] = (slot * 7919 + 54321) % modulus
+          minimum[slot] = modulus
+        }
+
+        shingle_count = count < 3 ? count : count - 2
+        for (item = 1; item <= shingle_count; item++) {
+          if (count < 3) {
+            shingle = token[item]
+          } else {
+            shingle = token[item] " " token[item + 1] " " token[item + 2]
+          }
+          hash = 0
+          for (character = 1; character <= length(shingle); character++) {
+            code = index(alphabet, substr(shingle, character, 1))
+            hash = (hash * 257 + code) % modulus
+          }
+          for (slot = 1; slot <= 32; slot++) {
+            value = (a[slot] * hash + b[slot]) % modulus
+            if (value < minimum[slot]) {
+              minimum[slot] = value
+            }
+          }
+        }
+
+        printf "["
+        for (slot = 1; slot <= 32; slot++) {
+          printf "%s%d", slot == 1 ? "" : ",", minimum[slot]
+        }
+        print "]"
+      }
+    '

--- a/pkgs/academic-ocr/tests/fake-curl.sh
+++ b/pkgs/academic-ocr/tests/fake-curl.sh
@@ -1,0 +1,31 @@
+set -euo pipefail
+
+payload=''
+for argument in "$@"; do
+  case $argument in
+    @*) payload=${argument#@} ;;
+  esac
+done
+[[ -n $payload && -f $payload ]] || {
+  printf 'academic-ocr-fake-curl: no @payload argument\n' >&2
+  exit 2
+}
+
+if jq -e 'has("messages")' "$payload" >/dev/null; then
+  jq -cn '{
+    choices: [{
+      message: {
+        content: "# Fixture paper\n\nThis generated academic page tests deterministic visual transcription through the bounded llama-swap HTTP adapter. It preserves headings, paragraphs, citations, tables, and mathematical notation without adding commentary.\n\n## Findings\n\nThe controlled fixture contains enough substantive language for the OCR fail-closed gate and the downstream chunking test."
+      }
+    }]
+  }'
+elif jq -e 'has("input")' "$payload" >/dev/null; then
+  jq -c '
+    .input
+    | to_entries
+    | {data: [ .[] | {index: .key, embedding: [range(0; 4096) | ((. + 1) / 4096)]} ]}
+  ' "$payload"
+else
+  printf 'academic-ocr-fake-curl: unsupported payload\n' >&2
+  exit 2
+fi

--- a/pkgs/academic-ocr/tests/fixtures/different.txt
+++ b/pkgs/academic-ocr/tests/fixtures/different.txt
@@ -1,0 +1,4 @@
+Vector databases organize numerical representations for similarity search across
+large collections. Index construction balances memory, latency, recall, update
+frequency, quantization, filtering, and operational complexity. Benchmark results
+must compare identical queries and documents before selecting a storage engine.

--- a/pkgs/academic-ocr/tests/fixtures/jitter-a.txt
+++ b/pkgs/academic-ocr/tests/fixtures/jitter-a.txt
@@ -1,0 +1,4 @@
+Ritual transitions create a liminal interval in which ordinary social positions
+are suspended. Participants move between stable classifications, encounter
+symbolic ambiguity, and return with a transformed status. The argument connects
+ceremony, community, hierarchy, temporality, and collective interpretation.

--- a/pkgs/academic-ocr/tests/fixtures/jitter-b.txt
+++ b/pkgs/academic-ocr/tests/fixtures/jitter-b.txt
@@ -1,0 +1,4 @@
+Ritual transitions create a liminal interval in which ordinary social positions
+are suspended. Participants move between stable classifications, encounter
+symbolic ambiguity and return with a transformed status. The argument connects
+ceremony, community, hierarchy, time, and collective interpretation.

--- a/pkgs/academic-ocr/tests/fixtures/scan-page.ps
+++ b/pkgs/academic-ocr/tests/fixtures/scan-page.ps
@@ -1,0 +1,13 @@
+%!PS-Adobe-3.0
+%%Pages: 1
+%%BoundingBox: 0 0 612 792
+%%Page: 1 1
+0.2 setlinewidth
+72 720 moveto 540 720 lineto 540 120 lineto 72 120 lineto closepath stroke
+100 670 moveto 500 670 lineto stroke
+100 640 moveto 480 640 lineto stroke
+100 610 moveto 510 610 lineto stroke
+100 580 moveto 455 580 lineto stroke
+100 550 moveto 495 550 lineto stroke
+showpage
+%%EOF

--- a/pkgs/academic-ocr/tests/fixtures/text-page.ps
+++ b/pkgs/academic-ocr/tests/fixtures/text-page.ps
@@ -1,0 +1,17 @@
+%!PS-Adobe-3.0
+%%Pages: 1
+%%BoundingBox: 0 0 612 792
+%%Page: 1 1
+/Helvetica-Bold findfont 18 scalefont setfont
+72 730 moveto (Fixture Paper for Academic OCR) show
+/Helvetica findfont 11 scalefont setfont
+72 700 moveto (This generated academic page contains a real PDF text layer for two independent engines.) show
+72 682 moveto (The evidence concerns liminality, ritual transitions, social structure, and careful interpretation.) show
+72 664 moveto (Poppler and MuPDF should recover nearly identical words even when spacing details differ.) show
+72 646 moveto (A stable signature tolerates minor punctuation and line-wrap jitter without hiding real disagreement.) show
+72 628 moveto (The canonical Markdown remains grounded to page one and retains its source and protocol digests.) show
+72 610 moveto (Deterministic chunks carry a title, section, page range, content hash, and embedding model.) show
+72 592 moveto (The disposable SQLite index can be reconstructed from canonical files and chunks alone.) show
+72 574 moveto (No fixture operation uses a network service, a mutable Python environment, or protected notes.) show
+showpage
+%%EOF

--- a/pkgs/academic-ocr/tests/test-workflow.sh
+++ b/pkgs/academic-ocr/tests/test-workflow.sh
@@ -1,0 +1,436 @@
+set -euo pipefail
+
+work=$(mktemp -d)
+cleanup() {
+  if [[ -d $work ]]; then
+    rm -r -- "$work"
+  fi
+}
+trap cleanup EXIT
+
+fixtures=${ACADEMIC_OCR_FIXTURES:?ACADEMIC_OCR_FIXTURES is not set}
+fake_curl=${ACADEMIC_OCR_FAKE_CURL:?ACADEMIC_OCR_FAKE_CURL is not set}
+paper_catalog=${ACADEMIC_OCR_PAPER_CATALOG:?ACADEMIC_OCR_PAPER_CATALOG is not set}
+sqlite_vec=${ACADEMIC_OCR_SQLITE_VEC:?ACADEMIC_OCR_SQLITE_VEC is not set}
+state="$work/state"
+mkdir -p "$state"
+
+fail() {
+  printf 'academic-ocr-tests: %s\n' "$*" >&2
+  exit 1
+}
+
+summary_from_output() {
+  local output=$1
+  [[ $(wc -l < "$output") -eq 1 ]] || fail "driver emitted more than one stdout line: $output"
+  grep -q '^TALLY_FINAL_MESSAGE=' "$output" || fail "driver emitted no final message: $output"
+  sed 's/^TALLY_FINAL_MESSAGE=//' "$output" | jq -c .
+}
+
+run_action() {
+  local action=$1 brief=$2 output=$3
+  TALLY_BRIEF="$brief" \
+    ACADEMIC_OCR_CURL="$fake_curl" \
+    ACADEMIC_OCR_STATE_ROOT="$state" \
+    academic-ocr-driver "$action" > "$output"
+  summary_from_output "$output" >/dev/null
+}
+
+signature_disagreement() {
+  local left=$1 right=$2
+  jq -n \
+    --argjson left "$left" \
+    --argjson right "$right" '
+      ([range(0; ([($left | length), ($right | length)] | max))
+        | select($left[.] != $right[.])]
+       | length * 1000
+       / ([($left | length), ($right | length)] | max)
+       | floor)
+    '
+}
+
+ps2pdf "$fixtures/text-page.ps" "$work/text-page.pdf"
+ps2pdf "$fixtures/scan-page.ps" "$work/scan-page.pdf"
+fixture_sha=$(sha256sum "$work/text-page.pdf" | awk '{print $1}')
+jq -e '
+  .turner.paperId == "fa3c575a-3089-4d27-957f-ba7d697b8737"
+  and .turner.sourceSha256 == "aa9db49df2216d7455fe0e81af561e05682e8fb68fe72a7e0de00a45b3af6265"
+  and .turner.expectedPages == 5
+  and .fosfuri.paperId == "96b65260-610c-4404-a08f-98b0e3ebc6d9"
+  and .fosfuri.sourceSha256 == "909a82261bc9e0c3b2feaf9b9e93bcefc969919d935fd96734e215d002fdeb2b"
+  and .fosfuri.expectedPages == 18
+  and (.fosfuri.sourceUrl | contains("491cfaeb-197d-4b1f-a510-261c480a7d22"))
+' "$paper_catalog" >/dev/null || fail 'fixed-paper catalog does not match the ruled identities'
+
+ocr_args=$(academic-ocr-prepare \
+  --source-file "$work/text-page.pdf" \
+  --url 'https://example.invalid/fixture.pdf' \
+  --sha256 "$fixture_sha" \
+  --paper-id fixture-paper \
+  --title 'Fixture Paper for Academic OCR' \
+  --expected-pages 1 \
+  --state-root "$state")
+[[ -f $ocr_args ]] || fail 'prepare did not emit an OCR args manifest'
+jq -e '
+  (.pages | length == 1)
+  and (.protocols | map(.id) == [
+    "poppler-text",
+    "mupdf-text",
+    "qwen3-vl-8b-ocr",
+    "qwen3-vl-32b-ocr"
+  ])
+  and .rasterDpi == 400
+  and .maxMutationIterations == 3
+  and .maxDisagreementPermille == 375
+' "$ocr_args" >/dev/null
+source_path=$(jq -r '.pages[0].sourcePath' "$ocr_args")
+[[ -f ${source_path%.pdf}.pages/200dpi/page-0001.png ]] || fail 'prepare did not render the fixture page'
+
+jq -n \
+  --arg sourcePath "$source_path" \
+  --arg artifactPath "$work/outside-state.json" '{
+    action: "recognize",
+    page: {paperId: "fixture-paper", pageNumber: 1, sourcePath: $sourcePath},
+    protocol: {id: "poppler-text", tier: "cheap"},
+    input: {id: "original", mutation: {kind: "none"}},
+    artifactPath: $artifactPath
+  }' > "$work/outside-state-brief.json"
+if TALLY_BRIEF="$work/outside-state-brief.json" ACADEMIC_OCR_STATE_ROOT="$state" \
+  academic-ocr-driver recognize > "$work/outside-state.out" 2> "$work/outside-state.err"; then
+  fail 'driver accepted an artifact path outside the academic OCR data root'
+fi
+grep -q 'escapes the academic OCR data root' "$work/outside-state.err" \
+  || fail 'driver did not explain its data-root boundary rejection'
+
+args_digest=$(sha256sum "$ocr_args" | awk '{print $1}')
+ocr_args_again=$(academic-ocr-prepare \
+  --source-file "$work/text-page.pdf" \
+  --url 'https://example.invalid/fixture.pdf' \
+  --sha256 "$fixture_sha" \
+  --paper-id fixture-paper \
+  --title 'Fixture Paper for Academic OCR' \
+  --expected-pages 1 \
+  --state-root "$state")
+[[ $ocr_args_again == "$ocr_args" ]] || fail 'prepare changed the manifest path on replay'
+[[ $(sha256sum "$ocr_args" | awk '{print $1}') == "$args_digest" ]] || fail 'prepare output is not deterministic'
+
+fosfuri_args=$(academic-ocr-prepare \
+  --paper fosfuri \
+  --source-file "$work/text-page.pdf" \
+  --sha256 "$fixture_sha" \
+  --expected-pages 1 \
+  --state-root "$work/fosfuri-state")
+fosfuri_run=$(dirname "$fosfuri_args")
+jq -e '
+  .paperId == "96b65260-610c-4404-a08f-98b0e3ebc6d9"
+  and .title == "The Licensing Dilemma: Understanding the Determinants of the Rate of Technology Licensing"
+  and (.sourceUrl | contains("491cfaeb-197d-4b1f-a510-261c480a7d22"))
+  and .pageCount == 1
+' "$fosfuri_run/source.json" >/dev/null \
+  || fail 'Fosfuri profile did not preserve db_id identity independently of the URL UUID'
+
+run_dir=$(dirname "$ocr_args")
+poppler_artifact="$run_dir/ocr/fixture-paper/page-1/poppler-text/original.json"
+mupdf_artifact="$run_dir/ocr/fixture-paper/page-1/mupdf-text/original.json"
+
+for protocol in poppler-text mupdf-text; do
+  artifact="$run_dir/ocr/fixture-paper/page-1/$protocol/original.json"
+  brief="$work/$protocol-brief.json"
+  jq -n \
+    --arg protocol "$protocol" \
+    --arg sourcePath "$source_path" \
+    --arg artifactPath "$artifact" '{
+      action: "recognize",
+      page: {paperId: "fixture-paper", pageNumber: 1, sourcePath: $sourcePath},
+      protocol: {id: $protocol, tier: "cheap"},
+      input: {id: "original", mutation: {kind: "none"}},
+      artifactPath: $artifactPath
+    }' > "$brief"
+  run_action recognize "$brief" "$work/$protocol.out"
+  jq -e '
+    .paperId == "fixture-paper"
+    and .pageNumber == 1
+    and .protocolId == $protocol
+    and .inputVariant == "original"
+    and (.textDigest | test("^sha256:[0-9a-f]{64}$"))
+    and (.signature | length == 32)
+    and .confidencePermille == 1000
+    and .hotZones == []
+    and .skewMilliDegrees == 0
+  ' --arg protocol "$protocol" "$artifact" >/dev/null
+done
+
+poppler_signature=$(jq -c '.signature' "$poppler_artifact")
+mupdf_signature=$(jq -c '.signature' "$mupdf_artifact")
+mechanical_disagreement=$(signature_disagreement "$poppler_signature" "$mupdf_signature")
+(( mechanical_disagreement <= 375 )) || fail "mechanical fixture signatures disagree at $mechanical_disagreement permille"
+
+arbiter_artifact="$run_dir/ocr/fixture-paper/page-1/arbiter/final.json"
+jq -n \
+  --arg sourcePath "$source_path" \
+  --arg popplerPath "$poppler_artifact" \
+  --arg popplerDigest "$(jq -r '.textDigest' "$poppler_artifact")" \
+  --arg mupdfPath "$mupdf_artifact" \
+  --arg mupdfDigest "$(jq -r '.textDigest' "$mupdf_artifact")" \
+  --arg artifactPath "$arbiter_artifact" '{
+    action: "arbitrate",
+    page: {paperId: "fixture-paper", pageNumber: 1, sourcePath: $sourcePath},
+    attempts: [{
+      taskUuid: "00000000-0000-4000-8000-000000000121",
+      witnessSeq: 1,
+      verdict: "pass",
+      protocolId: "poppler-text",
+      inputVariant: "original",
+      artifactPath: $popplerPath,
+      textDigest: $popplerDigest
+    }, {
+      taskUuid: "00000000-0000-4000-8000-000000000122",
+      witnessSeq: 2,
+      verdict: "pass",
+      protocolId: "mupdf-text",
+      inputVariant: "original",
+      artifactPath: $mupdfPath,
+      textDigest: $mupdfDigest
+    }],
+    artifactPath: $artifactPath
+  }' > "$work/arbiter-brief.json"
+run_action arbitrate "$work/arbiter-brief.json" "$work/arbiter.out"
+jq -e '
+  .paperId == "fixture-paper"
+  and .pageNumber == 1
+  and (.basis | length == 2)
+  and (.textDigest | test("^sha256:[0-9a-f]{64}$"))
+' "$arbiter_artifact" >/dev/null
+
+jitter_a=$(academic-ocr-signature "$fixtures/jitter-a.txt")
+jitter_b=$(academic-ocr-signature "$fixtures/jitter-b.txt")
+different=$(academic-ocr-signature "$fixtures/different.txt")
+jitter_disagreement=$(signature_disagreement "$jitter_a" "$jitter_b")
+different_disagreement=$(signature_disagreement "$jitter_a" "$different")
+(( jitter_disagreement <= 375 )) || fail "minor OCR jitter exceeds threshold: $jitter_disagreement"
+(( different_disagreement > 375 )) || fail "different content falls below threshold: $different_disagreement"
+if printf '   \n' | academic-ocr-signature - >/dev/null 2>&1; then
+  fail 'empty text unexpectedly produced a signature'
+fi
+
+scan_sha=$(sha256sum "$work/scan-page.pdf" | awk '{print $1}')
+scan_artifact="$work/scan-recognition.json"
+jq -n \
+  --arg sourcePath "$work/scan-page.pdf" \
+  --arg artifactPath "$scan_artifact" '{
+    action: "recognize",
+    page: {paperId: "scan-fixture", pageNumber: 1, sourcePath: $sourcePath},
+    protocol: {id: "poppler-text", tier: "cheap"},
+    input: {id: "original", mutation: {kind: "none"}},
+    artifactPath: $artifactPath
+  }' > "$work/scan-brief.json"
+if TALLY_BRIEF="$work/scan-brief.json" ACADEMIC_OCR_STATE_ROOT="$work" \
+  academic-ocr-driver recognize > "$work/scan.out" 2> "$work/scan.err"; then
+  fail 'empty mechanical extraction unexpectedly passed'
+fi
+[[ ! -e $scan_artifact ]] || fail 'failed mechanical extraction wrote a passing artifact'
+grep -q 'empty or near-empty' "$work/scan.err" || fail 'mechanical failure did not explain the fail-closed gate'
+[[ $scan_sha =~ ^[0-9a-f]{64}$ ]] || fail 'scan fixture hash failed'
+
+vlm_artifact="$run_dir/ocr/fixture-paper/page-1/qwen3-vl-8b-ocr/original.json"
+jq -n \
+  --arg sourcePath "$source_path" \
+  --arg artifactPath "$vlm_artifact" '{
+    action: "recognize",
+    page: {paperId: "fixture-paper", pageNumber: 1, sourcePath: $sourcePath},
+    protocol: {id: "qwen3-vl-8b-ocr", tier: "standard"},
+    input: {id: "original", mutation: {kind: "none"}},
+    artifactPath: $artifactPath
+  }' > "$work/vlm-brief.json"
+run_action recognize "$work/vlm-brief.json" "$work/vlm.out"
+jq -e '
+  .protocolId == "qwen3-vl-8b-ocr"
+  and .confidencePermille == 900
+  and .provenance.endpoint == "http://localhost:9292"
+  and (.provenance.promptDigest | test("^sha256:[0-9a-f]{64}$"))
+' "$vlm_artifact" >/dev/null
+
+vlm_digest=$(jq -r '.textDigest' "$vlm_artifact")
+selection=$(jq -n \
+  --arg digest "$vlm_digest" \
+  --arg path "$vlm_artifact" '{
+    paperId: "fixture-paper",
+    pageNumber: 1,
+    status: "converged",
+    resolution: "tier",
+    inputVariant: "original",
+    chosenArtifactPath: $path,
+    textDigest: $digest,
+    disagreementPermille: 0,
+    agreementProtocols: ["qwen3-vl-8b-ocr", "qwen3-vl-32b-ocr"],
+    attemptCount: 4,
+    proof: {taskUuid: "00000000-0000-4000-8000-000000000124", witnessSeq: 1}
+  }')
+package_dir="$run_dir/package"
+canonical_manifest="$package_dir/canonical/manifest.json"
+jq -n \
+  --argjson selection "$selection" \
+  --arg outputDir "$package_dir" \
+  --arg artifactPath "$canonical_manifest" '{
+    action: "assemble",
+    paper: {
+      paperId: "fixture-paper",
+      title: "Fixture Paper for Academic OCR",
+      sourceUrl: "https://example.invalid/fixture.pdf",
+      sourceSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    pages: [$selection],
+    outputDir: $outputDir,
+    artifactPath: $artifactPath
+  }' > "$work/assemble-brief.json"
+run_action assemble "$work/assemble-brief.json" "$work/assemble.out"
+assemble_summary=$(summary_from_output "$work/assemble.out")
+jq -e '.pages | length == 1' "$canonical_manifest" >/dev/null
+grep -q '<!-- page:001 -->' "$package_dir/canonical/paper.md"
+
+chunks_path="$package_dir/chunks.json"
+jq -n \
+  --arg paperPath "$package_dir/canonical/paper.md" \
+  --arg artifactPath "$chunks_path" '{
+    action: "chunk",
+    paperId: "fixture-paper",
+    paperPath: $paperPath,
+    chunkWords: 512,
+    embeddingModel: "qwen3-embedding-8b",
+    artifactPath: $artifactPath
+  }' > "$work/chunk-brief.json"
+run_action chunk "$work/chunk-brief.json" "$work/chunk.out"
+chunk_summary=$(summary_from_output "$work/chunk.out")
+jq -e '
+  .paper_uuid == "fixture-paper"
+  and .embed_model_version == "qwen3-embedding-8b"
+  and (.chunks | length > 0)
+  and all(.chunks[]; has("page_start") and has("page_end") and has("embed_text"))
+' "$chunks_path" >/dev/null
+chunks_digest=$(sha256sum "$chunks_path" | awk '{print $1}')
+run_action chunk "$work/chunk-brief.json" "$work/chunk-replay.out"
+[[ $(sha256sum "$chunks_path" | awk '{print $1}') == "$chunks_digest" ]] || fail 'chunk output changed on replay'
+
+embeddings_path="$package_dir/embeddings.json"
+jq -n \
+  --arg chunksPath "$chunks_path" \
+  --arg artifactPath "$embeddings_path" '{
+    action: "embed",
+    paperId: "fixture-paper",
+    chunksPath: $chunksPath,
+    embedding: {
+      endpoint: "http://localhost:9292",
+      model: "qwen3-embedding-8b",
+      batchSize: 16,
+      dimensions: 4096
+    },
+    artifactPath: $artifactPath
+  }' > "$work/embed-brief.json"
+run_action embed "$work/embed-brief.json" "$work/embed.out"
+embed_summary=$(summary_from_output "$work/embed.out")
+jq -e '
+  .model == "qwen3-embedding-8b"
+  and .dimensions == 4096
+  and (.vectors | length > 0)
+  and all(.vectors[]; .embedding | length == 4096)
+' "$embeddings_path" >/dev/null
+
+index_path="$package_dir/index/papers.db"
+jq -n \
+  --arg chunksPath "$chunks_path" \
+  --arg embeddingsPath "$embeddings_path" \
+  --arg artifactPath "$index_path" '{
+    action: "index",
+    paperId: "fixture-paper",
+    chunksPath: $chunksPath,
+    embeddingsPath: $embeddingsPath,
+    artifactPath: $artifactPath
+  }' > "$work/index-brief.json"
+run_action index "$work/index-brief.json" "$work/index.out"
+index_summary=$(summary_from_output "$work/index.out")
+[[ $(sqlite3 -cmd ".load $sqlite_vec" "$index_path" 'PRAGMA integrity_check;') == ok ]] \
+  || fail 'built index is not integral'
+[[ $(sqlite3 -cmd ".load $sqlite_vec" "$index_path" 'SELECT count(*) FROM chunks;') -gt 0 ]] \
+  || fail 'built index has no chunks'
+[[ $(sqlite3 -cmd ".load $sqlite_vec" "$index_path" 'SELECT count(*) FROM chunks_vec;') -gt 0 ]] \
+  || fail 'built index has no vectors'
+nearest_distance=$(sqlite3 -cmd ".load $sqlite_vec" "$index_path" '
+  SELECT distance
+  FROM chunks_vec
+  WHERE embedding MATCH (SELECT embedding FROM chunks_vec WHERE rowid = 1)
+  ORDER BY distance
+  LIMIT 1;
+')
+[[ $nearest_distance == 0.0 ]] || fail 'built vector index did not return an exact nearest neighbor'
+
+receipt_path="$run_dir/receipt.json"
+jq -n \
+  --argjson selection "$selection" \
+  --argjson assemble "$assemble_summary" \
+  --argjson chunk "$chunk_summary" \
+  --argjson embed "$embed_summary" \
+  --argjson index "$index_summary" \
+  --arg outputDir "$package_dir" \
+  --arg artifactPath "$receipt_path" '{
+    action: "receipt",
+    paper: {
+      paperId: "fixture-paper",
+      title: "Fixture Paper for Academic OCR",
+      sourceUrl: "https://example.invalid/fixture.pdf",
+      sourceSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    pages: [$selection],
+    protocols: [
+      {id: "poppler-text", tier: "cheap"},
+      {id: "mupdf-text", tier: "cheap"},
+      {id: "qwen3-vl-8b-ocr", tier: "standard"},
+      {id: "qwen3-vl-32b-ocr", tier: "specialist"}
+    ],
+    outputDir: $outputDir,
+    stages: {
+      assemble: {result: $assemble, proof: {taskUuid: "a", witnessSeq: 1}},
+      chunk: {result: $chunk, proof: {taskUuid: "b", witnessSeq: 2}},
+      embed: {result: $embed, proof: {taskUuid: "c", witnessSeq: 3}},
+      index: {result: $index, proof: {taskUuid: "d", witnessSeq: 4}}
+    },
+    artifactPath: $artifactPath
+  }' > "$work/receipt-brief.json"
+run_action receipt "$work/receipt-brief.json" "$work/receipt.out"
+jq -e '
+  .status == "complete"
+  and .ocr.page_count == 1
+  and .rebuild.index_is_disposable == true
+  and (.rebuild.durable_inputs | length == 2)
+' "$receipt_path" >/dev/null
+
+ocr_flow_log="$run_dir/ocr-flow.jsonl"
+jq -cn \
+  --argjson selection "$selection" '{
+    type: "flow-report",
+    report: {
+      flowRunId: "00000000-0000-4000-8000-000000000124",
+      flowName: "academic-ocr",
+      scriptHash: "fixture",
+      ordinalKeys: [],
+      observationOrder: [],
+      finalValue: {
+        schemaVersion: 1,
+        pageCount: 1,
+        convergedCount: 1,
+        arbitratedCount: 0,
+        configuredNodeUpperBound: 17,
+        pages: [$selection]
+      }
+    }
+  }' > "$ocr_flow_log"
+assemble_args=$(academic-ocr-plan-assemble --ocr-args "$ocr_args" --flow-log "$ocr_flow_log")
+[[ -f $assemble_args && -f $run_dir/ocr-result.json ]] || fail 'assemble planner did not retain its outputs'
+jq -e '
+  .paper.paperId == "fixture-paper"
+  and (.pages | length == 1)
+  and .embedding.model == "qwen3-embedding-8b"
+  and .embedding.dimensions == 4096
+' "$assemble_args" >/dev/null
+
+printf 'academic-ocr fixture tests passed (jitter=%s, different=%s, mechanical=%s permille)\n' \
+  "$jitter_disagreement" "$different_disagreement" "$mechanical_disagreement"


### PR DESCRIPTION
## Summary

- package deterministic preparation for the fixed Turner and Fosfuri papers, including db-ID/hash ownership and content-addressed staging
- implement the upstream mutation-ladder `recognize`/`arbitrate` contract with fail-closed Poppler/MuPDF evidence and llama-swap-only Qwen VLM lanes
- add canonical assembly, June-lineage chunking, batched embeddings, a disposable SQLite FTS5 + `sqlite-vec` index, and witnessed receipts
- register the patched upstream OCR flow and the coordinator-owned assembly flow with ruled pools, node limits, adapter capture, and no calendars
- add offline ShellCheck/fixture coverage and the supervised two-paper operator sequence

## Validation

- `nix build --offline --no-link .#academic-ocr`
- `nix flake check --offline --no-build`
- `nix build --no-link .#nixosConfigurations.coordinator.config.system.build.toplevel`
- `tally flow check` for both flows with registered Turner args
- `tally flow check` for both flows with realistic 18-page Fosfuri args
- topology assertions for coordinator-only adapter/pools, `executors = {}`, null calendars, and the build-time `ocr-gpu` substitution

The supervised paper/model runs and deployment were intentionally not performed.

References #95.
Closes #124.