### PR TITLE
Paperless v3 as a same-inode PDF projection on the NAS — staged, gates off

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -842,6 +842,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-paperless": {
+      "locked": {
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
         "lastModified": 1785491804,
@@ -1001,6 +1017,7 @@
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_5",
         "nixpkgs-fresh": "nixpkgs-fresh",
+        "nixpkgs-paperless": "nixpkgs-paperless",
         "nixpkgs-stable": "nixpkgs-stable",
         "ntm": "ntm",
         "piri": "piri",

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,17 @@
     # `nix flake update nixpkgs-stable` on the same few-years cadence.
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-26.05";
 
+    # nixpkgs-paperless — pins ONLY the NAS Paperless v3 module+package
+    # (#136, hosts/nas/paperless.nix): the stable-pinned NAS needs v3 (stable
+    # has 2.20.15, and 2.x is ruled out), the main pin deliberately lags, and
+    # nixpkgs-fresh is a nightly ROLLING resolver — the wrong risk profile
+    # for a database with schema migrations. A fixed rev makes Paperless
+    # upgrades a deliberate one-line bump reviewed like any other change.
+    # Pinned rev = nixos-unstable on 2026-08-04, paperless-ngx 3.0.4
+    # (upstream latest stable is 3.0.5, 2026-08-01, not yet in nixpkgs; bump
+    # this rev when it lands).
+    nixpkgs-paperless.url = "github:NixOS/nixpkgs/e72e4f299401a3689d4b3d5fc6496b11db7064eb";
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -563,6 +574,8 @@
           assert !nas.myNas.backups.enable; # ws2b hosts/nas/backups.nix
           assert !nas.myNas.archive.enable; # ws4  hosts/nas/archive.nix
           assert !nas.myNas.attic.enable; # ws5  hosts/nas/attic.nix
+          assert !nas.myNas.paperless.enable; # #136 hosts/nas/paperless.nix
+          assert !nas.services.paperless.enable;
           assert !coordinator.myNasClient.relayAttic;
           # `or false` because hosts/coordinator/backups.nix is not in
           # hosts/coordinator/default.nix's imports yet — that one line is
@@ -577,6 +590,8 @@
           # together: a relay pointing at a service that is off is a black
           # hole, and a backend with no relay is unreachable from the tailnet.
           assert nas.myNas.attic.enable == coordinator.myNasClient.relayAttic;
+          # Paperless backend and its tailnet relay flip together (#136).
+          assert nas.myNas.paperless.enable == coordinator.myNasClient.relayPaperless;
           # The binary cache can only live in one place: moving it to the NAS
           # requires the coordinator's own atticd to go away in the same
           # commit, because both bind tcp/8080 on the coordinator (the relay
@@ -586,6 +601,35 @@
           # The borg client is useless without the repo server it pushes to.
           assert (coordinator.myCoordinatorBackups.enable or false) -> nas.myNas.backups.enable;
           pkgs.runCommand "nas-topology" { } ''
+            touch "$out"
+          '';
+
+        # #136 gate-then-verify: evaluate the ENABLED Paperless shape without
+        # deploying it, so the gate flip is an eval-proven one-liner. Same
+        # extendModules simulation technique the NAS cutover used pre-#131.
+        nas-paperless-staged =
+          let
+            nasOn =
+              (self.nixosConfigurations.nas.extendModules {
+                modules = [ { myNas.paperless.enable = true; } ];
+              }).config;
+          in
+          assert nasOn.services.paperless.enable;
+          # v3 only — a 2.x here means the nixpkgs-paperless input regressed.
+          assert pkgs.lib.versionAtLeast nasOn.services.paperless.package.version "3";
+          # PDFs only: no Tika/Gotenberg, no persistent PDF/A twin, no NAS AI.
+          assert !nasOn.services.paperless.configureTika;
+          assert nasOn.services.paperless.settings.PAPERLESS_ARCHIVE_FILE_GENERATION == "never";
+          assert nasOn.services.paperless.settings.PAPERLESS_OCR_MODE == "auto";
+          assert nasOn.services.paperless.settings.PAPERLESS_AI_ENABLED == false;
+          # Same-subvolume storage contract for the hardlink projection.
+          assert nasOn.services.paperless.consumptionDir == "/mnt/nas/documents/.paperless-consume";
+          assert nasOn.services.paperless.mediaDir == "/mnt/nas/services/paperless/media";
+          assert nasOn.fileSystems ? "/mnt/nas/services/paperless/media/documents/originals";
+          # Enabling Paperless must not grow the NAS a Tailscale identity.
+          assert !nasOn.services.tailscale.enable;
+          assert nasOn.services.paperless.database.createLocally;
+          pkgs.runCommand "nas-paperless-staged" { } ''
             touch "$out"
           '';
 

--- a/hosts/coordinator/nas-client.nix
+++ b/hosts/coordinator/nas-client.nix
@@ -33,6 +33,7 @@ in
     # Separate gates, not additions to relayMedia: relayMedia is LIVE, and each
     # of these turns on with its own NAS-side gate in its own commit.
     relayAttic = lib.mkEnableOption "relaying the fleet binary cache to atticd on the NAS (#130 ws5)";
+    relayPaperless = lib.mkEnableOption "relaying tailnet Paperless traffic to the Ethernet-only NAS (#136)";
   };
 
   config = lib.mkMerge [
@@ -269,6 +270,48 @@ in
 
       # Same boundary hosts/coordinator/attic.nix used: mesh only, never wifi.
       networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 8080 ];
+    })
+
+    # ── #136: Paperless relay ───────────────────────────────────────────────
+    # The durable tailnet front door for the NAS-hosted Paperless backend:
+    # a declarative Caddy route (paperless.internal, same .internal doctrine
+    # as the media front doors above) plus a port relay. Like attic, no wake
+    # proxy — Paperless is always-on on the NAS (consumer + scheduler; see
+    # the exception note in hosts/nas/paperless.nix). Deliberately NOT a TTL
+    # artifact drop-dir entry: this route outlives any artifact sweep.
+    (lib.mkIf cfg.relayPaperless {
+      systemd.sockets.paperless-relay = {
+        description = "Coordinator front door for NAS Paperless";
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = "0.0.0.0:28981";
+          NoDelay = true;
+        };
+      };
+      systemd.services.paperless-relay = {
+        description = "Relay Paperless to nas:28981 over the private link";
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        serviceConfig = {
+          ExecStart = "${socketProxyd} nas:28981";
+          DynamicUser = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProtectHome = true;
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+          ];
+        };
+      };
+
+      networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ 28981 ];
+
+      services.caddy.virtualHosts."http://paperless.internal".extraConfig = ''
+        reverse_proxy 127.0.0.1:28981
+      '';
     })
   ];
 }

--- a/hosts/nas/default.nix
+++ b/hosts/nas/default.nix
@@ -22,6 +22,7 @@
     ./backups.nix # ws2b append-only borg repo server
     ./archive.nix # ws4  cold archive subvolume for retired model weights
     ./attic.nix # ws5  fleet binary cache, relayed by the coordinator
+    ./paperless.nix # #136 Paperless v3 same-inode PDF projection, gate OFF
     ../../modules/adguardhome.nix
     inputs.nixos-hardware.nixosModules.common-cpu-amd
     inputs.nixos-hardware.nixosModules.common-pc

--- a/hosts/nas/paperless.nix
+++ b/hosts/nas/paperless.nix
@@ -1,0 +1,257 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+# Paperless-ngx v3 as the human-facing PDF catalog (#136): a same-inode
+# PROJECTION of the canonical /mnt/nas/documents tree, never a second payload
+# copy. The stable-pinned NAS gets module AND package from the dedicated
+# `nixpkgs-paperless` input (pinned nixos-unstable rev, paperless-ngx 3.0.4
+# from upstream tag v3.0.4, src sha256-3gQtrafqr0avRkFCIlvu7apk2NUNVOFxkdhFE
+# USCz9I=) — v3 only, never the stable 2.x; upgrades happen by bumping that
+# one input deliberately, not by riding a rolling resolver (a database with
+# schema migrations must not auto-upgrade nightly like nixpkgs-fresh's
+# browser charter allows).
+#
+# Storage contract (constrains #130 subvolume decisions, already satisfied:
+# documents/ is one subvolume):
+#   /mnt/nas/documents/...                    canonical originals (tom-owned)
+#   /mnt/nas/documents/.paperless-view        Paperless originals dir — every
+#                                             file here is a HARDLINK to a
+#                                             canonical inode after relink
+#   /mnt/nas/documents/.paperless-consume     hardlink staging spool
+#   /mnt/nas/services/paperless/...           service state, db dumps, bridge
+#                                             ledger (separate subvolume)
+#   /mnt/nas/views/paperless                  read-only browsable bind of the
+#                                             view tree
+# All three document-side paths are inside the documents subvolume because
+# hardlinks cannot cross Btrfs subvolumes.
+#
+# Always-on exception (documented per the StopWhenUnneeded doctrine): unlike
+# Immich/Navidrome, Paperless keeps a consumer watching the spool and a
+# scheduler running maintenance, so socket activation would thrash it. Idle
+# RSS on the 8 GB box is a gate-flip validation measurement.
+#
+# Gate-flip runbook (walk on the real hardware, then flip
+# myNas.paperless.enable and invert the checks in flake.nix):
+#   1. mkdir the runbook dirs (tmpfiles 'z'-only doctrine, storage.nix):
+#        mkdir -m 750 /mnt/nas/documents/.paperless-view    (chown paperless)
+#        mkdir -m 770 /mnt/nas/documents/.paperless-consume (chown tom:paperless)
+#        mkdir -m 755 /mnt/nas/views
+#   2. deploy; verify paperless-web answers on 10.77.0.2:28981 from the
+#      coordinator only, and http://paperless.internal works from a tailnet
+#      client with auto-login (needs myNasClient.relayPaperless flipped in
+#      the same commit — the checks pair them).
+#   3. mint the bridge API token:
+#        paperless-manage drf_create_token tom \
+#          > /mnt/nas/services/paperless/bridge/api-token   (0600 tom)
+#   4. canary corpus admission per #136 §4: paperless-bridge scan / ingest
+#      --batch 4 / relink / verify on one born-digital academic, one scanned
+#      academic, one legacy scan, one general PDF; prove identical sha256 AND
+#      identical st_dev:st_ino for canonical + projected paths.
+#   5. measure idle/import RSS + disk wakeups alongside Immich/Navidrome
+#      before bulk admission; bulk-ingest in bounded batches afterwards.
+let
+  cfg = config.myNas.paperless;
+  storageRoot = "/mnt/nas";
+  documentsRoot = "${storageRoot}/documents";
+  serviceRoot = "${storageRoot}/services/paperless";
+  viewDir = "${documentsRoot}/.paperless-view";
+  spoolDir = "${documentsRoot}/.paperless-consume";
+  # Lazy: only forced when the gate is on.
+  paperlessPkgs = import inputs.nixpkgs-paperless {
+    inherit (pkgs.stdenv.hostPlatform) system;
+  };
+  bridge = pkgs.callPackage ../../pkgs/paperless-bridge { };
+  paperlessUnits = [
+    "paperless-scheduler.service"
+    "paperless-consumer.service"
+    "paperless-web.service"
+    "paperless-task-queue.service"
+  ];
+in
+{
+  # Swap in the v3-era module unconditionally (imports cannot depend on
+  # cfg.enable); it stays inert while services.paperless.enable is false.
+  # Same pattern as the unstable Immich swap in ./media.nix.
+  disabledModules = [ "services/misc/paperless.nix" ];
+  imports = [ "${inputs.nixpkgs-paperless}/nixos/modules/services/misc/paperless.nix" ];
+
+  options.myNas.paperless.enable = lib.mkEnableOption "Paperless-ngx v3 as the same-inode PDF projection of /mnt/nas/documents (#136)";
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.myNas.storage.enable;
+        message = "myNas.paperless requires the verified myNas.storage mount";
+      }
+      {
+        assertion = lib.versionAtLeast config.services.paperless.package.version "3";
+        message = "myNas.paperless is a v3-only deployment (#136); a 2.x package means the nixpkgs-paperless input regressed";
+      }
+    ];
+
+    services.paperless = {
+      enable = true;
+      package = paperlessPkgs.paperless-ngx;
+      dataDir = "${serviceRoot}/data";
+      mediaDir = "${serviceRoot}/media";
+      consumptionDir = spoolDir;
+      # The bridge (running as tom) hardlinks into the spool; this keeps the
+      # module from clamping the directory to the service user.
+      consumptionDirIsPublic = true;
+      # Wildcard bind + nftables scoping, NOT a 10.77.0.2 bind: binding the
+      # cable address raced address assignment at boot (hit live on nfsd,
+      # storage.nix). The firewall rule below is the actual access control.
+      address = "0.0.0.0";
+      port = 28981;
+      passwordFile = "${serviceRoot}/admin-password";
+      database.createLocally = true;
+      # configureTika stays default-false: no Tika/Gotenberg, PDFs only (#136).
+      settings = {
+        PAPERLESS_ADMIN_USER = "tom";
+        # Tailscale is the access boundary; auto-login only removes the second
+        # UI login, everything else (secret key, admin bootstrap, API tokens,
+        # CSRF) stays real.
+        PAPERLESS_AUTO_LOGIN_USERNAME = "tom";
+        PAPERLESS_URL = "http://paperless.internal";
+        PAPERLESS_ALLOWED_HOSTS = "paperless.internal,nas,10.77.0.2,127.0.0.1,localhost";
+        PAPERLESS_CSRF_TRUSTED_ORIGINS = "http://paperless.internal";
+        # Embedded text is extracted directly; only true scans get the cheap
+        # Tesseract baseline — and no PDF/A twin is ever persisted. The web
+        # viewer serves the original (= canonical) bytes.
+        PAPERLESS_OCR_MODE = "auto";
+        PAPERLESS_ARCHIVE_FILE_GENERATION = "never";
+        # Defer the LLM/vector index: it is built once, deliberately, after
+        # the bulk enrichment pass converges (#136), and any AI runs through
+        # coordinator llama-swap — never model weights on this box.
+        PAPERLESS_AI_ENABLED = false;
+        # 8 GB box shared with Immich/Navidrome/Plex: modest fixed concurrency.
+        PAPERLESS_TASK_WORKERS = 1;
+        PAPERLESS_THREADS_PER_WORKER = 2;
+        PAPERLESS_WEBSERVER_WORKERS = 2;
+        # Browsable view-tree paths for the projection (storage-path renames
+        # move only the hardlink directory entry; canonical never moves).
+        PAPERLESS_FILENAME_FORMAT = "{{ document_type }}/{{ created_year }}/{{ title }}";
+      };
+    };
+
+    # Paperless's "originals" are the hidden view tree on the documents
+    # subvolume, so the relink helper can hardlink them to canonical inodes.
+    # Thumbnails and the rest of mediaDir stay real service state.
+    fileSystems."${serviceRoot}/media/documents/originals" = {
+      device = viewDir;
+      fsType = "none";
+      options = [
+        "bind"
+        "nofail"
+        "x-systemd.requires-mounts-for=${storageRoot}"
+      ];
+    };
+    # Human-browsable, read-only face of the projection.
+    fileSystems."${storageRoot}/views/paperless" = {
+      device = viewDir;
+      fsType = "none";
+      options = [
+        "bind"
+        "ro"
+        "nofail"
+        "x-systemd.requires-mounts-for=${storageRoot}"
+      ];
+    };
+
+    systemd.services =
+      lib.genAttrs (map (lib.removeSuffix ".service") paperlessUnits) (_: {
+        unitConfig.RequiresMountsFor = [ storageRoot ];
+      })
+      // {
+        # First-boot admin credential, generated on the box like the module's
+        # own secret key — never a committed secret (mySecrets stays off, #136).
+        paperless-admin-password = {
+          description = "Generate the Paperless admin bootstrap password once";
+          wantedBy = [ "multi-user.target" ];
+          before = paperlessUnits;
+          unitConfig.RequiresMountsFor = [ storageRoot ];
+          serviceConfig.Type = "oneshot";
+          script = ''
+            f='${serviceRoot}/admin-password'
+            if [ ! -s "$f" ]; then
+              (umask 077; ${pkgs.openssl}/bin/openssl rand -base64 24 > "$f")
+              chown ${config.services.paperless.user}:${config.services.paperless.user} "$f"
+            fi
+          '';
+        };
+
+        # Nightly pg_dump of the paperless DB to the HDD services subvolume,
+        # same doctrine and retention as nas-db-dump in ./media.nix (the
+        # postgres dataDir lives on the NVMe fast tier). The full
+        # document-exporter snapshot is deliberately NOT enabled here: with
+        # originals it would be a same-disk payload copy of the whole corpus —
+        # it belongs on the #130 backup target when that gate flips.
+        paperless-db-dump = {
+          description = "Nightly pg_dump of the paperless database to the HDD";
+          requires = [ "postgresql.service" ];
+          after = [ "postgresql.service" ];
+          unitConfig.RequiresMountsFor = [ storageRoot ];
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = pkgs.writeShellScript "paperless-db-dump" ''
+              set -eu
+              out="${serviceRoot}/backups/db/paperless-pg-dump-$(date +%Y%m%dT%H%M%S).sql.gz"
+              ${pkgs.util-linux}/bin/runuser -u postgres -- \
+                ${config.services.postgresql.package}/bin/pg_dump --clean --if-exists paperless \
+                | ${pkgs.gzip}/bin/gzip > "$out"
+              ls -1t ${serviceRoot}/backups/db/paperless-pg-dump-*.sql.gz \
+                | tail -n +15 | ${pkgs.findutils}/bin/xargs -r rm --
+            '';
+          };
+        };
+      };
+    systemd.timers.paperless-db-dump = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = "*-*-* 02:45:00";
+        Persistent = true;
+      };
+    };
+
+    systemd.tmpfiles.rules = [
+      "d ${serviceRoot} 0711 root root -"
+      "d ${serviceRoot}/backups 0700 root root -"
+      "d ${serviceRoot}/backups/db 0700 postgres postgres -"
+      # Bridge state (ledger, receipts, token, accepted-tag sidecars) is
+      # tom's: the bridge runs unprivileged; only the relink helper is root.
+      "d ${serviceRoot}/bridge 0700 tom users -"
+      "d ${storageRoot}/views 0755 root root -"
+      # Runbook-created ('z' adjust-only, storage.nix doctrine — a 'd' here
+      # could silently precede the documents subvolume mount):
+      "z ${viewDir} 0750 ${config.services.paperless.user} ${config.services.paperless.user} -"
+      "z ${spoolDir} 0770 tom ${config.services.paperless.user} -"
+    ];
+
+    # The bridge CLI and its narrow root helper. The sudo rule is the entire
+    # privilege surface: tom may run exactly this helper as root, which
+    # itself refuses anything not ledger-known, allowlisted, and
+    # hash-identical (pkgs/paperless-bridge/relink-helper.py).
+    environment.systemPackages = [ bridge ];
+    security.sudo.extraRules = [
+      {
+        users = [ "tom" ];
+        commands = [
+          {
+            command = "${bridge}/bin/paperless-relink-helper";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+      }
+    ];
+
+    # Backend admitted only from the coordinator's end of the /30 cable; the
+    # tailnet reaches it through the coordinator relay + Caddy front door.
+    networking.firewall.extraInputRules = ''
+      ip saddr 10.77.0.1 tcp dport 28981 accept comment "paperless from coordinator"
+    '';
+  };
+}

--- a/hosts/nas/paperless.nix
+++ b/hosts/nas/paperless.nix
@@ -53,6 +53,12 @@
 #      identical st_dev:st_ino for canonical + projected paths.
 #   5. measure idle/import RSS + disk wakeups alongside Immich/Navidrome
 #      before bulk admission; bulk-ingest in bounded batches afterwards.
+#   6. (future AI phase only) llama-swap's firewall admits tailscale0 ONLY
+#      (modules/llama-swap.nix) — the NAS cannot reach 10.77.0.1:9292 until
+#      a coordinator-side rule admits the /30 cable source. Nothing in this
+#      v1 needs it (PAPERLESS_AI_ENABLED=false, enrich reads files + the
+#      local API); open that hole deliberately with the #136 AI-batching
+#      admission design, not before.
 let
   cfg = config.myNas.paperless;
   storageRoot = "/mnt/nas";

--- a/modules/adguardhome.nix
+++ b/modules/adguardhome.nix
@@ -88,6 +88,13 @@
             domain = "videos.internal";
             answer = "100.105.121.73";
           }
+          # #136: resolves fleet-wide now, but answers only once the
+          # myNas.paperless / myNasClient.relayPaperless pair flips on.
+          {
+            enabled = true;
+            domain = "paperless.internal";
+            answer = "100.105.121.73";
+          }
         ];
       };
 

--- a/pkgs/paperless-bridge/bridge.py
+++ b/pkgs/paperless-bridge/bridge.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+"""paperless-bridge — same-inode projection of canonical NAS PDFs into
+Paperless-ngx v3 (dotfiles#136).
+
+The canonical tree under /mnt/nas/documents is the storage authority; a
+Paperless "original" is only ever a second directory entry for the same
+inode. Stock Paperless copies consumed input into its media tree, so the
+bridge stages a temporary hardlink in the consume spool, lets the supported
+consumer create the document, verifies checksums, then has a narrow root
+helper atomically replace Paperless's copy with a hardlink to the canonical
+inode. Never forks Paperless, never touches its database.
+
+Commands (all idempotent; a converged corpus makes every one a no-op):
+  scan       inventory canonical PDFs into the ledger
+  ingest     stage pending entries through the Paperless consumer
+  relink     replace Paperless copies with canonical hardlinks (root helper)
+  enrich     project academic-ocr canonical paper.md into Paperless content
+  sync-tags  ensure the versioned taxonomy exists in Paperless; export accepted tags
+  verify     prove the same-inode invariant for every projected entry
+  audit      full state report; nonzero exit on any violation
+
+State: sqlite ledger + append-only receipts.jsonl under the bridge state
+dir. Reconciliation keys are source_id + sha256 + paperless document id;
+st_dev:st_ino is checked live, never trusted as durable identity.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from datetime import datetime, timezone
+
+CANONICAL_ROOT = os.environ.get("BRIDGE_CANONICAL_ROOT", "/mnt/nas/documents")
+STATE_DIR = os.environ.get("BRIDGE_STATE_DIR", "/mnt/nas/services/paperless/bridge")
+SPOOL = os.environ.get("BRIDGE_SPOOL", "/mnt/nas/documents/.paperless-consume")
+VIEW_ROOT = os.environ.get("BRIDGE_VIEW_ROOT", "/mnt/nas/documents/.paperless-view")
+PAPERLESS_URL = os.environ.get("PAPERLESS_URL", "http://127.0.0.1:28981")
+TOKEN_FILE = os.environ.get("PAPERLESS_TOKEN_FILE", "/mnt/nas/services/paperless/bridge/api-token")
+RELINK_HELPER = os.environ.get("BRIDGE_RELINK_HELPER", "paperless-relink-helper")
+ACADEMIC_CANONICAL = os.environ.get(
+    "BRIDGE_ACADEMIC_CANONICAL", "/mnt/nas/documents/academic-papers/canonical"
+)
+TAXONOMY = os.environ.get("BRIDGE_TAXONOMY", os.path.join(os.path.dirname(__file__), "taxonomy.json"))
+# Trees the bridge never inventories: its own machinery plus service state.
+EXCLUDE_DIRS = {".paperless-view", ".paperless-consume", ".snapshots"}
+
+MACHINE_TAG_PREFIXES = ("kind/", "topic/", "course/", "status/", "source/", "ai-candidate/")
+
+
+def now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def log(msg):
+    print(f"{now()} {msg}", file=sys.stderr)
+
+
+def die(msg, code=1):
+    log(f"FATAL: {msg}")
+    sys.exit(code)
+
+
+# ---------------------------------------------------------------- ledger
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS entries (
+  source_id TEXT PRIMARY KEY,
+  rel_path TEXT NOT NULL,
+  sha256 TEXT NOT NULL,
+  md5 TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  academic_db_id TEXT,
+  state TEXT NOT NULL DEFAULT 'inventoried',
+  paperless_id INTEGER,
+  media_path TEXT,
+  ocr_state TEXT NOT NULL DEFAULT 'baseline',
+  first_seen TEXT NOT NULL,
+  updated TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS entries_sha ON entries (sha256);
+CREATE UNIQUE INDEX IF NOT EXISTS entries_path ON entries (rel_path);
+"""
+
+STATES = ("inventoried", "ingested", "relinked", "canonical-synced")
+
+
+def ledger():
+    os.makedirs(STATE_DIR, exist_ok=True)
+    db = sqlite3.connect(os.path.join(STATE_DIR, "ledger.sqlite"))
+    db.row_factory = sqlite3.Row
+    db.executescript(SCHEMA)
+    return db
+
+
+def receipt(event, **fields):
+    rec = {"at": now(), "event": event, **fields}
+    with open(os.path.join(STATE_DIR, "receipts.jsonl"), "a") as f:
+        f.write(json.dumps(rec, sort_keys=True) + "\n")
+    return rec
+
+
+# ---------------------------------------------------------------- hashing
+
+
+def digests(path):
+    sha, md5 = hashlib.sha256(), hashlib.md5()
+    with open(path, "rb") as f:
+        while chunk := f.read(1 << 20):
+            sha.update(chunk)
+            md5.update(chunk)
+    return sha.hexdigest(), md5.hexdigest()
+
+
+# ---------------------------------------------------------------- API
+
+
+def token():
+    with open(TOKEN_FILE) as f:
+        return f.read().strip()
+
+
+def api(method, path, body=None, params=None):
+    url = PAPERLESS_URL.rstrip("/") + path
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Token {token()}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        raw = resp.read()
+    return json.loads(raw) if raw else None
+
+
+def api_all(path, params=None):
+    params = dict(params or {})
+    params.setdefault("page_size", 250)
+    out, page = [], 1
+    while True:
+        params["page"] = page
+        got = api("GET", path, params=params)
+        out.extend(got["results"])
+        if not got.get("next"):
+            return out
+        page += 1
+
+
+# ---------------------------------------------------------------- scan
+
+
+def academic_db_ids():
+    """rel_path (under the canonical root) -> academic db_id, from the catalog."""
+    catalog = os.path.join(CANONICAL_ROOT, "academic-papers/catalog/papers.sqlite")
+    if not os.path.exists(catalog):
+        return {}
+    db = sqlite3.connect(f"file:{catalog}?mode=ro", uri=True)
+    try:
+        rows = db.execute("SELECT db_id, file_path FROM paper_archive WHERE file_path IS NOT NULL")
+        out = {}
+        for db_id, fp in rows:
+            rel = os.path.join("academic-papers", fp) if not fp.startswith("academic-papers") else fp
+            out[rel.lstrip("/")] = db_id
+        return out
+    except sqlite3.OperationalError as e:
+        log(f"academic catalog unreadable ({e}); scanning without db_id mapping")
+        return {}
+    finally:
+        db.close()
+
+
+def cmd_scan(args):
+    db = ledger()
+    academic = academic_db_ids()
+    seen, added, moved = set(), 0, 0
+    for dirpath, dirnames, filenames in os.walk(CANONICAL_ROOT):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDE_DIRS and not d.startswith(".")]
+        for name in filenames:
+            if not name.lower().endswith(".pdf"):
+                continue
+            abs_path = os.path.join(dirpath, name)
+            if os.path.islink(abs_path):
+                continue
+            rel = os.path.relpath(abs_path, CANONICAL_ROOT)
+            seen.add(rel)
+            row = db.execute("SELECT * FROM entries WHERE rel_path = ?", (rel,)).fetchone()
+            if row:
+                continue  # known occurrence; verify owns drift detection
+            sha, md5 = digests(abs_path)
+            # A known payload whose old path vanished is a move, not a new
+            # occurrence; adopt it into the existing identity.
+            prior = db.execute(
+                "SELECT * FROM entries WHERE sha256 = ?", (sha,)
+            ).fetchall()
+            adopted = False
+            for p in prior:
+                if not os.path.exists(os.path.join(CANONICAL_ROOT, p["rel_path"])):
+                    db.execute(
+                        "UPDATE entries SET rel_path = ?, updated = ? WHERE source_id = ?",
+                        (rel, now(), p["source_id"]),
+                    )
+                    receipt("moved", source_id=p["source_id"], from_path=p["rel_path"], to_path=rel)
+                    moved += 1
+                    adopted = True
+                    break
+            if adopted:
+                continue
+            sid = str(uuid.uuid4())
+            db.execute(
+                "INSERT INTO entries (source_id, rel_path, sha256, md5, size, academic_db_id,"
+                " first_seen, updated) VALUES (?,?,?,?,?,?,?,?)",
+                (sid, rel, sha, md5, os.path.getsize(abs_path), academic.get(rel), now(), now()),
+            )
+            receipt("inventoried", source_id=sid, rel_path=rel, sha256=sha)
+            added += 1
+    missing = [
+        r["rel_path"]
+        for r in db.execute("SELECT rel_path FROM entries").fetchall()
+        if r["rel_path"] not in seen
+    ]
+    db.commit()
+    print(json.dumps({"added": added, "moved": moved, "missing_canonical": missing}))
+    if missing:
+        log(f"ALARM: {len(missing)} ledger entries have no canonical file; run verify")
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------- ingest
+
+
+def wait_for_document(spool_name, timeout_sec):
+    deadline = time.time() + timeout_sec
+    stem = os.path.splitext(spool_name)[0]
+    while time.time() < deadline:
+        got = api("GET", "/api/documents/", params={"original_filename__istartswith": stem})
+        if got["count"] == 1:
+            return got["results"][0]
+        if got["count"] > 1:
+            die(f"multiple Paperless documents match spool name {spool_name}")
+        time.sleep(5)
+    return None
+
+
+def paperless_metadata(doc_id):
+    return api("GET", f"/api/documents/{doc_id}/metadata/")
+
+
+def cmd_ingest(args):
+    db = ledger()
+    rows = db.execute(
+        "SELECT * FROM entries WHERE state = 'inventoried' ORDER BY rel_path LIMIT ?",
+        (args.batch,),
+    ).fetchall()
+    os.makedirs(SPOOL, exist_ok=True)
+    done = 0
+    for row in rows:
+        src = os.path.join(CANONICAL_ROOT, row["rel_path"])
+        if not os.path.exists(src):
+            log(f"skip {row['source_id']}: canonical file missing ({row['rel_path']})")
+            continue
+        sha, md5 = digests(src)
+        if sha != row["sha256"]:
+            log(f"ALARM: {row['rel_path']} content changed since inventory; refusing to ingest")
+            receipt("hash-mismatch", source_id=row["source_id"], expected=row["sha256"], actual=sha)
+            continue
+        # Duplicate payloads: if another occurrence of this sha is already in
+        # Paperless, its consumer would reject the stage as a duplicate.
+        # Academic occurrences are deliberately distinct research objects
+        # (dotfiles#136), so only they proceed; general duplicates alias.
+        twin = db.execute(
+            "SELECT * FROM entries WHERE sha256 = ? AND paperless_id IS NOT NULL", (row["sha256"],)
+        ).fetchone()
+        if twin and not row["academic_db_id"]:
+            db.execute(
+                "UPDATE entries SET state = 'relinked', paperless_id = ?, media_path = ?,"
+                " updated = ? WHERE source_id = ?",
+                (twin["paperless_id"], twin["media_path"], now(), row["source_id"]),
+            )
+            db.commit()
+            receipt("aliased", source_id=row["source_id"], alias_of=twin["source_id"],
+                    paperless_id=twin["paperless_id"])
+            continue
+        spool_name = f"{row['source_id']}.pdf"
+        spool_path = os.path.join(SPOOL, spool_name)
+        if not os.path.exists(spool_path):
+            os.link(src, spool_path)  # same-subvolume hardlink, never a copy
+        doc = wait_for_document(spool_name, args.timeout)
+        if doc is None:
+            log(f"timeout waiting for consumer on {spool_name}; will retry next run")
+            continue
+        meta = paperless_metadata(doc["id"])
+        if meta["original_checksum"] != md5:
+            die(
+                f"checksum mismatch for {row['rel_path']}: canonical md5 {md5},"
+                f" Paperless stored {meta['original_checksum']}"
+            )
+        db.execute(
+            "UPDATE entries SET state = 'ingested', paperless_id = ?, media_path = ?,"
+            " updated = ? WHERE source_id = ?",
+            (doc["id"], meta["media_filename"], now(), row["source_id"]),
+        )
+        db.commit()
+        receipt(
+            "ingested",
+            source_id=row["source_id"],
+            rel_path=row["rel_path"],
+            sha256=row["sha256"],
+            paperless_id=doc["id"],
+            media_path=meta["media_filename"],
+        )
+        done += 1
+        if os.path.exists(spool_path):
+            os.unlink(spool_path)
+    leftovers = os.listdir(SPOOL) if os.path.isdir(SPOOL) else []
+    print(json.dumps({"ingested": done, "spool_leftovers": leftovers}))
+    return 0
+
+
+# ---------------------------------------------------------------- relink
+
+
+def originals_dir():
+    # Paperless media originals, bind-mounted from the hidden view subvolume.
+    return os.path.join(VIEW_ROOT)
+
+
+def media_abs(media_path):
+    return os.path.join(originals_dir(), media_path)
+
+
+def cmd_relink(args):
+    db = ledger()
+    rows = db.execute("SELECT * FROM entries WHERE state = 'ingested' ORDER BY rel_path").fetchall()
+    done = 0
+    for row in rows:
+        src = os.path.join(CANONICAL_ROOT, row["rel_path"])
+        dst = media_abs(row["media_path"])
+        if os.path.exists(dst) and os.path.exists(src):
+            s, d = os.stat(src), os.stat(dst)
+            if (s.st_dev, s.st_ino) == (d.st_dev, d.st_ino):
+                db.execute(
+                    "UPDATE entries SET state = 'relinked', updated = ? WHERE source_id = ?",
+                    (now(), row["source_id"]),
+                )
+                db.commit()
+                continue
+        # BRIDGE_RELINK_HELPER may carry a privilege prefix ("sudo …").
+        cmd = [
+            *RELINK_HELPER.split(),
+            "--source-id", row["source_id"],
+            "--paperless-id", str(row["paperless_id"]),
+            "--source", src,
+            "--target", dst,
+            "--sha256", row["sha256"],
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            log(f"relink helper refused {row['source_id']}: {proc.stderr.strip()}")
+            receipt("relink-refused", source_id=row["source_id"], error=proc.stderr.strip())
+            continue
+        s, d = os.stat(src), os.stat(dst)
+        if (s.st_dev, s.st_ino) != (d.st_dev, d.st_ino):
+            die(f"relink helper reported success but inodes differ for {row['source_id']}")
+        db.execute(
+            "UPDATE entries SET state = 'relinked', updated = ? WHERE source_id = ?",
+            (now(), row["source_id"]),
+        )
+        db.commit()
+        receipt(
+            "relinked",
+            source_id=row["source_id"],
+            paperless_id=row["paperless_id"],
+            st_dev=s.st_dev,
+            st_ino=s.st_ino,
+        )
+        done += 1
+    print(json.dumps({"relinked": done}))
+    return 0
+
+
+# ---------------------------------------------------------------- enrich
+
+
+def ensure_custom_fields():
+    want = {
+        "academic-db-id": "string",
+        "source-id": "string",
+        "sha256": "string",
+        "doi": "string",
+        "ocr-state": "string",
+    }
+    have = {f["name"]: f for f in api_all("/api/custom_fields/")}
+    out = {}
+    for name, dtype in want.items():
+        if name not in have:
+            have[name] = api("POST", "/api/custom_fields/", {"name": name, "data_type": dtype})
+        out[name] = have[name]["id"]
+    return out
+
+
+def page_marker_projection(paper_md):
+    """Canonical paper.md -> Paperless content: drop frontmatter, keep the
+    page markers as plain text so lexical search can cite a page."""
+    body = re.sub(r"\A---\n.*?\n---\n", "", paper_md, flags=re.S)
+    body = re.sub(r"<!-- page:(\d+) source:[a-z0-9-]+ -->", r"[page \1]", body)
+    return body.strip() + "\n"
+
+
+def cmd_enrich(args):
+    db = ledger()
+    fields = ensure_custom_fields()
+    rows = db.execute(
+        "SELECT * FROM entries WHERE academic_db_id IS NOT NULL AND paperless_id IS NOT NULL"
+        " AND state IN ('relinked', 'canonical-synced')"
+    ).fetchall()
+    done, pending = 0, 0
+    for row in rows:
+        can_dir = os.path.join(ACADEMIC_CANONICAL, row["academic_db_id"])
+        receipt_path = os.path.join(can_dir, "receipt.json")
+        md_path = os.path.join(can_dir, "paper.md")
+        if not (os.path.isfile(receipt_path) and os.path.isfile(md_path)):
+            pending += 1
+            continue
+        with open(md_path) as f:
+            paper_md = f.read()
+        content_sha = hashlib.sha256(paper_md.encode()).hexdigest()
+        if row["ocr_state"] == "canonical" and row["state"] == "canonical-synced":
+            continue
+        m = re.search(r"^sha256:\s*([0-9a-f]{64})\s*$", paper_md[:1000], flags=re.M)
+        if m and m.group(1) != row["sha256"]:
+            log(
+                f"ALARM: canonical receipt for {row['academic_db_id']} is for source"
+                f" {m.group(1)[:12]}…, ledger has {row['sha256'][:12]}…; not syncing"
+            )
+            receipt("enrich-source-mismatch", source_id=row["source_id"],
+                    academic_db_id=row["academic_db_id"])
+            continue
+        api(
+            "PATCH",
+            f"/api/documents/{row['paperless_id']}/",
+            {
+                "content": page_marker_projection(paper_md),
+                "custom_fields": [
+                    {"field": fields["academic-db-id"], "value": row["academic_db_id"]},
+                    {"field": fields["source-id"], "value": row["source_id"]},
+                    {"field": fields["sha256"], "value": row["sha256"]},
+                    {"field": fields["ocr-state"], "value": "canonical"},
+                ],
+            },
+        )
+        db.execute(
+            "UPDATE entries SET state = 'canonical-synced', ocr_state = 'canonical',"
+            " updated = ? WHERE source_id = ?",
+            (now(), row["source_id"]),
+        )
+        db.commit()
+        receipt(
+            "canonical-synced",
+            source_id=row["source_id"],
+            paperless_id=row["paperless_id"],
+            academic_db_id=row["academic_db_id"],
+            content_sha256=content_sha,
+        )
+        done += 1
+    print(json.dumps({"synced": done, "awaiting_receipt": pending}))
+    return 0
+
+
+# ---------------------------------------------------------------- tags
+
+
+def cmd_sync_tags(args):
+    with open(TAXONOMY) as f:
+        tax = json.load(f)
+    valid = {t["slug"] for t in tax["tags"]}
+    have = {t["name"]: t for t in api_all("/api/tags/")}
+    created = 0
+    for t in tax["tags"]:
+        if t["slug"] not in have:
+            api("POST", "/api/tags/", {"name": t["slug"]})
+            created += 1
+    # Machine-namespace tags that exist in Paperless but not in the taxonomy
+    # are drift: report, never delete (a human may be mid-review).
+    drift = [
+        name
+        for name in have
+        if name.startswith(MACHINE_TAG_PREFIXES) and name not in valid
+    ]
+    # Export accepted tags to durable sidecars, one file per document.
+    sidecars = os.path.join(STATE_DIR, "accepted-tags")
+    os.makedirs(sidecars, exist_ok=True)
+    db = ledger()
+    tag_by_id = {t["id"]: t["name"] for t in api_all("/api/tags/")}
+    exported = 0
+    for row in db.execute("SELECT * FROM entries WHERE paperless_id IS NOT NULL").fetchall():
+        doc = api("GET", f"/api/documents/{row['paperless_id']}/")
+        names = sorted(
+            tag_by_id[t] for t in doc["tags"]
+            if not tag_by_id[t].startswith("ai-candidate/")
+        )
+        side = os.path.join(sidecars, f"{row['source_id']}.json")
+        payload = {
+            "source_id": row["source_id"],
+            "sha256": row["sha256"],
+            "paperless_id": row["paperless_id"],
+            "tags": names,
+            "taxonomy_version": tax["version"],
+        }
+        prior = None
+        if os.path.exists(side):
+            with open(side) as f:
+                prior = {k: v for k, v in json.load(f).items() if k != "exported_at"}
+        if prior != payload:
+            with open(side + ".tmp", "w") as f:
+                json.dump({**payload, "exported_at": now()}, f, indent=2, sort_keys=True)
+            os.replace(side + ".tmp", side)
+            exported += 1
+    print(json.dumps({"tags_created": created, "drift": drift, "sidecars_updated": exported}))
+    return 1 if drift else 0
+
+
+# ---------------------------------------------------------------- verify
+
+
+def cmd_verify(args):
+    db = ledger()
+    violations = []
+    for row in db.execute("SELECT * FROM entries").fetchall():
+        src = os.path.join(CANONICAL_ROOT, row["rel_path"])
+        src_ok = os.path.isfile(src)
+        if not src_ok:
+            violations.append({"source_id": row["source_id"], "kind": "missing-canonical",
+                               "path": row["rel_path"]})
+        if row["state"] in ("relinked", "canonical-synced"):
+            dst = media_abs(row["media_path"])
+            if not os.path.isfile(dst):
+                violations.append({"source_id": row["source_id"], "kind": "missing-projection",
+                                   "path": row["media_path"]})
+                continue
+            if src_ok:
+                s, d = os.stat(src), os.stat(dst)
+                if (s.st_dev, s.st_ino) != (d.st_dev, d.st_ino):
+                    violations.append({"source_id": row["source_id"], "kind": "detached-projection",
+                                       "path": row["media_path"]})
+                if args.hash:
+                    sha, _ = digests(src)
+                    if sha != row["sha256"]:
+                        violations.append({"source_id": row["source_id"], "kind": "hash-drift",
+                                           "path": row["rel_path"], "actual": sha})
+    for v in violations:
+        receipt("violation", **v)
+        log(f"ALARM: {v['kind']} {v['path']} ({v['source_id']})")
+    print(json.dumps({"entries": db.execute("SELECT COUNT(*) FROM entries").fetchone()[0],
+                      "violations": violations}))
+    return 1 if violations else 0
+
+
+# ---------------------------------------------------------------- audit
+
+
+def cmd_audit(args):
+    db = ledger()
+    by_state = dict(
+        db.execute("SELECT state, COUNT(*) FROM entries GROUP BY state").fetchall()
+    )
+    ledger_ids = {
+        r["paperless_id"]
+        for r in db.execute("SELECT paperless_id FROM entries WHERE paperless_id IS NOT NULL")
+    }
+    orphans = [d["id"] for d in api_all("/api/documents/") if d["id"] not in ledger_ids]
+    spool = os.listdir(SPOOL) if os.path.isdir(SPOOL) else []
+    report = {
+        "by_state": by_state,
+        "paperless_docs_outside_ledger": orphans,
+        "spool_leftovers": spool,
+    }
+    print(json.dumps(report, indent=2))
+    return 1 if orphans or spool else 0
+
+
+# ---------------------------------------------------------------- main
+
+
+def main():
+    p = argparse.ArgumentParser(prog="paperless-bridge", description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("scan")
+    ing = sub.add_parser("ingest")
+    ing.add_argument("--batch", type=int, default=50, help="entries per run (bounded admission)")
+    ing.add_argument("--timeout", type=int, default=300, help="per-document consumer wait seconds")
+    sub.add_parser("relink")
+    sub.add_parser("enrich")
+    sub.add_parser("sync-tags")
+    ver = sub.add_parser("verify")
+    ver.add_argument("--hash", action="store_true", help="also re-hash canonical bytes")
+    sub.add_parser("audit")
+    args = p.parse_args()
+    handler = {
+        "scan": cmd_scan,
+        "ingest": cmd_ingest,
+        "relink": cmd_relink,
+        "enrich": cmd_enrich,
+        "sync-tags": cmd_sync_tags,
+        "verify": cmd_verify,
+        "audit": cmd_audit,
+    }[args.cmd]
+    sys.exit(handler(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/paperless-bridge/default.nix
+++ b/pkgs/paperless-bridge/default.nix
@@ -1,0 +1,38 @@
+# Same-inode projection bridge between the canonical NAS document tree and
+# Paperless-ngx v3 (dotfiles#136). Two binaries: the unprivileged bridge CLI
+# (scan/ingest/relink/enrich/sync-tags/verify/audit) and the narrow root
+# relink helper it calls through a restricted sudo rule. The versioned tag
+# taxonomy ships alongside as the vocabulary authority.
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  python3,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "paperless-bridge";
+  version = "2026-08-04";
+  src = builtins.path {
+    path = ./.;
+    name = "paperless-bridge-src";
+    filter = path: _type: builtins.baseNameOf path != "default.nix";
+  };
+  nativeBuildInputs = [ makeWrapper ];
+  dontBuild = true;
+  installPhase = ''
+    lib=$out/libexec/paperless-bridge
+    mkdir -p $lib $out/bin
+    cp $src/bridge.py $src/relink-helper.py $src/taxonomy.json $lib/
+    chmod +x $lib/bridge.py $lib/relink-helper.py
+
+    makeWrapper ${python3}/bin/python3 $out/bin/paperless-bridge \
+      --add-flags $lib/bridge.py \
+      --set-default BRIDGE_TAXONOMY $lib/taxonomy.json
+    makeWrapper ${python3}/bin/python3 $out/bin/paperless-relink-helper \
+      --add-flags $lib/relink-helper.py
+  '';
+  meta = {
+    description = "same-inode canonical-PDF projection into Paperless-ngx, with verified relink and receipts";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/paperless-bridge/relink-helper.py
+++ b/pkgs/paperless-bridge/relink-helper.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""paperless-relink-helper — the only privileged step of the projection
+bridge (dotfiles#136). Replaces one Paperless-owned original with a hardlink
+to its canonical inode, after refusing everything that is not exactly the
+requested, ledger-known, hash-identical pair. Runs as root because Linux
+protected-hardlink rules stay enabled; everything else about the bridge is
+unprivileged.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import sys
+from datetime import datetime, timezone
+
+CANONICAL_ROOT = os.environ.get("BRIDGE_CANONICAL_ROOT", "/mnt/nas/documents")
+VIEW_ROOT = os.environ.get("BRIDGE_VIEW_ROOT", "/mnt/nas/documents/.paperless-view")
+STATE_DIR = os.environ.get("BRIDGE_STATE_DIR", "/mnt/nas/services/paperless/bridge")
+RECEIPTS = os.path.join(STATE_DIR, "relink-receipts.jsonl")
+
+
+def refuse(msg):
+    print(f"refused: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(1 << 20):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def under(root, path):
+    return os.path.commonpath([root, path]) == root
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--source-id", required=True)
+    p.add_argument("--paperless-id", required=True, type=int)
+    p.add_argument("--source", required=True)
+    p.add_argument("--target", required=True)
+    p.add_argument("--sha256", required=True)
+    a = p.parse_args()
+
+    # The pair must be one the unprivileged bridge already recorded: this
+    # helper takes no orders that the ledger has not seen.
+    db = sqlite3.connect(f"file:{os.path.join(STATE_DIR, 'ledger.sqlite')}?mode=ro", uri=True)
+    row = db.execute(
+        "SELECT rel_path, sha256, paperless_id FROM entries WHERE source_id = ?",
+        (a.source_id,),
+    ).fetchone()
+    if row is None:
+        refuse(f"source id {a.source_id} not in ledger")
+    rel_path, ledger_sha, ledger_pid = row
+    if ledger_pid != a.paperless_id:
+        refuse(f"paperless id {a.paperless_id} does not match ledger ({ledger_pid})")
+    if ledger_sha != a.sha256:
+        refuse("sha256 argument does not match ledger")
+
+    src = os.path.realpath(a.source)
+    dst = os.path.realpath(a.target)
+    if src != os.path.realpath(os.path.join(CANONICAL_ROOT, rel_path)):
+        refuse("source path does not match the ledger entry's canonical path")
+    if not under(os.path.realpath(CANONICAL_ROOT), src):
+        refuse("source escapes the canonical root")
+    if not under(os.path.realpath(VIEW_ROOT), dst):
+        refuse("target escapes the projection root")
+    for path, name in ((a.source, "source"), (a.target, "target")):
+        if os.path.islink(path):
+            refuse(f"{name} is a symlink")
+    st_src, st_dst = os.lstat(src), os.lstat(dst)
+    for st_, name in ((st_src, "source"), (st_dst, "target")):
+        if not stat.S_ISREG(st_.st_mode):
+            refuse(f"{name} is not a regular file")
+    if st_src.st_dev != st_dst.st_dev:
+        refuse("source and target are on different filesystems; hardlink impossible")
+    if sha256(src) != a.sha256:
+        refuse("source bytes do not match the requested sha256")
+    if sha256(dst) != a.sha256:
+        refuse("target bytes do not match the requested sha256; not the same document")
+
+    tmp = dst + ".relink-tmp"
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    os.link(src, tmp)
+    os.replace(tmp, dst)
+
+    st = os.stat(dst)
+    rec = {
+        "at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "source_id": a.source_id,
+        "paperless_id": a.paperless_id,
+        "rel_path": rel_path,
+        "sha256": a.sha256,
+        "st_dev": st.st_dev,
+        "st_ino": st.st_ino,
+    }
+    with open(RECEIPTS, "a") as f:
+        f.write(json.dumps(rec, sort_keys=True) + "\n")
+    print(json.dumps(rec))
+
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/paperless-bridge/taxonomy.json
+++ b/pkgs/paperless-bridge/taxonomy.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "comment": "Controlled tagging vocabulary for the Paperless projection (dotfiles#136). This file is the authority for stable slugs; Paperless numeric tag IDs are only a projection of it. AI writes only into ai-candidate/*; humans accept by retagging into the owning namespace, and sync-tags exports accepted tags to durable sidecars.",
+  "namespaces": {
+    "kind": "document genre; owned by the file/academic catalogs",
+    "topic": "controlled subject taxonomy; human-owned",
+    "course": "academic/course context; owned by the academic catalog",
+    "status": "reading workflow state; human-owned in Paperless",
+    "source": "provenance of the canonical file; machine-owned",
+    "personal": "durable personal curation; human-owned",
+    "ai-candidate": "proposed classifications awaiting human review; machine-owned"
+  },
+  "tags": [
+    { "slug": "kind/paper", "definition": "peer-reviewed or working academic paper" },
+    { "slug": "kind/book", "definition": "book or book chapter" },
+    { "slug": "kind/manual", "definition": "product or equipment manual" },
+    { "slug": "kind/invoice", "definition": "invoice or receipt" },
+    { "slug": "kind/administrative", "definition": "administrative or legal record" },
+    { "slug": "kind/article", "definition": "non-academic article or report" },
+    { "slug": "status/inbox", "definition": "not yet triaged" },
+    { "slug": "status/unread", "definition": "triaged, not yet read" },
+    { "slug": "status/reading", "definition": "currently reading" },
+    { "slug": "status/reviewed", "definition": "read and reviewed" },
+    { "slug": "source/academic", "definition": "from the academic corpus catalog" },
+    { "slug": "source/legacy", "definition": "from the pre-NAS legacy tree" },
+    { "slug": "source/scan", "definition": "digitized from paper by us" },
+    { "slug": "personal/favorite", "definition": "durable personal favorite" }
+  ]
+}


### PR DESCRIPTION
Implements the declarative + tooling scope of #136, everything gated OFF per the NAS gate-then-verify convention. The issue stays open: its acceptance criteria require the real-hardware runbook (in the header of `hosts/nas/paperless.nix`) — canary corpus admission, same-inode proof on real files, idle/import RSS measurement on the 8 GB box, and the gate/check flip in one commit.

## What's here

| Piece | Where |
|---|---|
| Pinned v3 source | `nixpkgs-paperless` input at a fixed nixos-unstable rev → paperless-ngx **3.0.4** (upstream tag v3.0.4; 3.0.5 is 3 days old and not in nixpkgs yet — bump the rev when it lands) |
| NAS service | `hosts/nas/paperless.nix`, `myNas.paperless.enable` (off): v3 module swap, postgres `createLocally`, `OCR_MODE=auto`, `ARCHIVE_FILE_GENERATION=never`, no Tika/Gotenberg, AI deferred, auto-login `tom`, on-box generated admin password, backend admitted only from `10.77.0.1` |
| Storage contract | Paperless originals = bind of `/mnt/nas/documents/.paperless-view`; consume spool beside it — both inside the documents subvolume so hardlinks work; browsable read-only `/mnt/nas/views/paperless`; nightly paperless pg_dump to the HDD (exporter deliberately deferred to #130's backup target — with originals it would be a same-disk payload copy) |
| Projection bridge | `pkgs/paperless-bridge`: `scan / ingest / relink / enrich / sync-tags / verify / audit`, sqlite ledger + append-only receipts, stable occurrence IDs with move adoption + academic `db_id` mapping + general-duplicate aliasing, hardlink staging through the supported consumer, checksum verify, receipt-driven `paper.md` → content enrichment, versioned `taxonomy.json` as the tag authority |
| Privilege boundary | one narrow root relink helper (sudo NOPASSWD on exactly that binary); refuses non-ledger pairs, path escapes, symlinks, cross-device, hash mismatches; atomic tmp-link + rename; own receipts |
| Coordinator | `myNasClient.relayPaperless` (off): socket relay → `nas:28981`, durable Caddy route `http://paperless.internal` (AdGuard rewrite added fleet-wide, harmless while gated) |
| Checks | `nas-topology` staged-off + pair asserts; new `nas-paperless-staged` evaluates the ENABLED shape via `extendModules` — v3-only, no Tika, never-archive, same-subvolume paths, still no NAS Tailscale |

## Validation run

- `nas-topology` and `nas-paperless-staged` checks build
- NAS toplevel builds with the gate off (no closure surprise for the nightly auto-update)
- `paperless-ngx` 3.0.4 substitutes from cache.nixos.org — the gate flip won't compile from source
- Bridge state machine exercised on a synthetic tree: scan idempotency, move adoption, **missing-canonical** and **detached-projection** alarms (exit 1, receipted), helper refusal paths, and a real hardlink relink converging to identical `st_dev:st_ino`

Refs #136 (leave open), #130, #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)