### PR TITLE
recordings-drain: Auto-queue diarization for new call recordings through tally

### DIFF
--- a/pkgs/call-diarize/tests/test_call_record.sh
+++ b/pkgs/call-diarize/tests/test_call_record.sh
@@ -121,3 +121,28 @@ jq -e --arg directory "$call_dir" '
 [[ "$(<"$stop_stderr")" == \
   "warning: tally daemon is unavailable; event is queued for a later drain" ]]
 [[ "$(<"$stop_stdout")" == queued\ diarization:*session\ closed:* ]]
+
+# Exercise the real helper's failure path too: a non-directory parent makes
+# the events directory unusable, but a finalized recording must still close.
+blocked_events="$temporary/events-not-directory"
+: >"$blocked_events"
+call_dir="$test_home/Recordings/calls/2026-08-09-unavailable-events"
+stop_stdout="$temporary/stop-unavailable-events.out"
+stop_stderr="$temporary/stop-unavailable-events.err"
+mkdir -p "$call_dir"
+printf 'far audio\n' >"$call_dir/far.wav"
+printf 'near audio\n' >"$call_dir/near.wav"
+printf '%s\n99999998\n99999999\n' "$call_dir" >"$current"
+
+HOME="$test_home" \
+  XDG_STATE_HOME="$state_home" \
+  PATH="$fake_bin:$PATH" \
+  TALLY_EVENTS_DIR="$blocked_events/events" \
+  TALLY_SOCKET="$temporary/missing-tally.sock" \
+  "$test_bash" "$call_record" stop >"$stop_stdout" 2>"$stop_stderr"
+
+[[ ! -e "$current" ]]
+[[ "$(<"$call_dir/mix.wav")" == "finalized mix" ]]
+[[ "$(<"$stop_stderr")" == \
+  *"warning: diarization was not queued; run call-diarize-backfill later"* ]]
+[[ "$(<"$stop_stdout")" == session\ closed:* ]]


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=crm-call-drain issue=163 task=recordings-drain revision=sha256:68cf418d5e2a2743091a0579c921663fd1c3bd5aeb3b1e2729ceb44d120caaee -->
Spec-build campaign progress for mecattaf/dotfiles#163.

Task `recordings-drain`: Auto-queue diarization for new call recordings through tally

Task ref: `crm-call-drain/recordings-drain`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/163
Head: `4f98bbf5bca0da2fb84e21fcf0e8360ffc2e9ea5`

Closes #169