### PR TITLE
tally: wave-3 E2 pin advance + journald-upload rotation-blip silencing

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1266,11 +1266,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785730976,
-        "narHash": "sha256-YW21jGuYPyO7x5EuYwiwR+dXL+ZBIyhGGVnkGIZu8X4=",
+        "lastModified": 1785910866,
+        "narHash": "sha256-9P0rKaz3613Vfhwl/R107l0fEiRiMvVp/4VCj1XJjRE=",
         "owner": "mecattaf",
         "repo": "tally.nix",
-        "rev": "ba1dd963ceea4904d9cb5382ee23b8c74b7e0ee1",
+        "rev": "8c66628df986154d0e510e287164cac78201ed81",
         "type": "github"
       },
       "original": {

--- a/hosts/coordinator/journal-upload.nix
+++ b/hosts/coordinator/journal-upload.nix
@@ -48,6 +48,19 @@ in
     settings.Upload.URL = "http://10.77.0.2:19532";
   };
 
+  # journald-remote drops the upload connection whenever it rotates its
+  # receiving journal file (NAS side: "microhttpd: Application reported
+  # internal error"); the uploader exits 1 and reconnects seconds later. That
+  # ~daily blip is not a signal — sustained upload loss is what matters, and
+  # the archive liveness dead-man's switch above is the detection for it — so
+  # keep the blip off the failure markers. fleet-deploy.service is restated
+  # because option definitions replace the default, and fleet-deploy writes
+  # its own richer marker.
+  myFailureSurfacing.excludeUnits = [
+    "fleet-deploy.service"
+    "systemd-journal-upload.service"
+  ];
+
   # The local journal stays persistent and bounded (#135, closing #133 item
   # 4 for journald): volatile storage would lose the final pre-lockup window
   # in an mt7925e-class hard freeze — the exact forensic case that motivates


### PR DESCRIPTION
Pre-reboot batch for the coordinator switch (refs #138, wave-3 E2).

## Pin advance ba1dd96 → 8c66628
Unfreezes the post-wave fixes that today's failure markers trace to:
- tally.nix#370 (fd06362a): watchdog keepalive off the dispatch loop — today's 05:44 tally-daemon SIGABRT is this exact starvation pattern (SI_USER SIGABRT mid `query_jobs`).
- tally.nix#371 (c3e9aa43): recovery now migrates pre-label unit-exit records itself — the manual batch-patch recipe from the 2026-08-03 crash-loop is obsolete.
- tally.nix#372 (c5045a01): removed-producer projections get a terminal witnessed fate — ends the `unknown producer "campaign-crm"` post-ack retry spam visible in the daemon log.
- Plus #391 (W-316 root fix), #392–#394 usage/occupancy accounting, #397 exit-20 contract, #398 pi preset framing.

## journald-upload exclusion from failure markers
`systemd-journal-remote` on the NAS drops the connection every time it rotates its receiving journal file ("microhttpd: Application reported internal error", confirmed at both marker timestamps). The uploader exits 1 and reconnects seconds later. Sustained upload loss is covered by the weekly archive liveness dead-man's switch, so the ~daily rotation blip is excluded from `myFailureSurfacing`.

Post-merge (E4, after switch + reboot): `tally flow check`, one fleet-gate run, delete inert `taskdata/` dirs. Disk gate: 226G free, well over the 16 GiB floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)