### PR TITLE
diarize-resume: call-diarize: resume or quarantine over partial evidence from an interrupted run

### DIFF
--- a/pkgs/call-diarize/call_diarize/cli.py
+++ b/pkgs/call-diarize/call_diarize/cli.py
@@ -7,8 +7,10 @@ import gc
 import hashlib
 import math
 import os
+import shutil
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -150,6 +152,36 @@ def _ensure_run_config(raw_root: Path, expected: dict[str, Any]) -> None:
             )
         return
     write_json_exclusive(path, expected)
+
+
+def _prepare_raw_root(call_dir: Path) -> Path:
+    """Start incomplete reruns with a clean evidence directory.
+
+    Evidence from a run that reached its final transcript remains protected. If
+    no transcript was published, preserve the interrupted run wholesale under
+    a timestamped sibling before creating the new run's evidence root.
+    """
+
+    raw_root = call_dir / "asr-raw"
+    transcript_path = call_dir / "transcript.md"
+    raw_root_exists = raw_root.exists() or raw_root.is_symlink()
+    if raw_root_exists and not transcript_path.exists():
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+        quarantine_base = call_dir / f"asr-raw.stale-{timestamp}"
+        quarantine = quarantine_base
+        suffix = 2
+        while quarantine.exists() or quarantine.is_symlink():
+            quarantine = quarantine_base.with_name(
+                f"{quarantine_base.name}-{suffix}"
+            )
+            suffix += 1
+        shutil.move(str(raw_root), str(quarantine))
+        print(
+            f"call-diarize: quarantined partial evidence: {raw_root} -> {quarantine}",
+            flush=True,
+        )
+    raw_root.mkdir(parents=True, exist_ok=True)
+    return raw_root
 
 
 def _load_or_transcribe(
@@ -431,8 +463,7 @@ def execute(args: argparse.Namespace) -> int:
         flush=True,
     )
 
-    raw_root = call_dir / "asr-raw"
-    raw_root.mkdir(parents=True, exist_ok=True)
+    raw_root = _prepare_raw_root(call_dir)
     _ensure_run_config(raw_root, _run_config(call_dir, hotwords))
 
     selected_by_track: dict[str, list[tuple[Window, dict[str, Any], str]]] = {

--- a/pkgs/call-diarize/tests/test_cli.py
+++ b/pkgs/call-diarize/tests/test_cli.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from call_diarize.cli import _prepare_raw_root, execute, parser
+from call_diarize.pipeline import load_json, write_json_exclusive
+
+
+class EvidenceRerunTests(unittest.TestCase):
+    attempt_relative = Path("cleanup/gemma/shard-005.attempt-01.json")
+
+    def test_rerun_quarantines_partial_evidence_and_can_rewrite_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            call_dir = Path(temporary)
+            interrupted_attempt = call_dir / "asr-raw" / self.attempt_relative
+            write_json_exclusive(interrupted_attempt, {"error": "interrupted"})
+
+            with redirect_stdout(io.StringIO()):
+                raw_root = _prepare_raw_root(call_dir)
+
+            quarantines = list(call_dir.glob("asr-raw.stale-*"))
+            self.assertEqual(len(quarantines), 1)
+            self.assertEqual(
+                load_json(quarantines[0] / self.attempt_relative),
+                {"error": "interrupted"},
+            )
+
+            rerun_attempt = raw_root / self.attempt_relative
+            write_json_exclusive(rerun_attempt, {"result": "fresh rerun"})
+            self.assertEqual(load_json(rerun_attempt), {"result": "fresh rerun"})
+
+    def test_completed_transcript_leaves_evidence_protected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            call_dir = Path(temporary)
+            transcript = call_dir / "transcript.md"
+            transcript.write_text("# Completed transcript\n", encoding="utf-8")
+            attempt = call_dir / "asr-raw" / self.attempt_relative
+            write_json_exclusive(attempt, {"result": "completed run"})
+
+            args = parser().parse_args([str(call_dir)])
+            with redirect_stdout(io.StringIO()):
+                status = execute(args)
+                protected_raw_root = _prepare_raw_root(call_dir)
+
+            self.assertEqual(status, 0)
+            self.assertEqual(protected_raw_root, call_dir / "asr-raw")
+            self.assertEqual(load_json(attempt), {"result": "completed run"})
+            self.assertEqual(list(call_dir.glob("asr-raw.stale-*")), [])
+            with self.assertRaisesRegex(
+                RuntimeError, "refusing to overwrite existing evidence"
+            ):
+                write_json_exclusive(attempt, {"result": "clobbered"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=crm-call-drain issue=163 task=diarize-resume revision=sha256:3ae0d013f5b9591a14f98ed1ed2fd8aa7b4d4459d1b4d64f28952ae3d812c552 -->
Spec-build campaign progress for mecattaf/dotfiles#163.

Task `diarize-resume`: call-diarize: resume or quarantine over partial evidence from an interrupted run

Task ref: `crm-call-drain/diarize-resume`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/163
Head: `bbf039d2bd62dd982b3cea635b96360cf9eafa76`

Closes #183