### PR TITLE
pre-reboot batch: llama-swap idle ttl, chrome-151 lock parity, mech-first caps, drain child-session error, webcam mic

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -813,11 +813,11 @@
     },
     "nixpkgs-fresh": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785828668,
+        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
         "type": "github"
       },
       "original": {

--- a/flows/tally-flows.nix
+++ b/flows/tally-flows.nix
@@ -115,7 +115,9 @@ in
     academic-paper-e2e = {
       script = "${academicDrainLib}/paper-e2e.js";
       onCalendar = null;
-      maxNodes = 10000;
+      # Must cover the script's meta.maxNodes (11,000 since the mech-first
+      # second engine + gate, PR #150); the checked-config build refuses less.
+      maxNodes = 11000;
       args = {
         paperId = turnerId;
         title = turner.title;
@@ -130,6 +132,13 @@ in
         refineModel = "qwen3-vl-32b-ocr";
         embedModel = "qwen3-embedding-8b";
         minAgreementPermille = 700;
+        # Mech-first shortcut gates (PR #150), data-calibrated on 2,374
+        # drained pages: both mechanical engines must clear the word floor
+        # AND self-agree at this Dice level to resolve without the GPU. The
+        # word floor is the safety-critical half — sparse-layer pages
+        # self-agree perfectly, so don't tighten Dice instead.
+        mechSelfAgreementPermille = 930;
+        mechMinWords = 200;
       };
     };
   };

--- a/home/dot_claude/skills/drain/scripts/ai_memory.py
+++ b/home/dot_claude/skills/drain/scripts/ai_memory.py
@@ -210,6 +210,10 @@ def current_identity(
         return current_identity("claude-code", env)
     if codex_id:
         return current_identity("codex", env)
+    if env.get("CLAUDE_CODE_CHILD_SESSION") == "1" and (
+        env.get("CLAUDE_CODE_SESSION_ID") or env.get("CLAUDE_SESSION_ID")
+    ):
+        raise MemoryError("drain is only available in a root Claude Code session")
     raise MemoryError(
         "no current session identity found (expected CLAUDE_CODE_SESSION_ID or CODEX_THREAD_ID)"
     )

--- a/home/tally.nix
+++ b/home/tally.nix
@@ -90,13 +90,14 @@ in
     # pages × four protocols × four inputs, plus 100 arbiters) died with the
     # Turner/Fosfuri sample flows in e61f906b; academic-paper-e2e replaced it
     # and spends 6 nodes per page (raster, mech, 8B, compare, 32B, compare)
-    # plus 6 fixed (fetch, assemble, chunk, embed, index, receipt). Its
-    # argsSchema admits 1,500 pages = 9,006 nodes, which is what its
-    # meta.maxNodes 10000 declares, so the host must admit that much or the
-    # drain dies on long papers at 2am. The NAS corpus of record currently
-    # tops out at 1,215 pages (7,296 nodes) with 231 papers above the 282
-    # pages a 1,700 cap would have allowed.
-    enqueue.fanoutCap = 10000;
+    # plus 6 fixed (fetch, assemble, chunk, embed, index, receipt). The
+    # mech-first shortcut (#147, PR #150) added a second mechanical engine and
+    # agreement gate per page, so the script's meta.maxNodes rose to 11,000;
+    # the host must admit that much or the drain dies on long papers at 2am —
+    # the new tally pin refuses the config outright when this cap is below the
+    # script meta. The NAS corpus of record currently tops out at 1,215 pages
+    # with 231 papers above the 282 pages a 1,700 cap would have allowed.
+    enqueue.fanoutCap = 11000;
 
     # These are real contention lanes, not synthetic maintenance pools.
     pools = lib.optionalAttrs isCoordinator {

--- a/hosts/coordinator/audio.nix
+++ b/hosts/coordinator/audio.nix
@@ -1,0 +1,57 @@
+{ pkgs, ... }:
+# coordinator audio intake — the iContact Camera Pro webcam mic is the mic Tom
+# actually speaks into (Claude Code /voice, meetings), so it is pinned as the
+# default PipeWire source rather than left to WirePlumber's priority election.
+#
+# Diagnosed 2026-08-04 after /voice reported "No audio detected from
+# microphone". Two independent faults, both invisible from the PipeWire side:
+#
+#  1. The webcam's *hardware* capture gain (ALSA `Mic Capture Volume` on card
+#     `Pro`, range 0-4096) sat at 0, so the USB endpoint streamed digital
+#     silence. Every capture path agreed: `pw-record` and a direct
+#     `ffmpeg -f alsa -i hw:3` both produced samples that were exactly zero.
+#     Meanwhile `wpctl` cheerfully reported the source at 53% and unmuted —
+#     PipeWire's number is a cubic mapping onto that same control, and nothing
+#     in the graph surfaces "the mixer element is at the bottom of its range".
+#     Repaired at runtime with `amixer -c Pro sset Mic 36% cap` (~+5.8 dB),
+#     which WirePlumber then persisted to its own state. This is *runtime*
+#     state, not declarative: if ~/.local/state/wireplumber is ever wiped the
+#     control can come back at the firmware default, so that amixer line is the
+#     first thing to re-run if the mic goes silent again.
+#
+#  2. The stored default source was the node name `asrtest`, left over from an
+#     earlier speech-recognition experiment and no longer present in the graph.
+#     WirePlumber fell back to whatever won on priority, which is why the
+#     default input drifted between the webcam, the INZONE Buds and the unused
+#     analog jack across reboots.
+#
+# The rule below fixes (2) properly: giving the webcam node a session priority
+# well above every other capture device makes it win the election outright, so
+# a stale or cleared default-nodes state can no longer move the intake.
+{
+  services.pipewire.wireplumber.extraConfig."51-coordinator-default-source" = {
+    "monitor.alsa.rules" = [
+      {
+        # Matched on node.name, which carries the USB serial — precise for this
+        # unit. Replacing the webcam means updating this string; the symptom
+        # would be the default input silently reverting to the Buds.
+        matches = [
+          {
+            "node.name" =
+              "alsa_input.usb-DCX-241206-FAY_iContact_Camera_Pro_01.00.00-02.analog-stereo";
+          }
+        ];
+        actions.update-props = {
+          # Stock ALSA sources land around 1000-2000; 3000 is unambiguous.
+          "priority.session" = 3000;
+        };
+      }
+    ];
+  };
+
+  # Absent until now, which is why the zeroed hardware mixer above took a
+  # `nix shell nixpkgs#alsa-utils` to even see. The PipeWire-level tools
+  # (wpctl/pw-record) cannot read or write raw ALSA mixer elements, so keep
+  # amixer/alsamixer/arecord on the box for the next time capture looks dead.
+  environment.systemPackages = [ pkgs.alsa-utils ];
+}

--- a/hosts/coordinator/default.nix
+++ b/hosts/coordinator/default.nix
@@ -18,6 +18,7 @@
     ./services.nix
     ./immich-ml.nix
     ./atuin.nix
+    ./audio.nix # pins the webcam mic as the default PipeWire source
     # Per-machine AdGuard Home DNS filter (loopback 127.0.0.1:53, resolved
     # forwards to it). The Zenbook Duo imports the same module.
     ../../modules/adguardhome.nix

--- a/lib/local-models.nix
+++ b/lib/local-models.nix
@@ -290,6 +290,19 @@ let
         type = types.ints.unsigned;
         default = 0;
       };
+      ttl = mkOption {
+        type = types.ints.unsigned;
+        default = 600;
+        description = ''
+          Idle seconds before llama-swap unloads the model (per-model ttl,
+          overriding the deliberate globalTTL = 0). The timer is
+          last-request-based and never fires with a request in flight, so
+          Tally-admitted batch jobs are only affected if they go quiet for
+          longer than this window — and then pay one transparent cold reload,
+          not an error (#149). 0 opts a deployment back into
+          resident-until-restart.
+        '';
+      };
       artifacts = mkOption {
         type = artifactRefsType;
         default = { };

--- a/modules/llama-swap.nix
+++ b/modules/llama-swap.nix
@@ -15,6 +15,16 @@
 # mechanism.
 let
   cfg = config.services.llama-swap;
+
+  # Explicit "stop using it now", separate from the roster's idle ttl (#149):
+  # unload one model by id, or everything when called bare.
+  llamaSwapUnload = pkgs.writeShellApplication {
+    name = "llama-swap-unload";
+    runtimeInputs = [ pkgs.curl ];
+    text = ''
+      exec curl -fsS -X POST "http://localhost:${toString cfg.port}/api/models/unload''${1:+/$1}"
+    '';
+  };
 in
 {
   services.llama-swap = {
@@ -48,15 +58,20 @@ in
       startPort = 10001;
       sendLoadingState = true;
 
-      # Tally owns residency and the explicit unload boundary. Do not let an
-      # independent global timer evict a model during an admitted batch job.
+      # Fallback only: every roster deployment carries a per-model idle ttl
+      # (lib/local-models.nix, #149) which overrides this. Tally admission is
+      # orthogonal — it leases job dispatch, not backend residency, and the
+      # ttl timer never fires with a request in flight.
       globalTTL = 0;
       unloadTimeout = 60;
     };
   };
 
   # Keep the operator CLI on PATH as well as in the service closure.
-  environment.systemPackages = [ cfg.package ];
+  environment.systemPackages = [
+    cfg.package
+    llamaSwapUnload
+  ];
 
   # Tailnet-only remote API, matching the fleet's VNC/media/ASR posture.
   networking.firewall.interfaces.tailscale0.allowedTCPPorts = [ cfg.port ];

--- a/modules/local-models.nix
+++ b/modules/local-models.nix
@@ -95,6 +95,7 @@ let
       value = rendered // {
         name = deployment.model;
         cmd = rendered.cmd + lib.optionalString (runtimeArgs != [ ]) " ${extraArgs}";
+        ttl = deployment.ttl;
       };
     };
 


### PR DESCRIPTION
Second pre-reboot batch for the coordinator switch.

- **local-ai (#149)**: every roster deployment gets a per-model `ttl` (default 600s idle) so interactively summoned models unload themselves; `globalTTL=0` stays as the documented fallback. Adds `llama-swap-unload` CLI. Verified rendered into all 10 model entries of the built closure. Closes #149.
- **tally caps**: PR #150's mech-first script raised `meta.maxNodes` to 11,000 and made the mech gates required args; the #152 pin's checked-config build refuses the old registration. Raises flow `maxNodes` + `fanoutCap` to 11,000 and supplies the calibrated gates (930‰ / 200 words). #150 and #152 were each green alone — this is the semantic merge conflict fix.
- **drain (#148)**: auto-detect path now reports the real 'root session only' refusal instead of 'no identity'; codex identities still win from a child Claude session. Tested all three paths. Closes #148.
- **nixpkgs-fresh**: lock advanced to 2026-08-04 unstable so a bare manual switch agrees with the nightly rolling override (chrome 151.0.7922.71).
- **coordinator**: cherry-pick of the local webcam-mic default-source commit (2026-08-04).

Full coordinator closure builds green with all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)