### PR TITLE
nas: adb + Immich CLI + staging dir for USB Android photo ingest

### DIFF
--- a/hosts/nas/default.nix
+++ b/hosts/nas/default.nix
@@ -5,6 +5,7 @@
 }:
 {
   imports = [
+    ./unstable-pkgs.nix
     ./hardware.nix
     ./disko.nix
     ./network.nix

--- a/hosts/nas/default.nix
+++ b/hosts/nas/default.nix
@@ -12,6 +12,7 @@
     ./journal.nix
     ./storage.nix
     ./media.nix
+    ./phone-ingest.nix
     ./lacie-mirror.nix
     # #130 expansion workstreams. All four land with their gates OFF; each has
     # a runbook in its own header and flips on its own, later, after that
@@ -53,6 +54,10 @@
   # disk; deployment order (NAS restore first, then the coordinator cutover)
   # is sequenced manually in #131.
   myNas.media.enable = true;
+  # Operator tooling only — adb, the Immich CLI, and a staging directory (#143).
+  # Nothing here starts on its own; the first camera-roll pull is driven by hand
+  # so its failure modes get observed before any of it is automated.
+  myNas.phoneIngest.enable = true;
 
   system.stateVersion = "26.05";
 }

--- a/hosts/nas/media.nix
+++ b/hosts/nas/media.nix
@@ -3,6 +3,7 @@
   inputs,
   lib,
   pkgs,
+  unstablePkgs,
   ...
 }:
 let
@@ -11,14 +12,12 @@ let
   # was created by the coordinator's unstable Immich (3.0.3 at migration time)
   # and its schema must never run under an older server (stable had 2.7.5).
   # So the media stack's version-coupled piece — Immich module + package —
-  # comes from the main unstable input and keeps riding it through the daily
-  # fleet auto-update, exactly like the data expects. Navidrome, Plex,
-  # PostgreSQL 17 and vectorchord were identical across both pins when this
-  # was wired (2026-08-02); they stay stable-sourced.
-  unstablePkgs = import inputs.nixpkgs {
-    inherit (pkgs.stdenv.hostPlatform) system;
-    config.allowUnfree = true;
-  };
+  # comes from the main unstable input (`unstablePkgs`, see
+  # ./unstable-pkgs.nix) and keeps riding it through the daily fleet
+  # auto-update, exactly like the data expects. Navidrome, Plex, PostgreSQL 17
+  # and vectorchord were identical across both pins when this was wired
+  # (2026-08-02); they stay stable-sourced.
+  #
   # Deliberately identical to the coordinator's historical media root. Immich
   # and Navidrome can then retain every stored absolute path after restore.
   storageRoot = "/mnt/nas";

--- a/hosts/nas/phone-ingest.nix
+++ b/hosts/nas/phone-ingest.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  lib,
+  pkgs,
+  unstablePkgs,
+  ...
+}:
+# Operator tooling for pulling an Android phone's camera roll into Immich over
+# USB (#143). Deliberately NOT a service: nothing here runs on its own, starts
+# at boot, or touches the media stack. It is the set of tools a human needs
+# present on the appliance to drive a repeatable ingest by hand.
+#
+# Route is adb, not MTP: adb preserves original mtimes, resumes cleanly, and
+# gives exact per-folder file counts before and after a pull. MTP gives none of
+# that reliably across a ~2000-file camera roll.
+let
+  cfg = config.myNas.phoneIngest;
+  storageRoot = "/mnt/nas";
+  # Staging lands on the HDD photos subvolume, not the NVMe fast tier. Pulled
+  # frames are REAL USER DATA from the moment they leave the phone until they
+  # are verified into Immich — and everything under /mnt/fast is, by that
+  # tier's own doctrine (see hosts/nas/media.nix), either rebuildable or
+  # dump-protected. Neither is true of a camera roll that may already have been
+  # deleted from the handset. On photos/ it rides the subvolume's snapshot and
+  # quarterly LaCie mirror story for free, and the 4 TB HDD does not care about
+  # transient bulk the 'fast' disk would notice.
+  stagingRoot = "${storageRoot}/photos/phone-staging";
+in
+{
+  options.myNas.phoneIngest.enable = lib.mkEnableOption "adb + Immich CLI operator tooling for USB Android photo ingest";
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.myNas.storage.enable;
+        message = "myNas.phoneIngest stages into the verified myNas.storage tree";
+      }
+    ];
+
+    environment.systemPackages = [
+      # Stable-sourced with the rest of the base system: adb's wire protocol is
+      # ancient and stable, and nothing about it is coupled to Immich's version.
+      pkgs.android-tools
+      # UNSTABLE-sourced, unlike its neighbour above. The CLI's upload API is
+      # versioned with the server, and this box runs the unstable Immich 3.0.3
+      # (media.nix) because the restored database demands it. Stable carries
+      # immich-cli 2.7.5 — the exact major-version mismatch the server package
+      # is already pinned around.
+      unstablePkgs.immich-cli
+    ];
+
+    # `programs.adb.enable` does not exist anymore: NixOS 26.05 removed it
+    # (nixos/modules/rename.nix) once systemd 258 grew built-in ADB uaccess
+    # rules, and dropped the android-udev-rules package with it.
+    #
+    # Those built-in rules are not sufficient here. systemd's 70-uaccess.rules
+    # tags the device and leaves permissions to a logind ACL for the user of
+    # the ACTIVE SEAT session — but this appliance is driven over SSH from the
+    # coordinator, and an SSH session has no seat. It happens to work today
+    # only as a side effect of headless.nix's getty autologin holding an active
+    # tty1 session for the same uid; a logout, a VT switch, or dropping that
+    # autologin would silently turn every pull into "no permissions".
+    #
+    # So restore the seat-independent half of what android-udev-rules did: a
+    # group that owns the device node outright. The interface triple matches
+    # systemd's own list — dc0201 (ADB over USB debug capability), ff4201
+    # (ADB), ff4203 (fastboot). ID_USB_INTERFACES is already populated for
+    # every usb_device by 50-udev-default.rules, well before this runs.
+    users.groups.adbusers = { };
+    users.users.tom.extraGroups = [ "adbusers" ];
+    services.udev.extraRules = ''
+      SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{ID_USB_INTERFACES}=="*:dc0201:*|*:ff4201:*|*:ff4203:*", GROUP="adbusers", MODE="0660"
+    '';
+
+    # Pull target. 0700 tom users, matching photos/ itself.
+    #
+    # No Immich API key is declared anywhere in this module, on purpose: the
+    # CLI authenticates at runtime via `immich login <url> <key>` into
+    # ~/.config/immich/auth.yml, which is mutable operator state and has no
+    # business in a world-readable Nix store.
+    systemd.tmpfiles.rules = [
+      "d ${stagingRoot} 0700 tom users -"
+    ];
+  };
+}

--- a/hosts/nas/unstable-pkgs.nix
+++ b/hosts/nas/unstable-pkgs.nix
@@ -1,0 +1,19 @@
+{
+  inputs,
+  pkgs,
+  ...
+}:
+# The NAS base system rides nixpkgs-stable (#135), but a few packages are
+# version-coupled to data or to a server this box already runs and must come
+# from the main unstable input instead — currently the Immich module/package
+# (hosts/nas/media.nix) and the Immich CLI (hosts/nas/phone-ingest.nix).
+#
+# Instantiating unstable is not free, so it happens exactly once here and is
+# handed to the rest of the host as the `unstablePkgs` module argument. Doing
+# it per-file would evaluate a second full nixpkgs for every consumer.
+{
+  _module.args.unstablePkgs = import inputs.nixpkgs {
+    inherit (pkgs.stdenv.hostPlatform) system;
+    config.allowUnfree = true;
+  };
+}


### PR DESCRIPTION
Closes #143.

Primes the NAS to ingest a phone's camera roll over USB, declaratively, as a repeatable operator workflow. Two atomic commits.

## 1. `nas: hoist the unstable nixpkgs instantiation into a shared module arg`

`media.nix` instantiated `import inputs.nixpkgs` in its own `let` for the version-coupled Immich module/package. The CLI needs the same universe, and a second `import` would evaluate a whole second nixpkgs. Moved to `hosts/nas/unstable-pkgs.nix`, which sets `_module.args.unstablePkgs` once.

Pure refactor, verified: `nixosConfigurations.nas...toplevel` resolves to the **identical derivation** before and after (`rxhbj5sm...-nixos-system-nas-26.05.20260731.5b4f72e.drv`).

## 2. `nas: adb + Immich CLI + staging dir for USB Android photo ingest`

New `hosts/nas/phone-ingest.nix` behind `myNas.phoneIngest.enable`, with the storage assertion — a separate file, per the issue, because this is operator tooling and not a service. Nothing in it starts on its own.

- `android-tools` from **stable**, with the base system.
- `immich-cli` from **unstable** (3.0.3), matching the server. Stable carries 2.7.5.
- `/mnt/nas/photos/phone-staging`, `0700 tom users`.

### Staging on the HDD, per the issue's weak preference

Pulled frames are real user data from the moment they leave the phone until they are verified into Immich, and may already be gone from the handset. Everything on `/mnt/fast` is by that tier's own doctrine either rebuildable or dump-protected — neither holds for a camera roll. On `photos/` the staging tree also inherits the subvolume's snapshot and quarterly LaCie mirror story for free, and the 4 TB HDD does not notice transient bulk that the small NVMe would.

### Deviation from the issue: `programs.adb.enable` does not exist anymore

NixOS 26.05 **removed** the option (`nixos/modules/rename.nix`) once systemd 258 grew built-in ADB uaccess rules, and dropped the `android-udev-rules` package with it. Both now `throw` on the stable pin.

Those built-in rules alone are **not sufficient here**. `70-uaccess.rules` tags the device and leaves permissions to a logind ACL for the user of the *active seat session* — and this appliance is driven over SSH, which has no seat. It would work today only as a side effect of `headless.nix`'s getty autologin holding an active tty1 session for the same uid (confirmed live: session 1, tom, seat0, active). A logout, a VT switch, or dropping that autologin would silently turn every pull into `no permissions`.

So the module restores the seat-independent half of `android-udev-rules`: an `adbusers` group that owns the device node outright, with `tom` in it. The matched interface triple is systemd's own list — `dc0201` (ADB DbC), `ff4201` (ADB), `ff4203` (fastboot). `ID_USB_INTERFACES` is already populated for every `usb_device` by `50-udev-default.rules`, well before this runs. The uaccess ACL still applies on top; the group is the floor.

### Out of scope, as instructed

No API key in nix — the CLI authenticates at runtime into `~/.config/immich/auth.yml`. No pull/verify/import wrapper script; the first run gets driven by hand so the failure modes are observed before they are encoded.

`services.immich`, the `BindPaths` overlay, `mediaLocation`, the NVMe/HDD split, and the `photos/backups` exclusion are untouched.

## Verification

Full `nixosConfigurations.nas...toplevel` build is clean. Against the built closure:

- `sw/bin/adb` → android-tools 35.0.2, `sw/bin/fastboot` present
- `sw/bin/immich --version` → **3.0.3**, matching the running server
- the rule lands in `etc/udev/rules.d/99-local.rules`
- `d /mnt/nas/photos/phone-staging 0700 tom users -` in `tmpfiles.d/00-nixos.conf`
- `users.users.tom.extraGroups` includes `adbusers`; `users.groups.adbusers` declared

Everything is declarative config, so AC 5 (survives reboot) holds by construction. AC 2's `adb devices` output and AC 6 need the deployed generation and a physically attached phone; reported separately after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)