### PR TITLE
diarize-idempotency: call-diarize: idempotent segment extraction — retry path must never fail on existing intermediate files

### DIFF
--- a/pkgs/call-diarize/call_diarize/pipeline.py
+++ b/pkgs/call-diarize/call_diarize/pipeline.py
@@ -7,6 +7,7 @@ import json
 import math
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import wave
@@ -167,6 +168,12 @@ def segment_track(
     """Use ffmpeg's segment muxer to make aligned 24 kHz model inputs."""
 
     track_dir = output_dir / f"{track}-{seconds:02d}s"
+    # The muxer overwrites only the indexes it emits. Rebuild the directory so
+    # an old high-numbered chunk cannot survive into the new window list.
+    if track_dir.is_symlink() or track_dir.is_file():
+        track_dir.unlink()
+    elif track_dir.exists():
+        shutil.rmtree(track_dir)
     track_dir.mkdir(parents=True, exist_ok=True)
     pattern = track_dir / f"{track}-%06d.wav"
     subprocess.run(

--- a/pkgs/call-diarize/tests/test_pipeline.py
+++ b/pkgs/call-diarize/tests/test_pipeline.py
@@ -60,12 +60,15 @@ class SegmentExtractionTests(unittest.TestCase):
                 handle.writeframes(b"\0\0" * 48_000)
 
             first_segments = segment_track(source, "mix", 1, root)
+            stale_segment = first_segments[0].audio_path.with_name("mix-999999.wav")
+            stale_segment.write_bytes(first_segments[0].audio_path.read_bytes())
             first_segments[0].audio_path.write_bytes(b"interrupted initial extraction")
             second_segments = segment_track(source, "mix", 1, root)
             self.assertEqual(
                 [window.audio_path for window in second_segments],
                 [window.audio_path for window in first_segments],
             )
+            self.assertFalse(stale_segment.exists())
             self.assertAlmostEqual(second_segments[0].actual_seconds, 1.0)
 
             first_retry = slice_track(source, "mix", 0.0, 1, root)


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=crm-call-drain issue=163 task=diarize-idempotency revision=sha256:9c87440eed8025e2b0ee42596cdb33188ff0bd269775a27653c65400e60f257d -->
Spec-build campaign progress for mecattaf/dotfiles#163.

Task `diarize-idempotency`: call-diarize: idempotent segment extraction — retry path must never fail on existing intermediate files

Task ref: `crm-call-drain/diarize-idempotency`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/163
Head: `ae67cc5af0c817d9757dac404a1795f2c0954e92`

Closes #178