### PR TITLE
coordinator: warm the /mnt/nas automount before the graphical session (#139)

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -342,6 +342,11 @@ in
   # local folders; first click triggers the automount. createDirectories stays
   # off — the dirs live on the NAS and mkdir through a dead mount at HM
   # activation would hang or spray errors.
+  #
+  # These entries (and the Photos bookmark above) only survive into the sidebar
+  # because hosts/coordinator/nas-client.nix warms the automount before
+  # graphical-session.target: a path that isn't there when the session starts is
+  # silently dropped, which is #139.
   # ---------------------------------------------------------------------------
   xdg.userDirs = lib.mkIf (hostName == "coordinator") {
     enable = true;

--- a/hosts/coordinator/nas-client.nix
+++ b/hosts/coordinator/nas-client.nix
@@ -7,6 +7,24 @@
 let
   cfg = config.myNasClient;
   socketProxyd = "${pkgs.systemd}/lib/systemd/systemd-socket-proxyd";
+
+  # #139. One poke below the mountpoint is the whole fix; everything else here
+  # is the bound on how long that poke may cost a login. Budget: each attempt
+  # gets 5s (one soft-mount round of timeo=50/retrans=2 plus slack), and the
+  # retry loop gives up 10s in — the retries exist only for the cold-boot case,
+  # where greetd autologins tom→niri (modules/common.nix) while enp191s0 or the
+  # NAS itself is still a couple of seconds behind. Success is checked against
+  # the kernel, not against `ls`: a failed automount leaves the empty autofs
+  # trigger directory in place, which `ls` reports as an ordinary empty dir.
+  warmNasAutomount = pkgs.writeShellScript "nas-automount-warm" ''
+    deadline=$(( $(${pkgs.coreutils}/bin/date +%s) + 10 ))
+    while :; do
+      ${pkgs.coreutils}/bin/timeout 5s ${pkgs.coreutils}/bin/ls /mnt/nas/ >/dev/null 2>&1 || :
+      ${pkgs.util-linux}/bin/findmnt --type nfs4 --mountpoint /mnt/nas >/dev/null 2>&1 && exit 0
+      [ "$(${pkgs.coreutils}/bin/date +%s)" -ge "$deadline" ] && exit 0
+      ${pkgs.coreutils}/bin/sleep 1
+    done
+  '';
 in
 {
   options.myNasClient = {
@@ -43,6 +61,45 @@ in
           "x-systemd.mount-timeout=30s"
           "_netdev"
         ];
+      };
+
+      # ── #139: warm the automount before the graphical session ──────────────
+      # home/home.nix points the Music/Videos XDG user dirs and the Photos
+      # bookmark at /mnt/nas. When the automount is still cold at session start
+      # those paths do not resolve, GLib drops them, and the Nautilus sidebar
+      # comes up without them — `nautilus -q` plus a relaunch on a warm mount
+      # was the manual workaround. Nothing sets TimeoutIdleSec on the automount,
+      # so mounting it once at session start keeps it up for the rest of the
+      # boot and every later-launched app sees real directories.
+      #
+      # Ordered Before= but only Wants=/WantedBy= graphical-session.target: niri
+      # itself is likewise Before= that target, so the compositor comes up in
+      # parallel and even the worst case delays session-scoped services (portals,
+      # piri), never the desktop appearing. A dead NAS therefore degrades to
+      # exactly today's behaviour — sidebar entries absent — bounded by the
+      # script's own 10s deadline, with TimeoutStartSec as the hard backstop for
+      # the pathological case where the poke is stuck in the kernel (a start-job
+      # timeout completes the job, so the target is never held past it). The
+      # soft-mount options above stay untouched: this only touches the mount, it
+      # does not change what happens when the touch fails.
+      #
+      # The "-" prefix keeps a cold NAS from marking the unit failed: an
+      # unreachable NAS is a normal outcome here, not something worth a marker
+      # in modules/failure-surfacing.nix (which watches per-user units too).
+      systemd.user.services.nas-automount-warm = {
+        description = "Warm the /mnt/nas automount before the graphical session";
+        before = [ "graphical-session.target" ];
+        # PartOf so a logout resets this oneshot and the next session warms the
+        # mount again; the user manager lingers, so without it a second login in
+        # the same boot would skip the poke.
+        partOf = [ "graphical-session.target" ];
+        wantedBy = [ "graphical-session.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "-${warmNasAutomount}";
+          TimeoutStartSec = "20s";
+        };
       };
     })
 


### PR DESCRIPTION
Closes #139

## What changed

- `hosts/coordinator/nas-client.nix` — new `systemd.user.services.nas-automount-warm`, inside the existing `useRemoteStorage` gate so it lands exactly where the automount does. A oneshot that pokes `/mnt/nas`, ordered `Before=graphical-session.target`, `WantedBy=`/`PartOf=` it.
- `home/home.nix` — three comment lines under `xdg.userDirs` pointing at the unit, so the next reader of the NAS sidebar block knows why the paths survive.

The poke checks success against the kernel (`findmnt --type nfs4 --mountpoint /mnt/nas`), not against `ls`: a failed automount leaves the empty autofs trigger directory in place, which `ls` happily reports as an ordinary empty dir. Nothing sets `TimeoutIdleSec` on the automount, so mounting it once at session start keeps it up for the rest of the boot — a Nautilus launched an hour later sees real directories.

## Acceptance

**"After a full reboot with the NAS up, Nautilus shows Music, Videos and Photos with no manual `nautilus -q`."** — Addressed by ordering the poke ahead of `graphical-session.target`. Proven live *except* the reboot itself (see below): with `mnt-nas.mount` stopped, running this unit's `ExecStart` under the real user manager remounted it in **0.118s** and exited 0, after which `xdg-user-dir MUSIC/VIDEOS` and `/mnt/nas/{music,videos,photos}` all resolve.

**"Login with the NAS unplugged is not delayed beyond the unit's timeout and the session is otherwise normal."** — Bounded three ways: 5s per poke (one soft-mount round of `timeo=50`/`retrans=2` plus slack), a 10s deadline on the retry loop, and `TimeoutStartSec=20s` as the hard backstop for the pathological case where the poke is stuck in the kernel (a start-job timeout completes the job, so the target is never held past it). Measured against an absent mountpoint: **9.1s, exit 0**. `niri.service` is itself `Before=graphical-session.target` (verified on the live box), so the poke runs *in parallel with the compositor* — even the worst case delays only session-scoped services (portals, piri), never the desktop appearing.

**Hard constraint — soft-mount semantics unchanged.** The `fileSystems."/mnt/nas"` block is byte-identical; `git show --stat` touches no option. This changes *when* the mount is touched, not what happens when the touch fails. No hard mount, nothing that can wedge PID 1.

The `-` prefix on `ExecStart` keeps an unreachable NAS from writing a failure marker: `modules/failure-surfacing.nix` watches per-user units, and a cold NAS is a normal outcome here, not something to page about.

## Validation run

| command | result |
| --- | --- |
| `nix flake check` | **exit 0**, "all checks passed" — built the coordinator system closure including `unit-nas-automount-warm.service` |
| `nix fmt -- --check` on both files | exit 0 |
| unit rendered from `.#nixosConfigurations.coordinator...toplevel` | present at `etc/systemd/user/nas-automount-warm.service` + symlinked into `graphical-session.target.wants/` |
| `systemd-run --user --wait` of the script, mount **cold** | exit 0 in 0.118s, `/mnt/nas` mounted nfs4 afterwards |
| same script against an absent mountpoint | exit 0 in 9.1s (deadline bound holds, no failure state) |

The cold-mount test stopped `mnt-nas.mount` on the live coordinator and the unit remounted it; the box was left mounted, as found. No `nixos-rebuild`/`home-manager switch` was run — this is PR-only, the fleet ships on its own pin.

## Unproven until a real reboot

The reboot-time acceptance **cannot be proven from this session** and is not claimed. What is proven is the mechanism (cold automount → warmed by this exact ExecStart, under the user manager, in 0.1s) and the bound (9.1s / exit 0 with no NAS). What still needs one real boot on the coordinator with the NAS up:

- that Nautilus actually shows Music, Videos and Photos on a fresh autologin with no `nautilus -q` — i.e. that the cold-mount race is the *whole* cause of #139 and not merely a necessary condition;
- that the unit wins the race on a *cold boot*, where enp191s0 and the NAS's own boot may lag autologin. The 10s retry loop exists for exactly this and is untested against a genuinely late NAS;
- the unplugged-cable login, which nobody has run with the cable out.

`journalctl --user -u nas-automount-warm -b` after the next reboot is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
