### PR TITLE
recordings-drain: Auto-queue diarization for new call recordings through tally

### DIFF
--- a/home/dot_local/bin/call-record
+++ b/home/dot_local/bin/call-record
@@ -83,11 +83,30 @@ stop)
     done
     rm -f "$CURRENT"
 
+    mix_written=false
     if [[ -s "$dir/far.wav" && -s "$dir/near.wav" ]]; then
         sox -m "$dir/far.wav" "$dir/near.wav" "$dir/mix.wav" gain -n -1
+        mix_written=true
     else
         echo "warning: one track is empty; skipping mix" >&2
     fi
+
+    # The shared helper writes the same atomic, full-submission event as the
+    # historical backfill command. Queue only after mix.wav is finalized. An
+    # unavailable package, events directory, or tally daemon must never turn a
+    # successfully closed recording into a failed `stop`.
+    if [[ "$mix_written" == true ]]; then
+        if command -v call-diarize-backfill >/dev/null 2>&1; then
+            if ! call-diarize-backfill --enqueue "$dir"; then
+                echo "warning: diarization was not queued; run call-diarize-backfill later" >&2
+            fi
+        else
+            echo "warning: call-diarize-backfill is unavailable; diarization was not queued" >&2
+        fi
+    else
+        echo "warning: diarization was not queued because mix.wav was not produced" >&2
+    fi
+
     echo "session closed:"
     for f in far near mix; do
         [[ -f "$dir/$f.wav" ]] && printf '  %-8s %s  (%s)\n' "$f.wav" "$dir/$f.wav" "$(soxi -d "$dir/$f.wav" 2>/dev/null || echo '?')"

--- a/home/tally.nix
+++ b/home/tally.nix
@@ -71,7 +71,10 @@ in
     ../flows/tally-flows.nix
   ];
 
-  home.packages = lib.optionals isCoordinator [ pkgs.local-ai-monthly ];
+  home.packages = lib.optionals isCoordinator [
+    pkgs.call-diarize
+    pkgs.local-ai-monthly
+  ];
 
   services.tally = {
     enable = isCoordinator;
@@ -168,6 +171,15 @@ in
     # single-node build plus activation one exclusive maintenance window.
     # The system service handles Zenbook's successful offline/low-power skip internally.
     producers = lib.optionalAttrs isCoordinator {
+      # call-record and call-diarize-backfill drop complete EnqueuePayload files
+      # into tally's shared events directory. tally-drain.timer already claims
+      # that directory every five seconds, so this entry declares the producer
+      # contract without rendering a competing drain unit or timer.
+      call-diarization = {
+        kind = "events-dir";
+        selfDrain = false;
+      };
+
       # The parent serializes one monthly review but does not reserve the GPU.
       # After deterministic Git/Nix/HF preparation it enqueues one low-priority
       # coordinator-gpu child for Pi, waits for the commentary, then verifies and

--- a/pkgs/call-diarize/backfill.sh
+++ b/pkgs/call-diarize/backfill.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: call-diarize-backfill [recordings-root]" >&2
+  exit 1
+}
+
+events_directory() {
+  if [[ -n "${TALLY_EVENTS_DIR:-}" ]]; then
+    printf '%s\n' "${TALLY_EVENTS_DIR}"
+  elif [[ -n "${XDG_STATE_HOME:-}" ]]; then
+    printf '%s\n' "${XDG_STATE_HOME}/tally/events"
+  else
+    : "${HOME:?HOME is required when XDG_STATE_HOME and TALLY_EVENTS_DIR are unset}"
+    printf '%s\n' "${HOME}/.local/state/tally/events"
+  fi
+}
+
+warn_if_daemon_unavailable() {
+  local socket
+  if [[ -n "${TALLY_SOCKET:-}" ]]; then
+    socket="${TALLY_SOCKET}"
+  elif [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    socket="${XDG_RUNTIME_DIR}/tally/tally.sock"
+  else
+    echo "warning: tally daemon availability is unknown; event is queued for a later drain" >&2
+    return
+  fi
+
+  if [[ ! -S "$socket" ]]; then
+    echo "warning: tally daemon is unavailable; event is queued for a later drain" >&2
+  fi
+}
+
+enqueue_directory() {
+  local requested_dir="$1"
+  local call_dir directory_name dedup_key event_hash
+  local events_dir event_path temporary
+
+  if [[ ! -d "$requested_dir" ]]; then
+    echo "call-diarize-backfill: not a call directory: $requested_dir" >&2
+    return 1
+  fi
+  if ! call_dir="$(realpath "$requested_dir")"; then
+    echo "call-diarize-backfill: cannot resolve call directory: $requested_dir" >&2
+    return 1
+  fi
+
+  directory_name="${call_dir##*/}"
+  dedup_key="call-diarize:${directory_name}"
+  events_dir="$(events_directory)"
+  if ! mkdir -p -- "$events_dir"; then
+    echo "call-diarize-backfill: cannot create tally events directory: $events_dir" >&2
+    return 1
+  fi
+
+  if ! event_hash="$(printf '%s' "$dedup_key" | sha256sum)"; then
+    echo "call-diarize-backfill: cannot derive event identity for: $call_dir" >&2
+    return 1
+  fi
+  event_hash="${event_hash%% *}"
+  event_path="$events_dir/call-diarize-${event_hash:0:32}.json"
+  if ! temporary="$(mktemp "$events_dir/.call-diarize.XXXXXXXXXX")"; then
+    echo "call-diarize-backfill: cannot create an atomic event in: $events_dir" >&2
+    return 1
+  fi
+
+  # For /home/tom/Recordings/calls/2026-08-09-demo this writes exactly:
+  # {"argv":["call-diarize","/home/tom/Recordings/calls/2026-08-09-demo"],"adapter":"shell","pool":["coordinator-gpu"],"priority":"low","source":"events-dir","dedupKey":"call-diarize:2026-08-09-demo","submission":{"mode":"full"},"evidence":["exit:0"],"runtimeMaxSec":21600,"noEnqueue":true}
+  if ! jq -cn \
+    --arg call_dir "$call_dir" \
+    --arg dedup_key "$dedup_key" \
+    '{
+      argv: ["call-diarize", $call_dir],
+      adapter: "shell",
+      pool: ["coordinator-gpu"],
+      priority: "low",
+      source: "events-dir",
+      dedupKey: $dedup_key,
+      submission: {mode: "full"},
+      evidence: ["exit:0"],
+      runtimeMaxSec: 21600,
+      noEnqueue: true
+    }' >"$temporary"; then
+    rm -f -- "$temporary"
+    echo "call-diarize-backfill: cannot render event for: $call_dir" >&2
+    return 1
+  fi
+
+  if ! mv -fT -- "$temporary" "$event_path"; then
+    rm -f -- "$temporary"
+    echo "call-diarize-backfill: cannot publish event: $event_path" >&2
+    return 1
+  fi
+
+  printf 'queued diarization: %s -> %s\n' "$call_dir" "$event_path"
+}
+
+if [[ "${1:-}" == "--enqueue" ]]; then
+  [[ $# -eq 2 ]] || usage
+  enqueue_directory "$2"
+  warn_if_daemon_unavailable
+  exit 0
+fi
+
+[[ $# -le 1 ]] || usage
+if [[ $# -eq 1 ]]; then
+  recordings_root="$1"
+elif [[ -n "${CALL_RECORDINGS_ROOT:-}" ]]; then
+  recordings_root="${CALL_RECORDINGS_ROOT}"
+else
+  : "${HOME:?HOME is required when CALL_RECORDINGS_ROOT is unset}"
+  recordings_root="${HOME}/Recordings/calls"
+fi
+
+if [[ ! -d "$recordings_root" ]]; then
+  echo "call-diarize-backfill: no recordings directory: $recordings_root" >&2
+  exit 0
+fi
+
+queued=0
+failed=0
+while IFS= read -r -d '' call_dir; do
+  if [[ -e "$call_dir/transcript.md" ]]; then
+    continue
+  fi
+  if enqueue_directory "$call_dir"; then
+    ((queued += 1))
+  else
+    ((failed += 1))
+  fi
+done < <(find "$recordings_root" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+
+printf 'call-diarize-backfill: queued %d recording(s)' "$queued"
+if ((failed > 0)); then
+  printf '; failed %d' "$failed"
+fi
+printf '\n'
+
+if ((queued > 0)); then
+  warn_if_daemon_unavailable
+fi
+((failed == 0))

--- a/pkgs/call-diarize/default.nix
+++ b/pkgs/call-diarize/default.nix
@@ -5,6 +5,8 @@
   bash,
   coreutils,
   ffmpeg,
+  findutils,
+  jq,
   python313,
   python313Packages,
   uv,
@@ -26,11 +28,26 @@ stdenvNoCC.mkDerivation {
   src = ./.;
 
   nativeBuildInputs = [ makeWrapper ];
-  nativeCheckInputs = [ python313 ];
+  nativeCheckInputs = [
+    bash
+    coreutils
+    findutils
+    jq
+    python313
+  ];
   doCheck = true;
 
   checkPhase = ''
     runHook preCheck
+    ${bash}/bin/bash -n launcher.sh backfill.sh tests/test_backfill.sh
+    PATH=${
+      lib.makeBinPath [
+        coreutils
+        findutils
+        jq
+      ]
+    }:$PATH \
+      ${bash}/bin/bash tests/test_backfill.sh
     PYTHONPATH=$PWD ${python313}/bin/python -m unittest discover -s tests -v
     ${python313}/bin/python -m compileall -q call_diarize
     runHook postCheck
@@ -40,7 +57,7 @@ stdenvNoCC.mkDerivation {
     runHook preInstall
     mkdir -p $out/bin $out/libexec/call-diarize
     cp -R call_diarize model-support tests $out/libexec/call-diarize/
-    cp launcher.sh pyproject.toml uv.lock $out/libexec/call-diarize/
+    cp launcher.sh backfill.sh pyproject.toml uv.lock $out/libexec/call-diarize/
     makeWrapper ${bash}/bin/bash $out/bin/call-diarize \
       --add-flags "$out/libexec/call-diarize/launcher.sh" \
       --prefix PATH : ${
@@ -56,6 +73,15 @@ stdenvNoCC.mkDerivation {
       --set CALL_DIARIZE_PYTHON ${lib.escapeShellArg "${python}/bin/python3"} \
       --set CALL_DIARIZE_PYTHONPATH "$out/libexec/call-diarize:${runtimePythonPath}" \
       --set CALL_DIARIZE_TORCH_ROOT ${lib.escapeShellArg (toString torchRocm)}
+    makeWrapper ${bash}/bin/bash $out/bin/call-diarize-backfill \
+      --add-flags "$out/libexec/call-diarize/backfill.sh" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          findutils
+          jq
+        ]
+      }
     runHook postInstall
   '';
 

--- a/pkgs/call-diarize/tests/test_backfill.sh
+++ b/pkgs/call-diarize/tests/test_backfill.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+temporary="$(mktemp -d)"
+trap 'rm -rf -- "$temporary"' EXIT
+
+recordings="$temporary/Recordings/calls"
+events="$temporary/state/tally/events"
+mkdir -p \
+  "$recordings/2026-08-07-existing" \
+  "$recordings/2026-08-08-needs-diarization" \
+  "$recordings/2026-08-09-needs-diarization"
+: >"$recordings/2026-08-07-existing/transcript.md"
+
+TALLY_EVENTS_DIR="$events" \
+  TALLY_SOCKET="$temporary/missing-tally.sock" \
+  bash backfill.sh "$recordings"
+
+mapfile -d '' event_files < <(find "$events" -maxdepth 1 -type f -name '*.json' -print0 | sort -z)
+[[ ${#event_files[@]} -eq 2 ]]
+
+for event in "${event_files[@]}"; do
+  jq -e '
+    .argv[0] == "call-diarize" and
+    (.argv[1] | startswith("/")) and
+    .adapter == "shell" and
+    .pool == ["coordinator-gpu"] and
+    .priority == "low" and
+    .source == "events-dir" and
+    .dedupKey == ("call-diarize:" + (.argv[1] | split("/")[-1])) and
+    .submission == {"mode":"full"} and
+    .evidence == ["exit:0"] and
+    .runtimeMaxSec == 21600 and
+    .noEnqueue == true and
+    (keys | sort) == ([
+      "adapter", "argv", "dedupKey", "evidence", "noEnqueue", "pool",
+      "priority", "runtimeMaxSec", "source", "submission"
+    ] | sort)
+  ' "$event" >/dev/null
+done
+
+# Repeating the scan replaces the same deterministic pending files rather than
+# multiplying events before tally has a chance to claim them.
+TALLY_EVENTS_DIR="$events" \
+  TALLY_SOCKET="$temporary/missing-tally.sock" \
+  bash backfill.sh "$recordings" >/dev/null
+[[ "$(find "$events" -maxdepth 1 -type f -name '*.json' -print | wc -l)" -eq 2 ]]
+
+single="$recordings/2026-08-10-single"
+mkdir -p "$single"
+TALLY_EVENTS_DIR="$events" \
+  TALLY_SOCKET="$temporary/missing-tally.sock" \
+  bash backfill.sh --enqueue "$single" >/dev/null
+
+single_event="$(
+  find "$events" -maxdepth 1 -type f -name '*.json' -print0 \
+    | xargs -0 jq -r 'select(.dedupKey == "call-diarize:2026-08-10-single") | input_filename'
+)"
+[[ -n "$single_event" ]]
+jq -e --arg directory "$(realpath "$single")" \
+  '.argv == ["call-diarize", $directory]' "$single_event" >/dev/null


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=crm-call-drain issue=163 task=recordings-drain revision=sha256:f4042004a246a8fae65a2f1d10cc75cc71c51a3522b070fb8b08c407266eb8a6 -->
Spec-build campaign progress for mecattaf/dotfiles#163.

Task `recordings-drain`: Auto-queue diarization for new call recordings through tally

Task ref: `crm-call-drain/recordings-drain`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/163
Head: `50036276462988e14ac43d7e780133f748ff9d7f`

Closes #169