### PR TITLE
local-ai: Fara1.5-9B/4B + fara-cli, claude-code-router allowlist

### DIFF
--- a/docs/local-ai/README.md
+++ b/docs/local-ai/README.md
@@ -80,7 +80,7 @@ nix build .#checks.x86_64-linux.huggingface-cli-smoke --no-link
 | Streaming speech-to-text | Voxtype with `parakeet-unified-en-0.6b` | Coordinator-only systemd user service; local ONNX Runtime/MIGraphX on gfx1151 | Model download is an idempotent service pre-start step. |
 | Document OCR/RAG | Qwen3-VL 8B primary, 32B refine, Qwen3 Embedding 8B, Qwen3-VL Embedding 8B | Coordinator llama.cpp ROCm behind llama-swap | Active coordinator allowlist; text and multimodal embedders are complementary. |
 | Shared text and coding | Qwen 3.6 35B-A3B and stock 27B, both UD-Q8_K_XL with integrated MTP; Gemma 4 26B Q8 with matched MTP | Coordinator Vulkan behind llama-swap | Active coordinator allowlist. Qwen3-Coder-Next remains cataloged only. |
-| Computer use | Fara 1.5 27B Q8_0 plus BF16 projector | Coordinator ROCm behind llama-swap | Active coordinator allowlist. |
+| Computer use | Fara 1.5 27B/9B/4B, each Q8_0 plus matched BF16 projector | Coordinator ROCm behind llama-swap | Active coordinator allowlist; three sizes for the latency/quality tradeoff. |
 | Application utility slot | FastFlowLM Qwen3 4B behind the stable ID `utility` | `utility-model` wrapper; one start/request/stop cycle per request | Callers never name the concrete model. Projected from the catalog, not from `services.npu-llm.models`. |
 | Ad-hoc NPU inference | FastFlowLM Gemma 4 E4B and GPT-OSS 20B | Direct, ad-hoc `flm run <model>` | Installed on coordinator; no model server starts at boot and idle residency is zero. |
 | Call transcription + diarization | Microsoft VibeVoice-ASR | Future dedicated PyTorch/ROCm batch service | BF16 payload and tokenizer are Nix-rooted on coordinator; service remains future work. |

--- a/docs/local-ai/model-roster.md
+++ b/docs/local-ai/model-roster.md
@@ -63,6 +63,8 @@ advances.
 | `qwen3.6-27b` | coding | canonical | llama.cpp Vulkan, integrated MTP | **Served** | 35,776,484,480 |
 | `gemma4-26b-a4b-it` | coding | canonical | llama.cpp Vulkan, matched Q8 MTP head | **Served** | 27,321,628,544 |
 | `fara1.5-27b` | vision | canonical | llama.cpp ROCm, BF16 projector | **Served** | 29,596,213,728 |
+| `fara1.5-9b` | vision | canonical | llama.cpp ROCm, BF16 projector | **Served** | 10,467,688,096 |
+| `fara1.5-4b` | vision | canonical | llama.cpp ROCm, BF16 projector | **Served** | 5,169,523,456 |
 | `qwen3-vl-8b-ocr` | vision | canonical | llama.cpp ROCm, BF16 projector | **Served** | 9,872,089,504 |
 | `qwen3-vl-32b-ocr` | vision | canonical | llama.cpp ROCm, BF16 projector | **Served** | 36,018,055,616 |
 | `qwen3-embedding-8b` | embedding | canonical | llama.cpp ROCm, last pooling | **Served** | 8,047,105,824 |
@@ -84,26 +86,28 @@ advances.
 
 ### Reconciling the totals
 
-The catalog holds **15 deployment rows** (11 `canonical`, 4 `candidate`) and
-**23 artifacts** across **209 pinned files** totalling **382,552,147,731 bytes
-(356.28 GiB)**. That figure is the whole catalog including rows that never
+The catalog holds **17 deployment rows** (13 `canonical`, 4 `candidate`) and
+**27 artifacts** across **213 pinned files** totalling **398,189,359,283 bytes
+(370.84 GiB)**. That figure is the whole catalog including rows that never
 download.
 
-Of it, **19 artifacts / 205 files / 276,848,174,227 bytes (257.83 GiB)** are
+Of it, **23 artifacts / 209 files / 292,485,385,779 bytes (272.40 GiB)** are
 actually rooted on the coordinator — the count `flake.nix` asserts. Because the
 two Mage-Flow repositories share byte-identical components and Nix reuses those
-fixed-output paths, the real on-disk figure is **267,564,622,488 bytes
-(249.19 GiB)**; see [`mage.md`](mage.md).
+fixed-output paths, the real on-disk figure is **283,201,834,040 bytes
+(263.75 GiB)**; see [`mage.md`](mage.md).
 
 The four **Cataloged** rows account for the remaining **105,703,973,504 bytes
 (98.44 GiB)** that are never fetched.
 
 Adding the runtime-owned FastFlowLM and Voxtype payloads to the Nix-rooted
-logical total gives the 302,925,289,718-byte coordinator ledger in
-[`deployment-decisions-2026-07-29.md`](deployment-decisions-2026-07-29.md).
-That ledger predates this page's accounting of the `utility` slot and does not
-include a figure for `qwen3:4b`; FastFlowLM owns those files and the repository
-records no size for them.
+logical total gives a 318,562,501,270-byte coordinator ledger, up from the
+302,925,289,718-byte figure in
+[`deployment-decisions-2026-07-29.md`](deployment-decisions-2026-07-29.md)
+before `fara15-9b-q8-0`/`fara15-4b-q8-0` were added. That earlier ledger also
+predates this page's accounting of the `utility` slot and does not include a
+figure for `qwen3:4b`; FastFlowLM owns those files and the repository records
+no size for them.
 
 ## Pinned artifact provenance
 
@@ -118,6 +122,8 @@ revisions live in the catalog.
 | `qwen3.6-27b` | stock [`Qwen/Qwen3.6-27B@6a9e13b`](https://huggingface.co/Qwen/Qwen3.6-27B/tree/6a9e13bd6fc8f0983b9b99948120bc37f49c13e9), quantized by [`unsloth/Qwen3.6-27B-MTP-GGUF@5cb35eb`](https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF/tree/5cb35eb3dcbf52dbce5f87dbc64df6aaffadcace) |
 | `gemma4-26b-a4b-it` | [`unsloth/gemma-4-26B-A4B-it-GGUF@c099eb4`](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF/tree/c099eb48e663fd284577b04978a94ffccb261841) → `gemma-4-26B-A4B-it-Q8_0.gguf` + `MTP/mtp-gemma-4-26B-A4B-it-Q8_0.gguf` |
 | `fara1.5-27b` | [`bartowski/Fara1.5-27B-GGUF@dd7cba9`](https://huggingface.co/bartowski/Fara1.5-27B-GGUF/tree/dd7cba968d1a9c8feab0c2b85d93b117e6cc16fe) → Q8_0 + BF16 projector |
+| `fara1.5-9b` | [`bartowski/Fara1.5-9B-GGUF@153cb27`](https://huggingface.co/bartowski/Fara1.5-9B-GGUF/tree/153cb27ac91d4a2b9391ecf278542e610d040178) → Q8_0 + BF16 projector |
+| `fara1.5-4b` | [`bartowski/Fara1.5-4B-GGUF@b97f335`](https://huggingface.co/bartowski/Fara1.5-4B-GGUF/tree/b97f335231e01efbbad37bb89b5310340fc10735) → Q8_0 + BF16 projector |
 | `qwen3-vl-8b-ocr` | [`unsloth/Qwen3-VL-8B-Instruct-GGUF@b93a7ee`](https://huggingface.co/unsloth/Qwen3-VL-8B-Instruct-GGUF/tree/b93a7ee713758252c555be4210c00540df954dc2) → Q8_0 + `mmproj-BF16.gguf` |
 | `qwen3-vl-32b-ocr` | [`unsloth/Qwen3-VL-32B-Instruct-GGUF@b9262a3`](https://huggingface.co/unsloth/Qwen3-VL-32B-Instruct-GGUF/tree/b9262a359f54dead8e2609f6146e2fc3398fd0d9) → Q8_0 + `mmproj-BF16.gguf` |
 | `qwen3-embedding-8b` | [`Qwen/Qwen3-Embedding-8B-GGUF@69d0e58`](https://huggingface.co/Qwen/Qwen3-Embedding-8B-GGUF/tree/69d0e58a13e463cd99a9b83e3f5fee7c10265fab) → Q8_0 |

--- a/flake.nix
+++ b/flake.nix
@@ -1186,6 +1186,8 @@
               "qwen36-27b-mtp-ud-q8-k-xl"
               "gemma4-26b-a4b-it-mtp-q8-0"
               "fara15-27b-q8-0"
+              "fara15-9b-q8-0"
+              "fara15-4b-q8-0"
               "qwen3-vl-8b-ocr"
               "qwen3-vl-32b-ocr-refine"
               "qwen3-embedding-8b-q8-0"
@@ -1201,7 +1203,7 @@
               "vibevoice-qwen25-7b-tokenizer"
             ];
           assert
-            builtins.length (nixpkgs.lib.intersectLists modelPackagePaths coordinatorExtraDependencies) == 19;
+            builtins.length (nixpkgs.lib.intersectLists modelPackagePaths coordinatorExtraDependencies) == 23;
           assert nixpkgs.lib.all (artifact: artifact.source.layout == "snapshot") mageArtifacts;
           assert builtins.length mageFiles == 164;
           assert nixpkgs.lib.foldl' (total: file: total + file.bytes) 0 mageFiles == 45863017994;
@@ -1216,6 +1218,8 @@
           assert
             builtins.attrNames coordinatorSettings.models == [
               "fara1.5-27b"
+              "fara1.5-4b"
+              "fara1.5-9b"
               "gemma4-26b-a4b-it"
               "qwen3-embedding-8b"
               "qwen3-vl-32b-ocr"

--- a/home/home.nix
+++ b/home/home.nix
@@ -38,6 +38,7 @@ let
     "ccusage"
     "ck"
     "claude-agent-acp"
+    "claude-code-router" # bin: `ccr` — routes Claude Code requests to other model backends/providers
     "qmd"
     # NB: `pi` is intentionally absent — home/pi.nix ships a wrapped `pi` (real
     # binary + declarative extension roster) as the sole `pi` on PATH. Keeping it
@@ -475,6 +476,13 @@ in
     gst_all_1.gst-plugins-good
     gst_all_1.gst-plugins-bad
     libjxl
+  ]
+  ++ lib.optionals (hostName == "coordinator") [
+    # Reference CLI for the local Fara1.5 computer-use models (overlay pkg,
+    # see pkgs/fara-cli.nix). Drives a real Chromium tab via Playwright;
+    # point it at the coordinator's own llama-swap server, e.g.:
+    #   fara-cli --base_url http://localhost:9292/v1 --model fara1.5-9b --task "..."
+    fara-cli
   ];
 
   # nvim → implemented in ./nvim.nix (imported above).

--- a/lib/local-models.nix
+++ b/lib/local-models.nix
@@ -456,6 +456,70 @@ let
               notes = "BF16 vision projector paired with the Q8_0 Fara deployment.";
             };
 
+            fara15-9b-q8-0 = mkSingleFileArtifact {
+              maker = "Microsoft / bartowski";
+              baseCheckpoint = {
+                url = "https://huggingface.co/microsoft/Fara1.5-9B";
+                revision = "1a93677cd89d5601bc2ed759791e981f3a520032";
+              };
+              hfUrl = "https://huggingface.co/bartowski/Fara1.5-9B-GGUF";
+              revision = "153cb27ac91d4a2b9391ecf278542e610d040178";
+              path = "Fara1.5-9B-Q8_0.gguf";
+              bytes = 9545983104;
+              oid = "a2e30cca7aec006266308153ae781347505af16baa514bbd4e0e3f4a79ea3a22";
+              hash = "sha256-ouMMynrsAGJmMIFTrngTR1Ba8WuqUUu9Tg4/SnnqOiI=";
+              quantization = "Q8_0";
+              notes = "Q8_0 is an explicit operator choice for the mid-tier browser-computer-use appliance; do not silently down-quantize it.";
+            };
+
+            fara15-9b-mmproj-bf16 = mkSingleFileArtifact {
+              kind = "mmproj";
+              maker = "Microsoft / bartowski";
+              baseCheckpoint = {
+                url = "https://huggingface.co/microsoft/Fara1.5-9B";
+                revision = "1a93677cd89d5601bc2ed759791e981f3a520032";
+              };
+              hfUrl = "https://huggingface.co/bartowski/Fara1.5-9B-GGUF";
+              revision = "153cb27ac91d4a2b9391ecf278542e610d040178";
+              path = "mmproj-Fara1.5-9B-bf16.gguf";
+              bytes = 921704992;
+              oid = "42ff0ff38666cefc4b1594a05c1644fe9bfc49edfed587ec551e471e0dd8b61d";
+              hash = "sha256-Qv8P84ZmzvxLFZSgXBZE/pv8Se3+1YfsVR5HHg3Yth0=";
+              notes = "BF16 vision projector paired with the Q8_0 Fara-9B deployment.";
+            };
+
+            fara15-4b-q8-0 = mkSingleFileArtifact {
+              maker = "Microsoft / bartowski";
+              baseCheckpoint = {
+                url = "https://huggingface.co/microsoft/Fara1.5-4B";
+                revision = "776a33ae5b2ad503796a97ae20fdc66f61d2feea";
+              };
+              hfUrl = "https://huggingface.co/bartowski/Fara1.5-4B-GGUF";
+              revision = "b97f335231e01efbbad37bb89b5310340fc10735";
+              path = "Fara1.5-4B-Q8_0.gguf";
+              bytes = 4493954144;
+              oid = "943b76f8ff6893c465de5c841e5116941fe87c8863dbb759d386697faa723880";
+              hash = "sha256-lDt2+P9ok8Rl3lyEHlEWlB/ofIhj27dZ04Zpf6pyOIA=";
+              quantization = "Q8_0";
+              notes = "Q8_0 is an explicit operator choice for the small browser-computer-use appliance; do not silently down-quantize it.";
+            };
+
+            fara15-4b-mmproj-bf16 = mkSingleFileArtifact {
+              kind = "mmproj";
+              maker = "Microsoft / bartowski";
+              baseCheckpoint = {
+                url = "https://huggingface.co/microsoft/Fara1.5-4B";
+                revision = "776a33ae5b2ad503796a97ae20fdc66f61d2feea";
+              };
+              hfUrl = "https://huggingface.co/bartowski/Fara1.5-4B-GGUF";
+              revision = "b97f335231e01efbbad37bb89b5310340fc10735";
+              path = "mmproj-Fara1.5-4B-bf16.gguf";
+              bytes = 675569312;
+              oid = "703176d1c7afe714d5e323d5fbf5f62314e46c808de44d9cc99abb963039a60d";
+              hash = "sha256-cDF20cev5xTV4yPV+/X2IxTkbICN5E2cyZq7ljA5pg0=";
+              notes = "BF16 vision projector paired with the Q8_0 Fara-4B deployment.";
+            };
+
             qwen36-35b-a3b-abliterated-heretic-q4-k-m = mkSingleFileArtifact {
               maker = "Youssofal";
               baseCheckpoint = {
@@ -1006,6 +1070,62 @@ let
               evidence = "unverified";
               hardware = "Ryzen AI MAX+ 395 / gfx1151 / 128 GB unified memory";
               notes = "Browser-computer-use VLM on coordinator. Q8_0 is an explicit quality decision; the BF16 projector is mandatory.";
+            };
+
+            fara15-9b-q8-0 = {
+              model = "fara1.5-9b";
+              role = "vision";
+              status = "canonical";
+              backend = "rocm";
+              hosts = [ "coordinator" ];
+              ramTierGb = 16;
+              artifacts = {
+                model = "fara15-9b-q8-0";
+                mmproj = "fara15-9b-mmproj-bf16";
+              };
+              runtime = llamaCppRuntime [
+                "--mmproj"
+                "@mmproj@"
+                "--ctx-size"
+                "32768"
+                "--gpu-layers"
+                "999"
+                "--flash-attn"
+                "on"
+                "--no-mmap"
+                "--jinja"
+              ];
+              evidence = "unverified";
+              hardware = "Ryzen AI MAX+ 395 / gfx1151 / 128 GB unified memory";
+              notes = "Mid-tier browser-computer-use VLM on coordinator, same family and serving shape as fara1.5-27b at lower latency/RAM cost. Q8_0 is an explicit quality decision; the BF16 projector is mandatory.";
+            };
+
+            fara15-4b-q8-0 = {
+              model = "fara1.5-4b";
+              role = "vision";
+              status = "canonical";
+              backend = "rocm";
+              hosts = [ "coordinator" ];
+              ramTierGb = 8;
+              artifacts = {
+                model = "fara15-4b-q8-0";
+                mmproj = "fara15-4b-mmproj-bf16";
+              };
+              runtime = llamaCppRuntime [
+                "--mmproj"
+                "@mmproj@"
+                "--ctx-size"
+                "32768"
+                "--gpu-layers"
+                "999"
+                "--flash-attn"
+                "on"
+                "--no-mmap"
+                "--jinja"
+              ];
+              evidence = "unverified";
+              hardware = "Ryzen AI MAX+ 395 / gfx1151 / 128 GB unified memory";
+              notes = "Smallest browser-computer-use VLM on coordinator, same family and serving shape as fara1.5-27b/9b at the lowest latency/RAM cost. Q8_0 is an explicit quality decision; the BF16 projector is mandatory.";
             };
 
             qwen36-35b-abliterated-heretic = {

--- a/modules/strix.nix
+++ b/modules/strix.nix
@@ -30,6 +30,8 @@
         "qwen36-27b-mtp-ud-q8-k-xl"
         "gemma4-26b-a4b-it-mtp-q8-0"
         "fara15-27b-q8-0"
+        "fara15-9b-q8-0"
+        "fara15-4b-q8-0"
         "qwen3-vl-8b-ocr"
         "qwen3-vl-32b-ocr-refine"
         "qwen3-embedding-8b-q8-0"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -131,4 +131,9 @@ final: prev: {
   # Bounded academic OCR appliance: deterministic PDF mechanics, the tally
   # mutation-ladder driver, and canonical/chunk/embed/index receipt stages.
   academic-ocr = final.callPackage ../pkgs/academic-ocr { };
+
+  # Reference CLI for Microsoft's Fara1.5 computer-use-agent models. Not in
+  # nixpkgs; upstream ships no release tags, so this pins the exact commit
+  # cloned 2026-08-03. See pkgs/fara-cli.nix.
+  fara-cli = final.callPackage ../pkgs/fara-cli.nix { };
 }

--- a/pkgs/browserbase.nix
+++ b/pkgs/browserbase.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+# Not in nixpkgs (2026-08-03). Only transitive dependency `fara-cli` needs it
+# for: microsoft/fara imports `browserbase` unconditionally at module load
+# (src/fara/fara_7b/browser/browser_bb.py), even though the local Playwright
+# path never calls into it. A plain Stainless-generated OpenAI-style SDK
+# client; packaging it directly is simpler than patching upstream's import.
+python3Packages.buildPythonPackage rec {
+  pname = "browserbase";
+  version = "1.15.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-04Yd5bvsOGAyOIENr2vEnTY3vezgrQ53A1Gf/35471I=";
+  };
+
+  # Upstream's build-system pin (hatchling==1.26.3) is stricter than the
+  # dependency pin relaxed by pythonRelaxDeps below, and only applies before
+  # the package's own build backend runs, so drop it by hand.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'hatchling==1.26.3' 'hatchling'
+  '';
+
+  build-system = with python3Packages; [
+    hatchling
+    hatch-fancy-pypi-readme
+  ];
+
+  dependencies = with python3Packages; [
+    anyio
+    distro
+    httpx
+    pydantic
+    sniffio
+    typing-extensions
+  ];
+
+  pythonImportsCheck = [ "browserbase" ];
+
+  meta = {
+    description = "Python SDK for the Browserbase headless-browser API";
+    homepage = "https://pypi.org/project/browserbase/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/fara-cli.nix
+++ b/pkgs/fara-cli.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  playwright-driver,
+  callPackage,
+}:
+
+let
+  # markitdown -> pdfplumber -> pandas-stubs, whose own test suite fails
+  # against this nixpkgs pin's pytest (unrelated pre-existing breakage:
+  # PytestRemovedIn10Warning from parametrize-with-a-generator in
+  # pandas-stubs' vendored pandas test copies). overrideScope threads the
+  # unchecked build through every consumer in this package set.
+  pyPkgs = python3Packages.overrideScope (
+    _pyfinal: pyprev: {
+      pandas-stubs = pyprev.pandas-stubs.overridePythonAttrs (_: {
+        doCheck = false;
+        pythonImportsCheck = [ ];
+      });
+    }
+  );
+  browserbase = callPackage ./browserbase.nix { python3Packages = pyPkgs; };
+in
+# microsoft/fara — the reference CLI for the Fara1.5 computer-use-agent
+# models (fara15-27b-q8-0 / fara15-9b-q8-0 / fara15-4b-q8-0 in
+# lib/local-models.nix). It drives a real Chromium tab through Playwright,
+# steered by an OpenAI-compatible chat endpoint; point it at the
+# coordinator's own llama-swap server with --base_url/--model (see
+# home/home.nix). No upstream release tags exist yet, so this pins the
+# exact commit cloned 2026-08-03.
+pyPkgs.buildPythonApplication rec {
+  pname = "fara";
+  version = "0-unstable-2026-07-22";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "fara";
+    rev = "a675d6d61c41c47ae87bacefeab22caad18e3e84";
+    hash = "sha256-TexN3pzrfdFYWO4+E6CEHk90WZs0Ceztp1Sdbss60Tk=";
+  };
+
+  build-system = [ pyPkgs.hatchling ];
+
+  # Upstream pins playwright==1.51; nixpkgs carries a newer 1.x release and
+  # the two speak the same wire protocol against playwright-driver's browser
+  # binaries below, so relax rather than vendor a second Playwright.
+  pythonRelaxDeps = [ "playwright" ];
+
+  dependencies = with pyPkgs; [
+    playwright
+    openai
+    pillow
+    tenacity
+    pyyaml
+    jsonschema
+    browserbase
+    pydantic
+    markitdown
+    tiktoken
+  ];
+
+  # Fara only ever launches `browser_channel="chromium"` (run_fara.py); skip
+  # firefox/webkit and point Playwright at the Nix-built binary instead of
+  # its own mutable ~/.cache download.
+  makeWrapperArgs = [
+    "--set"
+    "PLAYWRIGHT_BROWSERS_PATH"
+    "${playwright-driver.browsers-chromium}"
+    "--set"
+    "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"
+    "1"
+  ];
+
+  pythonImportsCheck = [ "fara" ];
+
+  meta = {
+    description = "Reference CLI/agent harness for Microsoft's Fara1.5 computer-use models";
+    homepage = "https://github.com/microsoft/fara";
+    license = lib.licenses.mit;
+    mainProgram = "fara-cli";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `fara15-9b-q8-0` and `fara15-4b-q8-0` to the local-model catalog and coordinator allowlist — Q8_0 GGUF + matched BF16 vision projector from bartowski, same ROCm/llama.cpp serving shape as the existing `fara1.5-27b`, exposed as `fara1.5-9b` / `fara1.5-4b` in llama-swap.
- Packages `fara-cli` (`pkgs/fara-cli.nix`), Microsoft's reference CUA harness for the Fara1.5 family (drives a real Chromium tab via Playwright against an OpenAI-compatible endpoint), pinned to a commit since upstream ships no release tags. Includes a small local `browserbase` package (`pkgs/browserbase.nix`) for an otherwise-unconditional import upstream makes.
- Adds `claude-code-router` (`ccr`) to the curated `llm-agents.nix` allowlist in `home/home.nix`.
- Updates `docs/local-ai/README.md` and `docs/local-ai/model-roster.md` catalog totals accordingly.

## Test plan
- [x] `nix flake check` passes, including the `local-model-routing` assertion suite (allowlist, byte/artifact counts, quantization policy)
- [x] `nix build .#nixosConfigurations.coordinator.pkgs.fara-cli` builds and `fara-cli --help` runs, with `PLAYWRIGHT_BROWSERS_PATH`/`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` wired into the wrapper
- [x] `nix build .#nixosConfigurations.coordinator.config.system.build.toplevel` builds clean and fetches both new Fara GGUFs + projectors as fixed-output derivations

🤖 Generated with [Claude Code](https://claude.com/claude-code)