### PR TITLE
tally: advance pin to 089d000

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1283,11 +1283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786330798,
-        "narHash": "sha256-RIQqpzMaknDSgRwIxAl9XNCuaC3lnGuQH6N01NfUCzM=",
+        "lastModified": 1786337566,
+        "narHash": "sha256-JOUQNxx6A/V51KNYzTWQke90tPRtAU6yvttEsAwfHSI=",
         "owner": "mecattaf",
         "repo": "tally.nix",
-        "rev": "40bd3ef0aaf0c3dfbfdd93cce9b74c1e2028f025",
+        "rev": "089d00065a425bb3d00c6c17d489d557a08fd78a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Advance the `tally` flake input from `40bd3ef` to `089d000`, incorporating campaign recovery PR #453 and the Nix-source test fix in PR #454.

## Why

The previous pin predates the bounded/auditable campaign recovery changes. The first merged revision exposed a test fixture that relied on source-tree Git metadata; `089d000` includes the hermetic follow-up and is the first revision proven to package cleanly under both Tally's standalone flake and dotfiles' toolchain.

## Impact

Only the Tally lock node changes. The repository's deliberately lagged primary nixpkgs input and all other inputs remain untouched.

## Validation

- `nix flake check --no-build` — all checks passed
- `nix build .#nixosConfigurations.coordinator.config.system.build.toplevel --no-link --print-out-paths` → `/nix/store/dxh6qrnr2aci04dis9b6s3nwvlzahi8y-nixos-system-coordinator-26.11.20260723.e2587ca`
- The build includes Tally's complete Nix package test suite under the dotfiles Rust/Nixpkgs toolchain
