### PR TITLE
academic-drain: mech-first shortcut — skip VLM OCR on pages with a clean text layer

### DIFF
--- a/pkgs/academic-ocr-drain/assemble.sh
+++ b/pkgs/academic-ocr-drain/assemble.sh
@@ -7,7 +7,7 @@ dir="$1"; uuid="$2"; sha="$3"; title="$4"; out="$5"; shift 5
 mkdir -p "$(dirname "$out")"
 tmp="$out.tmp.$$"
 {
-  printf -- '---\nuuid: %s\ntitle: "%s"\nsha256: %s\npipeline: tally-flow-e2e-2026-07-29\n---\n' "$uuid" "$title" "$sha"
+  printf -- '---\nuuid: %s\ntitle: "%s"\nsha256: %s\npipeline: tally-flow-e2e-2026-08-04\n---\n' "$uuid" "$title" "$sha"
   for spec in "$@"; do
     page="${spec%%:*}"; src="${spec#*:}"
     case "$src" in

--- a/pkgs/academic-ocr-drain/compare.sh
+++ b/pkgs/academic-ocr-drain/compare.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# compare.sh <mech-txt> <vlm-md> <out-verdict-json> <min-agreement-permille>
+# compare.sh <ref-txt> <cand-txt> <out-verdict-json> <min-agreement-permille> [min-words]
 # Dice coefficient over normalized word multisets. Exit 3 when below threshold —
 # the failed verdict is the flow's routing signal to the specialist lane.
+# min-words (default 0) additionally fails any side under the floor; the
+# mech-first shortcut (dotfiles#147) uses it to route sparse-text-layer pages
+# (figures, covers) to the VLM lane even when both engines agree.
 set -euo pipefail
 . "$(dirname "$0")/env.sh"
-mech="$1"; vlm="$2"; out="$3"; min="$4"
+mech="$1"; vlm="$2"; out="$3"; min="$4"; minwords="${5:-0}"
 mkdir -p "$(dirname "$out")"
 norm() { "$CORE/tr" '[:upper:]' '[:lower:]' < "$1" | "$CORE/tr" -cs '[:alnum:]' '\n' | "$AWK" 'length($0)>=2' | "$CORE/sort"; }
 norm "$mech" > "$out.a.$$"
@@ -24,6 +27,10 @@ if [ "$na" -ge 200 ] && [ $((nb * 1000)) -lt $((600 * na)) ]; then
 fi
 "$JQ" -n --argjson a "$agree" --argjson na "$na" --argjson nb "$nb" --argjson c "$common" --argjson t "$truncated" \
   '{agreementPermille: $a, refWords: $na, candWords: $nb, commonWords: $c, truncationSuspected: $t}' > "$out"
+if [ "$na" -lt "$minwords" ] || [ "$nb" -lt "$minwords" ]; then
+  echo "word floor: ref=$na cand=$nb below min-words $minwords" >&2
+  exit 3
+fi
 if [ "$truncated" = true ]; then
   echo "candidate $nb words < 60% of reference $na words: truncation suspected" >&2
   exit 3

--- a/pkgs/academic-ocr-drain/default.nix
+++ b/pkgs/academic-ocr-drain/default.nix
@@ -22,7 +22,7 @@
 }:
 stdenvNoCC.mkDerivation {
   pname = "academic-ocr-drain";
-  version = "2026-07-29";
+  version = "2026-08-04";
   src = builtins.path {
     path = ./.;
     name = "academic-ocr-drain-src";

--- a/pkgs/academic-ocr-drain/drain.sh
+++ b/pkgs/academic-ocr-drain/drain.sh
@@ -58,12 +58,17 @@ while IFS= read -r line; do
     log "free space ${free_gb}G below floor ${MIN_FREE_GB}G; stopping"; break
   fi
 
+  # mechSelfAgreementPermille/mechMinWords calibrated on 2,374 already-drained
+  # pages (2026-08-04, dotfiles#147): 930/200 shortcuts 78% of pages with 0.3%
+  # residual mech-vs-VLM disagreement — the floor, not the Dice gate, is the
+  # safety-critical half.
   args_file="$DRAIN/args/$db_id.json"
   "$JQ" --arg dataRoot "$DATA_ROOT" --arg tools "$SELF" --arg bash "$BASH_BIN" '{
     paperId: .db_id, title: .title, sourceUrl: .file_url, sha256: .sha256,
     pageCount: .pages, dataRoot: $dataRoot, tools: $tools, bash: $bash,
     dpi: 200, ocrModel: "qwen3-vl-8b-ocr", refineModel: "qwen3-vl-32b-ocr",
-    embedModel: "qwen3-embedding-8b", minAgreementPermille: 700
+    embedModel: "qwen3-embedding-8b", minAgreementPermille: 700,
+    mechSelfAgreementPermille: 930, mechMinWords: 200
   }' <<<"$line" >"$args_file"
 
   run_id_file="$DRAIN/run-ids/$db_id"
@@ -71,7 +76,9 @@ while IFS= read -r line; do
   run_id=$("$CORE/cat" "$run_id_file")
 
   log "start $db_id pages=$pages run_id=$run_id"
-  max_nodes=$((6 * pages + 30))
+  # Worst case per page since the mech-first shortcut (dotfiles#147):
+  # mech + cmpmech + raster + vlm8b + cmp8b + vlm32b + cmp32b = 7 nodes.
+  max_nodes=$((7 * pages + 30))
   # One file per attempt, appended to the paper's log afterwards: the
   # supersede check below must only ever see THIS attempt's output, or a
   # historical args-changed error in the accumulated log would rotate the
@@ -91,13 +98,14 @@ while IFS= read -r line; do
       >>"$DRAIN/completed.jsonl"
     log "done $db_id ($ran this session)"
   else
-    # A tally pin advance can change the flow-args canonicalization, making
-    # every in-flight run's recorded pin unresolvable (FlowReplayError
-    # args-changed-mid-run, resolution "supersede" — first seen 2026-08-03,
-    # tally.nix#371 class). That is not a systemic failure: rotate the run id
-    # so the paper restarts fresh next time, and keep draining.
-    if "$GREP" -q '"code":"args-changed-mid-run"' "$attempt_log"; then
-      log "SUPERSEDE $db_id: flow-run pin invalidated by a tally pin advance; rotating run id"
+    # A tally pin advance can change the flow-args canonicalization, and a
+    # flow-script ship changes the script pin: either makes every in-flight
+    # run's recorded pin unresolvable (FlowReplayError, resolution
+    # "supersede" — args variant first seen 2026-08-03, tally.nix#371 class;
+    # script variant on the 2026-08-04 mech-first ship). Not a systemic
+    # failure: rotate the run id so the paper restarts fresh, keep draining.
+    if "$GREP" -qE '"code":"(args|script)-changed-mid-run"' "$attempt_log"; then
+      log "SUPERSEDE $db_id: flow-run pin invalidated (flow script or args changed); rotating run id"
       "$CORE/rm" -f "$run_id_file" "$attempt_log"
       continue
     fi

--- a/pkgs/academic-ocr-drain/paper-e2e.js
+++ b/pkgs/academic-ocr-drain/paper-e2e.js
@@ -1,7 +1,7 @@
 export const meta = {
   name: "paper-e2e",
   description:
-    "One paper end-to-end: fetch, per-page mechanical + VLM consensus OCR, assemble, chunk, embed, index, receipt",
+    "One paper end-to-end: fetch, per-page mech-first OCR with VLM consensus fallback, assemble, chunk, embed, index, receipt",
   pools: ["coordinator-gpu", "flow-build"],
   argsSchema: {
     type: "object",
@@ -18,7 +18,9 @@ export const meta = {
       "ocrModel",
       "refineModel",
       "embedModel",
-      "minAgreementPermille"
+      "minAgreementPermille",
+      "mechSelfAgreementPermille",
+      "mechMinWords"
     ],
     properties: {
       paperId: { type: "string", pattern: "^[0-9a-f-]{36}$" },
@@ -33,12 +35,14 @@ export const meta = {
       ocrModel: { type: "string", minLength: 1 },
       refineModel: { type: "string", minLength: 1 },
       embedModel: { type: "string", minLength: 1 },
-      minAgreementPermille: { type: "integer", minimum: 0, maximum: 1000 }
+      minAgreementPermille: { type: "integer", minimum: 0, maximum: 1000 },
+      mechSelfAgreementPermille: { type: "integer", minimum: 0, maximum: 1000 },
+      mechMinWords: { type: "integer", minimum: 0 }
     },
     additionalProperties: false
   },
-  maxNodes: 10000,
-  iterationCap: 10000,
+  maxNodes: 11000,
+  iterationCap: 11000,
   selectors: []
 };
 
@@ -61,13 +65,6 @@ async function resolvePage(page) {
   const vlm8b = `${root}/vlm/${p}.md`;
   const vlm32b = `${root}/refine/${p}.md`;
 
-  await run("raster", [blob, String(page), String(args.dpi), png], {
-    pools: ["flow-build"],
-    key: `raster-${p}`,
-    label: `raster-${p}`,
-    evidence: ["exit:0", `artifact:${png}`, "hash:sha256"]
-  });
-
   const mech = await run("mech", [blob, String(page), mechDir], {
     pools: ["flow-build"],
     key: `mech-${p}`,
@@ -77,6 +74,45 @@ async function resolvePage(page) {
   });
   const mechOk = mech.verdict === "pass" && !mech.error;
   const mechRef = `${mechDir}/poppler.txt`;
+
+  // Mech-first shortcut (dotfiles#147): when the two mechanical engines agree
+  // with each other AND both cleared the word floor, the digital text layer is
+  // the page — resolve without rendering or any GPU node. The floor, not the
+  // Dice gate, is what excludes sparse-layer pages (figures, covers, UI-chrome
+  // print-to-PDFs) whose engines agree perfectly on text that doesn't cover
+  // the visual content; compare.sh's truncation guard stays live because the
+  // floor keeps every shortcut reference voucher-eligible.
+  if (mechOk) {
+    const self = await run(
+      "compare",
+      [
+        mechRef,
+        `${mechDir}/mupdf.txt`,
+        `${root}/verdicts/${p}-mech.json`,
+        String(args.mechSelfAgreementPermille),
+        String(args.mechMinWords)
+      ],
+      {
+        pools: ["flow-build"],
+        key: `cmpmech-${p}`,
+        label: `cmpmech-${p}`,
+        evidence: ["exit:0", `artifact:${root}/verdicts/${p}-mech.json`, "hash:sha256"],
+        settle: true
+      }
+    );
+    if (self.verdict === "pass" && !self.error) {
+      return { page, source: "mech" };
+    }
+  }
+
+  // VLM lane: mech failed closed (scanned page) or the engines disagreed.
+  // Only now is the page render needed.
+  await run("raster", [blob, String(page), String(args.dpi), png], {
+    pools: ["flow-build"],
+    key: `raster-${p}`,
+    label: `raster-${p}`,
+    evidence: ["exit:0", `artifact:${png}`, "hash:sha256"]
+  });
 
   const ocr = await run("vlm", [png, args.ocrModel, vlm8b], {
     pools: ["coordinator-gpu"],


### PR DESCRIPTION
Closes #147.

`resolvePage()` now runs `mech` first; when poppler and mupdf both clear a word floor and agree with each other (Dice, reusing `compare.sh`), the page resolves as `source:mech` with no render and no GPU node. Raster moves inside the VLM lane, so shortcut pages produce no PNG at all. Fallback to the existing vlm8b → compare → vlm32b ladder is unchanged for scanned pages, sparse text layers, and engine disagreement.

## Threshold calibration (2,374 already-drained pages)

| thr | floor | coverage | mech-vs-VLM <700‰ residual |
|---|---|---|---|
| 930 | 0 | 90.9% | 2.1% |
| **930** | **200** | **77.8%** | **0.3%** |
| 970 | 0 | 69.1% | 2.4% |

The floor, not the Dice gate, is the safety-critical half: the bad tail (figure pages, covers, LinkedIn-style print-to-PDFs) self-agrees at a perfect 1000‰ on a text layer that doesn't cover the visual content, but runs sparse. All 6 residual pages at 930/200 resolved `vlm32b-disputed` under the old flow anyway. The floor also keeps `compare.sh`'s #127 truncation guard voucher-eligible on every shortcut page.

## Also fixed

`drain.sh`'s supersede handler only matched `args-changed-mid-run`; shipping a new flow script pins out every persisted run-id with `script-changed-mid-run`, which burned the 3-consecutive-failure fuse instead of rotating. Now both variants rotate.

## Live validation on the coordinator

Two 11-page papers drained end-to-end on the built package: **51s and 101s wall-clock vs ~13min at the old pace**. 21/22 pages resolved `mech`; the one page under the word floor (159 words) correctly took the VLM lane (exactly one render produced, resolved `vlm8b`); supersede rotation observed once on the stale-pinned paper; absorb epilogue committed both to notes.

At ~78% shortcut coverage the remaining 3,003-paper / ~193k-page queue drops from an estimated ~145–170 GPU-days to roughly 3–4 weeks of GPU-bound work, dominated by the genuinely-scanned minority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)