### PR TITLE
cleanup-robustness: call-diarize: cleanup stage must degrade gracefully — fix unavailable-segment ordering rejection; raw-ASR fallback on shard failure

### DIFF
--- a/pkgs/call-diarize/call_diarize/cleanup.py
+++ b/pkgs/call-diarize/call_diarize/cleanup.py
@@ -32,6 +32,14 @@ action is exactly keep, duplicate, or unavailable. duplicate_of is an earlier so
 only for duplicate; otherwise it is null. Do not add prose or Markdown fences."""
 
 
+class CleanupShardFailure(RuntimeError):
+    """A cleanup model exhausted its retry budget for one bounded shard."""
+
+    def __init__(self, report: dict[str, Any]) -> None:
+        self.report = report
+        super().__init__(str(report["error"]))
+
+
 def _models_url(endpoint: str) -> str:
     marker = "/v1/chat/completions"
     if marker in endpoint:
@@ -125,13 +133,22 @@ def validate_decisions(
         raise ValueError(
             "decision IDs are missing, duplicated, invented, or out of order"
         )
+    candidates_by_id = {
+        str(candidate["source_id"]): candidate for candidate in shard["candidates"]
+    }
     normalized: list[dict[str, Any]] = []
     for item, source_id in zip(decisions, expected, strict=True):
         action = item.get("action")
-        if action not in ALLOWED_ACTIONS:
-            raise ValueError(f"invalid action for {source_id}: {action!r}")
         duplicate_of = item.get("duplicate_of")
-        if action == "duplicate":
+        if candidates_by_id[source_id].get("kind") == "unavailable":
+            # Availability is fixed by deterministic ASR validation before cleanup.
+            # A model cannot make this row removable, so its proposed action and
+            # duplicate target carry no ordering invariant to validate.
+            action = "unavailable"
+            duplicate_of = None
+        elif action not in ALLOWED_ACTIONS:
+            raise ValueError(f"invalid action for {source_id}: {action!r}")
+        elif action == "duplicate":
             if not isinstance(duplicate_of, str) or duplicate_of not in global_order:
                 raise ValueError(
                     f"invalid duplicate target for {source_id}: {duplicate_of!r}"
@@ -273,10 +290,77 @@ def run_model_shard(
                     "error": correction,
                 },
             )
-    raise RuntimeError(
+    message = (
         f"{model} failed cleanup shard {shard['shard_id']} after {retries} attempts: "
         + " | ".join(errors)
     )
+    raise CleanupShardFailure(
+        {
+            "schema": 1,
+            "status": "cleanup-failed",
+            "nonfatal": True,
+            "fallback": "raw-asr",
+            "label": label,
+            "model": model,
+            "shard_id": shard["shard_id"],
+            "candidate_ids": [
+                str(candidate["source_id"]) for candidate in shard["candidates"]
+            ],
+            "attempt_count": len(errors),
+            "attempts": [
+                {"attempt": first_attempt + index, "error": error}
+                for index, error in enumerate(errors)
+            ],
+            "error": message,
+        }
+    )
+
+
+def _cached_failure_report(
+    label: str,
+    model: str,
+    shard: dict[str, Any],
+    raw_root: Path,
+) -> tuple[Path, dict[str, Any] | None]:
+    path = raw_root / "cleanup" / label / f"shard-{shard['shard_id']}.failed.json"
+    if not path.exists():
+        return path, None
+    report = load_json(path)
+    expected_ids = [str(candidate["source_id"]) for candidate in shard["candidates"]]
+    expected_path = str(path.relative_to(raw_root))
+    if (
+        not isinstance(report, dict)
+        or report.get("status") != "cleanup-failed"
+        or report.get("nonfatal") is not True
+        or report.get("fallback") != "raw-asr"
+        or report.get("label") != label
+        or report.get("model") != model
+        or str(report.get("shard_id")) != str(shard["shard_id"])
+        or report.get("candidate_ids") != expected_ids
+        or report.get("evidence_path") != expected_path
+    ):
+        raise RuntimeError(f"cached cleanup failure mismatch: {path}")
+    return path, report
+
+
+def _raw_fallback_decisions(
+    shard: dict[str, Any], report: dict[str, Any]
+) -> list[dict[str, Any]]:
+    reason = (
+        f"raw-ASR fallback after {report['label']} cleanup failed "
+        f"shard {report['shard_id']}"
+    )
+    return [
+        {
+            "source_id": str(candidate["source_id"]),
+            "action": (
+                "unavailable" if candidate.get("kind") == "unavailable" else "keep"
+            ),
+            "duplicate_of": None,
+            "reason": reason,
+        }
+        for candidate in shard["candidates"]
+    ]
 
 
 def run_both_models(
@@ -285,38 +369,75 @@ def run_both_models(
     raw_root: Path,
     endpoint: str,
     timeout: int,
-) -> dict[str, dict[str, dict[str, Any]]]:
+) -> tuple[
+    dict[str, dict[str, dict[str, Any]]],
+    list[dict[str, Any]],
+]:
+    shard_list = list(shards)
     global_order = {str(row["source_id"]): index for index, row in enumerate(rows)}
     decisions_by_model: dict[str, dict[str, dict[str, Any]]] = {}
+    failures: list[dict[str, Any]] = []
     for label, model in MODELS.items():
         by_id: dict[str, dict[str, Any]] = {}
-        for shard in shards:
+        for shard in shard_list:
             print(
                 f"cleanup {label} shard {shard['shard_id']} "
                 f"({shard['candidate_count']} candidates)",
                 flush=True,
             )
-            for decision in run_model_shard(
-                label,
-                model,
-                shard,
-                raw_root,
-                endpoint,
-                global_order,
-                timeout,
-            ):
+            failure_path, failure = _cached_failure_report(
+                label, model, shard, raw_root
+            )
+            if failure is None:
+                try:
+                    model_decisions = run_model_shard(
+                        label,
+                        model,
+                        shard,
+                        raw_root,
+                        endpoint,
+                        global_order,
+                        timeout,
+                    )
+                except CleanupShardFailure as exc:
+                    failure = {
+                        **exc.report,
+                        "evidence_path": str(failure_path.relative_to(raw_root)),
+                    }
+                    write_json_exclusive(failure_path, failure)
+            if failure is not None:
+                failures.append(failure)
+                print(
+                    f"call-diarize: warning: cleanup {label} shard "
+                    f"{shard['shard_id']} exhausted retries; using raw ASR",
+                    flush=True,
+                )
+                model_decisions = _raw_fallback_decisions(shard, failure)
+            for decision in model_decisions:
                 by_id[decision["source_id"]] = decision
         if set(by_id) != set(global_order):
             raise RuntimeError(f"{model} did not account for every source candidate")
         decisions_by_model[label] = by_id
-    return decisions_by_model
+    return decisions_by_model, failures
 
 
 def reduce_consensus(
     rows: list[dict[str, Any]],
     decisions: dict[str, dict[str, dict[str, Any]]],
+    cleanup_failures: Iterable[dict[str, Any]] = (),
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Keep by default; drop only two-model duplicate consensus plus lexical proof."""
+
+    failures_by_source: dict[str, list[dict[str, Any]]] = {}
+    for failure in cleanup_failures:
+        summary = {
+            "label": failure["label"],
+            "model": failure["model"],
+            "shard_id": str(failure["shard_id"]),
+            "evidence_path": failure["evidence_path"],
+        }
+        for source_id in failure["candidate_ids"]:
+            failures_by_source.setdefault(str(source_id), []).append(summary)
 
     kept: list[dict[str, Any]] = []
     dropped: list[dict[str, Any]] = []
@@ -342,9 +463,11 @@ def reduce_consensus(
                 }
             )
 
+        row_failures = failures_by_source.get(source_id, [])
         lexical_target = lexical_duplicate_target(row, kept)
         consensus_duplicate = (
-            row.get("kind") == "speech"
+            not row_failures
+            and row.get("kind") == "speech"
             and gemma["action"] == "duplicate"
             and qwen["action"] == "duplicate"
             and lexical_target is not None
@@ -359,10 +482,11 @@ def reduce_consensus(
                 }
             )
         else:
-            kept.append(
-                {
-                    **row,
-                    "cleanup_decisions": {"gemma": gemma, "qwen": qwen},
-                }
-            )
+            kept_row = {
+                **row,
+                "cleanup_decisions": {"gemma": gemma, "qwen": qwen},
+            }
+            if row_failures:
+                kept_row["cleanup_failures"] = row_failures
+            kept.append(kept_row)
     return kept, dropped, disagreements

--- a/pkgs/call-diarize/call_diarize/cli.py
+++ b/pkgs/call-diarize/call_diarize/cli.py
@@ -332,8 +332,22 @@ def _render_transcript(rows: list[dict[str, Any]], manifest: dict[str, Any]) -> 
         ),
         "",
     ]
+    marked_failure_shards: set[str] = set()
     for row in rows:
-        label = "unavailable" if row["kind"] == "unavailable" else "speech"
+        cleanup_failures = row.get("cleanup_failures", [])
+        failed_shards = sorted(
+            {str(failure["shard_id"]) for failure in cleanup_failures}
+        )
+        for shard_id in failed_shards:
+            if shard_id not in marked_failure_shards:
+                lines.extend([f"<!-- cleanup-failed shard-{shard_id} -->", ""])
+                marked_failure_shards.add(shard_id)
+        if failed_shards:
+            label = "raw; cleanup-failed " + ",".join(
+                f"shard-{shard_id}" for shard_id in failed_shards
+            )
+        else:
+            label = "unavailable" if row["kind"] == "unavailable" else "speech"
         lines.extend(
             [
                 (
@@ -367,6 +381,7 @@ def _review_item(prefix: str, item: dict[str, Any]) -> list[str]:
 def _render_review(
     rejections: list[dict[str, Any]],
     final_unavailable: list[dict[str, Any]],
+    cleanup_failures: list[dict[str, Any]],
     disagreements: list[dict[str, Any]],
     lexical_conflicts: list[dict[str, Any]],
     dropped: list[dict[str, Any]],
@@ -376,6 +391,7 @@ def _render_review(
         for rejection in rejections
         for row in rejection["low_channel_support_rows"]
     ]
+    failed_shards = {str(failure["shard_id"]) for failure in cleanup_failures}
     lines = [
         "# Call transcript review queue",
         "",
@@ -385,6 +401,8 @@ def _render_review(
         "",
         f"- Rejected ASR windows across all retry levels: {len(rejections)}",
         f"- Final unavailable spans: {len(final_unavailable)}",
+        f"- Cleanup model/shard failures: {len(cleanup_failures)}",
+        f"- Raw-ASR fallback shards: {len(failed_shards)}",
         f"- Low-channel-support rows seen in rejected windows: {len(low_support)}",
         f"- Gemma/Qwen decision disagreements: {len(disagreements)}",
         f"- Near/far versus mixed lexical conflicts: {len(lexical_conflicts)}",
@@ -396,6 +414,22 @@ def _render_review(
     if final_unavailable:
         for item in final_unavailable:
             lines.extend(_review_item("unavailable", item))
+    else:
+        lines.append("None.")
+
+    lines.extend(["", "## Cleanup raw-ASR fallbacks", ""])
+    if cleanup_failures:
+        for failure in cleanup_failures:
+            lines.extend(
+                [
+                    (
+                        f"- shard-{failure['shard_id']} `{failure['label']}` "
+                        f"({failure['model']}): kept {len(failure['candidate_ids'])} "
+                        "raw candidate(s)."
+                    ),
+                    f"  - Evidence: `{failure['evidence_path']}`",
+                ]
+            )
     else:
         lines.append("None.")
 
@@ -561,14 +595,16 @@ def execute(args: argparse.Namespace) -> int:
             if previous
             else None
         )
-    decisions = run_both_models(
+    decisions, cleanup_failures = run_both_models(
         shards,
         isolated,
         raw_root,
         args.llama_swap_endpoint,
         args.llama_timeout,
     )
-    cleaned, dropped, disagreements = reduce_consensus(isolated, decisions)
+    cleaned, dropped, disagreements = reduce_consensus(
+        isolated, decisions, cleanup_failures
+    )
 
     leaf_counts = {"60": 0, "30": 0, "15": 0}
     for selected in selected_by_track.values():
@@ -578,6 +614,14 @@ def execute(args: argparse.Namespace) -> int:
         float(item.get("generation_seconds", 0)) for item in runtime_records
     )
     audio_seconds = sum(float(item.get("audio_seconds", 0)) for item in runtime_records)
+    raw_fallback_shards = {
+        str(failure["shard_id"]) for failure in cleanup_failures
+    }
+    raw_fallback_candidates = {
+        str(source_id)
+        for failure in cleanup_failures
+        for source_id in failure["candidate_ids"]
+    }
     manifest = {
         "schema": 1,
         "pipeline_version": __version__,
@@ -593,6 +637,10 @@ def execute(args: argparse.Namespace) -> int:
         "isolated_candidate_count": len(isolated),
         "published_row_count": len(cleaned),
         "consensus_duplicate_drop_count": len(dropped),
+        "cleanup_failure_count": len(cleanup_failures),
+        "raw_fallback_shard_count": len(raw_fallback_shards),
+        "raw_fallback_candidate_count": len(raw_fallback_candidates),
+        "cleanup_failures": cleanup_failures,
         "asr_generation_seconds": round(generation_seconds, 3),
         "asr_audio_seconds": round(audio_seconds, 3),
         "asr_realtime_factor": round(generation_seconds / max(audio_seconds, 0.001), 3),
@@ -616,6 +664,7 @@ def execute(args: argparse.Namespace) -> int:
     review = _render_review(
         rejections,
         final_unavailable,
+        cleanup_failures,
         disagreements,
         lexical_conflicts,
         dropped,

--- a/pkgs/call-diarize/tests/test_cli.py
+++ b/pkgs/call-diarize/tests/test_cli.py
@@ -5,9 +5,10 @@ import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 from call_diarize.cli import _prepare_raw_root, execute, parser
-from call_diarize.pipeline import load_json, write_json_exclusive
+from call_diarize.pipeline import Window, load_json, write_json_exclusive
 
 
 class EvidenceRerunTests(unittest.TestCase):
@@ -71,6 +72,130 @@ class EvidenceRerunTests(unittest.TestCase):
                 RuntimeError, "refusing to overwrite existing evidence"
             ):
                 write_json_exclusive(attempt, {"result": "clobbered"})
+
+
+class CleanupFallbackTests(unittest.TestCase):
+    def test_exhausted_cleanup_shard_publishes_marked_raw_transcript(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            call_dir = Path(temporary) / "call"
+            call_dir.mkdir()
+            for name in ("near.wav", "far.wav", "mix.wav"):
+                (call_dir / name).write_bytes(b"test recording placeholder")
+
+            asr_window = Window("near", 0.0, 60, 1.0, call_dir / "near.wav")
+            raw_row = {
+                "source_id": "near-000000000000-60-s000",
+                "track": "near",
+                "speaker": "Thomas",
+                "start": 0.0,
+                "end": 1.0,
+                "text": "Unedited raw ASR sentence.",
+                "kind": "speech",
+                "source_raw": "near/60s/000000000000.json",
+            }
+            runtime = {
+                "device_name": "test GPU",
+                "generation_seconds": 1.0,
+                "audio_seconds": 1.0,
+            }
+
+            def record_asr_leaf(
+                initial,
+                _levels,
+                _source,
+                _temp_root,
+                _engine,
+                _hotwords,
+                _raw_root,
+                _activity,
+                selected,
+                _unavailable,
+                _rejections,
+                runtime_records,
+            ):
+                selected.append((initial, {"segments": []}, initial.key))
+                runtime_records.append(runtime)
+
+            activity_context = mock.MagicMock()
+            activity_context.__enter__.return_value = mock.MagicMock()
+            activity_context.__exit__.return_value = False
+            gpu = {
+                "device_name": "test GPU",
+                "torch_version": "test Torch",
+                "rocm_version": "test ROCm",
+            }
+            args = parser().parse_args([str(call_dir)])
+
+            with (
+                mock.patch(
+                    "call_diarize.cli.validate_capture_files",
+                    return_value={"near": 1.0, "far": 1.0, "mix": 1.0},
+                ),
+                mock.patch(
+                    "call_diarize.cli._state_root", return_value=call_dir / "state"
+                ),
+                mock.patch(
+                    "call_diarize.cli._support_dir",
+                    return_value=call_dir / "support",
+                ),
+                mock.patch(
+                    "call_diarize.cli.ensure_model_layout",
+                    return_value=call_dir / "model",
+                ),
+                mock.patch(
+                    "call_diarize.cli.preflight_models",
+                    return_value=["gemma4-26b-a4b-it", "qwen3.6-35b-a3b"],
+                ),
+                mock.patch("call_diarize.cli.gpu_probe", return_value=gpu),
+                mock.patch(
+                    "call_diarize.cli.segment_track",
+                    side_effect=[[asr_window], [], []],
+                ),
+                mock.patch(
+                    "call_diarize.cli.AudioActivity",
+                    return_value=activity_context,
+                ),
+                mock.patch("call_diarize.cli.VibeVoiceASR"),
+                mock.patch(
+                    "call_diarize.cli._process_tree",
+                    side_effect=record_asr_leaf,
+                ),
+                mock.patch(
+                    "call_diarize.cli._rows_from_selected",
+                    side_effect=[[raw_row], []],
+                ),
+                mock.patch(
+                    "call_diarize.cleanup._http_json",
+                    side_effect=ValueError("forced invalid cleanup response"),
+                ) as cleanup_request,
+                redirect_stdout(io.StringIO()),
+            ):
+                status = execute(args)
+
+            self.assertEqual(status, 0)
+            self.assertEqual(cleanup_request.call_count, 6)
+            transcript = (call_dir / "transcript.md").read_text(encoding="utf-8")
+            self.assertIn("Unedited raw ASR sentence.", transcript)
+            self.assertIn("<!-- cleanup-failed shard-000 -->", transcript)
+            self.assertIn("(raw; cleanup-failed shard-000)", transcript)
+
+            manifest = load_json(call_dir / "asr-raw/manifest.json")
+            self.assertEqual(manifest["cleanup_failure_count"], 2)
+            self.assertEqual(manifest["raw_fallback_shard_count"], 1)
+            self.assertEqual(manifest["raw_fallback_candidate_count"], 1)
+            self.assertTrue(
+                all(failure["nonfatal"] for failure in manifest["cleanup_failures"])
+            )
+            for label in ("gemma", "qwen"):
+                report = load_json(
+                    call_dir
+                    / f"asr-raw/cleanup/{label}/shard-000.failed.json"
+                )
+                self.assertEqual(report["fallback"], "raw-asr")
+                self.assertEqual(report["attempt_count"], 3)
+
+            review = (call_dir / "review-queue.md").read_text(encoding="utf-8")
+            self.assertIn("Raw-ASR fallback shards: 1", review)
 
 
 if __name__ == "__main__":

--- a/pkgs/call-diarize/tests/test_pipeline.py
+++ b/pkgs/call-diarize/tests/test_pipeline.py
@@ -273,6 +273,36 @@ class CleanupContractTests(unittest.TestCase):
         normalized = validate_decisions(value, shard, {"a": 0, "b": 1})
         self.assertEqual([item["source_id"] for item in normalized], ["a", "b"])
 
+    def test_unavailable_row_ignores_non_earlier_duplicate_target(self) -> None:
+        unavailable = unavailable_row(
+            Window("near", 480.0, 15, 15.0, Path("unused.wav")),
+            "near/15s/000000480000.json",
+            ["forced unavailable"],
+        )
+        source_id = "near-000000480000-15-unavailable"
+        self.assertEqual(unavailable["source_id"], source_id)
+        shard = {
+            "shard_id": "006",
+            "candidate_count": 1,
+            "candidates": [unavailable],
+        }
+        value = {
+            "shard_id": "006",
+            "decisions": [
+                {
+                    "source_id": source_id,
+                    "action": "duplicate",
+                    "duplicate_of": source_id,
+                    "reason": "model confused fixed availability with duplication",
+                }
+            ],
+        }
+
+        normalized = validate_decisions(value, shard, {source_id: 0})
+
+        self.assertEqual(normalized[0]["action"], "unavailable")
+        self.assertIsNone(normalized[0]["duplicate_of"])
+
     def test_drop_requires_both_models_and_lexical_match(self) -> None:
         first = row("a", "This is an unmistakable repeated sentence.", 0, 3)
         second = row("b", "This is an unmistakable repeated sentence.", 3, 6)


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=crm-call-drain issue=163 task=cleanup-robustness revision=sha256:293596210973ef0cffc30aebf321e9c232bcc66a15ee936a1ff3d8508c7769d0 -->
Spec-build campaign progress for mecattaf/dotfiles#163.

Task `cleanup-robustness`: call-diarize: cleanup stage must degrade gracefully — fix unavailable-segment ordering rejection; raw-ASR fallback on shard failure

Task ref: `crm-call-drain/cleanup-robustness`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/163
Head: `2fd1c7a3a90c77b4b5b91cc78cdb13f117e7f9d5`

Closes #189