### PR TITLE
dcal-tally-source: dcal: project tally scheduled runs into a read-only calendar

### DIFF
--- a/pkgs/dcal/cmd/dcal/commands_test.go
+++ b/pkgs/dcal/cmd/dcal/commands_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -124,6 +126,7 @@ func TestFreshSyncAndStatusAreCleanNoOps(t *testing.T) {
 	stdout, stderr, code := runCLI(t, "", "sync")
 	require.Equal(t, 0, code, stderr)
 	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "tally source skipped")
 
 	stdout, stderr, code = runCLI(t, "", "status", "--format", "json")
 	require.Equal(t, 0, code, stderr)
@@ -132,6 +135,64 @@ func TestFreshSyncAndStatusAreCleanNoOps(t *testing.T) {
 	stdout, stderr, code = runCLI(t, "", "account", "ls", "--format", "json")
 	require.Equal(t, 0, code, stderr)
 	assert.JSONEq(t, `[]`, stdout)
+}
+
+func TestTallyFixtureSyncIsIdempotentAndReadOnly(t *testing.T) {
+	root := shortTempRoot(t)
+	setCLIEnv(t, root)
+	t.Setenv("DCAL_DISABLE_HTTP", "true")
+	fixture, err := filepath.Abs(filepath.Join("..", "..", "testdata", "tally-producers.json"))
+	require.NoError(t, err)
+
+	_, stderr, code := runCLI(t, "", "sync", "--tally-fixture", fixture)
+	require.Equal(t, 0, code, stderr)
+	first := cliStatus(t)
+	require.Len(t, first.Calendars, 1)
+	assert.Equal(t, "tally", first.Calendars[0].Name)
+	require.Greater(t, first.Events, 0)
+
+	_, stderr, code = runCLI(t, "", "sync", "--tally-fixture", fixture)
+	require.Equal(t, 0, code, stderr)
+	second := cliStatus(t)
+	assert.Equal(t, first.Events, second.Events)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	services, err := bootDaemonServices(ctx)
+	require.NoError(t, err)
+	t.Cleanup(services.Close)
+
+	stdout, stderr, code := runCLI(t, services.SocketPath(), "ls", "--calendar", "tally", "--format", "json")
+	require.Equal(t, 0, code, stderr)
+	var events []eventRecord
+	require.NoError(t, json.Unmarshal([]byte(stdout), &events))
+	require.NotEmpty(t, events)
+	assert.True(t, hasFutureEvent(events, time.Now()))
+
+	_, stderr, code = runCLI(t, services.SocketPath(), "edit", events[0].ID, "--title", "changed")
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "read-only")
+	_, stderr, code = runCLI(t, services.SocketPath(), "rm", events[0].ID)
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "read-only")
+}
+
+func cliStatus(t *testing.T) statusResult {
+	t.Helper()
+	stdout, stderr, code := runCLI(t, "", "status", "--format", "json")
+	require.Equal(t, 0, code, stderr)
+	var result statusResult
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	return result
+}
+
+func hasFutureEvent(events []eventRecord, now time.Time) bool {
+	for _, event := range events {
+		if event.Start.After(now) {
+			return true
+		}
+	}
+	return false
 }
 
 func shortTempRoot(t *testing.T) string {
@@ -152,6 +213,7 @@ func setCLIEnv(t *testing.T, root string) {
 		"DCAL_GOOGLE_CLIENT_ID",
 		"DCAL_GOOGLE_CLIENT_SECRET",
 		"DCAL_MICROSOFT_CLIENT_ID",
+		"TALLY_SOCKET",
 	} {
 		unsetEnv(t, key)
 	}

--- a/pkgs/dcal/cmd/dcal/sync.go
+++ b/pkgs/dcal/cmd/dcal/sync.go
@@ -16,8 +16,11 @@ import (
 	"github.com/mecattaf/dcal/internal/providers/microsoft"
 	"github.com/mecattaf/dcal/internal/support/log"
 	"github.com/mecattaf/dcal/internal/sync"
+	"github.com/mecattaf/dcal/internal/tallysource"
 	"github.com/mecattaf/dcal/repo"
 )
+
+var tallyFixture string
 
 var syncCmd = &cobra.Command{
 	Use:   "sync [account-id]",
@@ -28,13 +31,8 @@ var syncCmd = &cobra.Command{
 		if len(args) == 1 {
 			accountID = args[0]
 		}
-
-		if notifyDaemon(accountID, true) {
-			if jsonOutput {
-				return printJSON(syncResult("started", true, accountID))
-			}
-			infof("sync started in the running dcal daemon")
-			return nil
+		if accountID != "" && tallyFixture != "" {
+			return fmt.Errorf("--tally-fixture cannot be combined with an account id")
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -45,6 +43,29 @@ var syncCmd = &cobra.Command{
 			return err
 		}
 		defer closer()
+
+		if accountID == "" {
+			inventory, source, skipped, err := tallysource.Load(ctx, tallyFixture)
+			if err != nil {
+				return err
+			}
+			if skipped {
+				infof("tally source skipped: socket %s is unavailable", source)
+			} else if _, err := tallysource.NewProjector(st.repo).Sync(ctx, inventory); err != nil {
+				return fmt.Errorf("project tally calendar: %w", err)
+			}
+		}
+
+		// Fixtures are a synchronous test seam even when a daemon happens to be
+		// running. Live sync retains the existing asynchronous daemon behavior
+		// after the tally projection has been committed locally.
+		if tallyFixture == "" && notifyDaemon(accountID, true) {
+			if jsonOutput {
+				return printJSON(syncResult("started", true, accountID))
+			}
+			infof("sync started in the running dcal daemon")
+			return nil
+		}
 
 		switch accountID {
 		case "":
@@ -66,6 +87,10 @@ var syncCmd = &cobra.Command{
 		log.Info("sync complete")
 		return nil
 	},
+}
+
+func init() {
+	syncCmd.Flags().StringVar(&tallyFixture, "tally-fixture", "", "Read a recorded query.producers JSON response instead of the live tally socket")
 }
 
 func syncResult(status string, daemon bool, accountID string) map[string]any {

--- a/pkgs/dcal/internal/providers/local/provider.go
+++ b/pkgs/dcal/internal/providers/local/provider.go
@@ -11,9 +11,15 @@ import (
 )
 
 type Provider struct {
-	account calendar.Account
-	root    string
+	account  calendar.Account
+	root     string
+	readOnly bool
 }
+
+// SettingReadOnly marks every calendar exposed by a local account read-only.
+// Managed projections use this so normal local-account syncs preserve their
+// write policy instead of rediscovering the backing ICS file as writable.
+const SettingReadOnly = "readOnly"
 
 func New(account calendar.Account, root string) (*Provider, error) {
 	abs, err := filepath.Abs(root)
@@ -31,7 +37,8 @@ func New(account calendar.Account, root string) (*Provider, error) {
 	case !info.IsDir():
 		return nil, fmt.Errorf("local root %q is not a directory", abs)
 	}
-	return &Provider{account: account, root: abs}, nil
+	readOnly, _ := account.Settings[SettingReadOnly].(bool)
+	return &Provider{account: account, root: abs, readOnly: readOnly}, nil
 }
 
 func (p *Provider) Kind() calendar.AccountKind { return calendar.AccountLocal }
@@ -87,6 +94,7 @@ func (p *Provider) directoryCalendar(name string) calendar.Calendar {
 		AccountID:           p.account.ID,
 		RemoteID:            "dir:" + name,
 		Name:                name,
+		ReadOnly:            p.readOnly,
 		SupportedComponents: localComponents,
 	}
 }
@@ -96,6 +104,7 @@ func (p *Provider) fileCalendar(name string) calendar.Calendar {
 		AccountID:           p.account.ID,
 		RemoteID:            "file:" + name,
 		Name:                strings.TrimSuffix(name, filepath.Ext(name)),
+		ReadOnly:            p.readOnly,
 		SupportedComponents: localComponents,
 	}
 }

--- a/pkgs/dcal/internal/providers/local/write.go
+++ b/pkgs/dcal/internal/providers/local/write.go
@@ -95,6 +95,35 @@ func (p *Provider) DeleteEvent(ctx context.Context, cal calendar.Calendar, ev ca
 	}
 }
 
+// ReplaceEvents atomically rewrites a single-file local calendar from a full
+// managed snapshot. It is intentionally outside calendar.Provider: ordinary
+// callers mutate events one at a time, while source adapters such as tally own
+// the complete contents of their read-only projection.
+func (p *Provider) ReplaceEvents(cal calendar.Calendar, events []calendar.Event) error {
+	source, err := p.calendarPath(cal)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(cal.RemoteID, "dir:") {
+		return errors.New("replace events requires a single-file local calendar")
+	}
+
+	doc := icalconv.NewCalendar()
+	seen := make(map[string]struct{}, len(events))
+	for i := range events {
+		uid := strings.TrimSpace(events[i].UID)
+		if uid == "" {
+			return errors.New("replace events: event missing UID")
+		}
+		if _, ok := seen[uid]; ok {
+			return fmt.Errorf("replace events: duplicate UID %q", uid)
+		}
+		seen[uid] = struct{}{}
+		doc.Children = append(doc.Children, icalconv.BuildEvent(&events[i], uid).Component)
+	}
+	return writeAtomic(source, doc)
+}
+
 func createInDirectory(dir, uid string, ev *calendar.Event) error {
 	path := filepath.Join(dir, filenameSanitizer.Replace(uid)+".ics")
 	switch _, err := os.Stat(path); {

--- a/pkgs/dcal/internal/tallysource/expand.go
+++ b/pkgs/dcal/internal/tallysource/expand.go
@@ -1,0 +1,133 @@
+package tallysource
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultIterations = 512
+	defaultHorizon    = 7 * 24 * time.Hour
+)
+
+type commandRunner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+type calendarExpander struct {
+	run        commandRunner
+	iterations int
+	horizon    time.Duration
+}
+
+func newCalendarExpander() calendarExpander {
+	return calendarExpander{
+		run:        runCommand,
+		iterations: defaultIterations,
+		horizon:    defaultHorizon,
+	}
+}
+
+func (e calendarExpander) future(ctx context.Context, expression string, base time.Time) ([]time.Time, error) {
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return nil, errors.New("empty calendar expression")
+	}
+	iterations := e.iterations
+	if iterations <= 0 || iterations > defaultIterations {
+		iterations = defaultIterations
+	}
+	horizon := e.horizon
+	if horizon <= 0 {
+		horizon = defaultHorizon
+	}
+
+	output, err := e.run(
+		ctx,
+		"systemd-analyze",
+		"calendar",
+		"--iterations="+strconv.Itoa(iterations),
+		"--base-time="+base.Format(time.RFC3339Nano),
+		expression,
+	)
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("systemd-analyze calendar %q: %s", expression, message)
+	}
+
+	times, err := parseCalendarOutput(output)
+	if err != nil {
+		return nil, fmt.Errorf("systemd-analyze calendar %q: %w", expression, err)
+	}
+	limit := base.Add(horizon)
+	out := times[:0]
+	for _, at := range times {
+		if at.After(base) && !at.After(limit) {
+			out = append(out, at)
+		}
+	}
+	return out, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = localeC(os.Environ())
+	return cmd.CombinedOutput()
+}
+
+func localeC(env []string) []string {
+	out := make([]string, 0, len(env)+2)
+	for _, item := range env {
+		if strings.HasPrefix(item, "LC_ALL=") || strings.HasPrefix(item, "LANG=") {
+			continue
+		}
+		out = append(out, item)
+	}
+	return append(out, "LC_ALL=C", "LANG=C")
+}
+
+func parseCalendarOutput(output []byte) ([]time.Time, error) {
+	seen := make(map[time.Time]struct{})
+	var out []time.Time
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		isUTCDetail := strings.HasPrefix(line, "(in UTC):")
+		isIteration := strings.HasPrefix(line, "Next elapse:") || strings.HasPrefix(line, "Iteration #")
+		if (!isUTCDetail && !isIteration) || !strings.HasSuffix(line, " UTC") {
+			continue
+		}
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			continue
+		}
+		at, err := time.Parse("Mon 2006-01-02 15:04:05 MST", strings.TrimSpace(line[colon+1:]))
+		if err != nil {
+			return nil, fmt.Errorf("parse UTC firing %q: %w", line, err)
+		}
+		at = at.UTC()
+		if _, ok := seen[at]; ok {
+			continue
+		}
+		seen[at] = struct{}{}
+		out = append(out, at)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(out) == 0 && !bytes.Contains(output, []byte("never")) {
+		return nil, errors.New("output contained no UTC firing times")
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Before(out[j]) })
+	return out, nil
+}

--- a/pkgs/dcal/internal/tallysource/expand_test.go
+++ b/pkgs/dcal/internal/tallysource/expand_test.go
@@ -1,0 +1,48 @@
+package tallysource
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleCalendarOutput = `Normalized form: *-*-* 03:00:00
+    Next elapse: Tue 2026-08-11 03:00:00 CEST
+       (in UTC): Tue 2026-08-11 01:00:00 UTC
+       From now: 15h left
+   Iteration #2: Wed 2026-08-12 03:00:00 CEST
+       (in UTC): Wed 2026-08-12 01:00:00 UTC
+       From now: 1 day 15h left
+`
+
+func TestParseCalendarOutputUsesUTCProjection(t *testing.T) {
+	times, err := parseCalendarOutput([]byte(sampleCalendarOutput))
+	require.NoError(t, err)
+	require.Len(t, times, 2)
+	assert.Equal(t, time.Date(2026, 8, 11, 1, 0, 0, 0, time.UTC), times[0])
+	assert.Equal(t, time.Date(2026, 8, 12, 1, 0, 0, 0, time.UTC), times[1])
+}
+
+func TestCalendarExpanderCapsIterationsAndHorizon(t *testing.T) {
+	base := time.Date(2026, 8, 10, 10, 0, 0, 0, time.UTC)
+	var commandArgs []string
+	expander := calendarExpander{
+		iterations: defaultIterations + 1,
+		horizon:    36 * time.Hour,
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			assert.Equal(t, "systemd-analyze", name)
+			commandArgs = append([]string(nil), args...)
+			return []byte(sampleCalendarOutput), nil
+		},
+	}
+
+	times, err := expander.future(context.Background(), "*-*-* 03:00:00", base)
+	require.NoError(t, err)
+	require.Len(t, times, 1)
+	assert.Contains(t, strings.Join(commandArgs, " "), "--iterations=512")
+	assert.Contains(t, strings.Join(commandArgs, " "), "--base-time=2026-08-10T10:00:00Z")
+}

--- a/pkgs/dcal/internal/tallysource/inventory.go
+++ b/pkgs/dcal/internal/tallysource/inventory.go
@@ -1,0 +1,186 @@
+// Package tallysource projects tally producer schedules into a managed local
+// calendar.
+package tallysource
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const maxFrameBytes = 16 * 1024 * 1024
+
+// Inventory is the versioned result of tally's query.producers method.
+type Inventory struct {
+	SchemaVersion   int        `json:"schemaVersion"`
+	ProtocolVersion int        `json:"protocolVersion"`
+	Items           []Producer `json:"items"`
+}
+
+type Producer struct {
+	Name       string   `json:"name"`
+	Kind       string   `json:"kind"`
+	Configured bool     `json:"configured"`
+	Enabled    bool     `json:"enabled"`
+	Unit       Unit     `json:"unit"`
+	Schedule   Schedule `json:"schedule"`
+	Runtime    Runtime  `json:"runtime"`
+}
+
+type Unit struct {
+	Service string  `json:"service"`
+	Timer   *string `json:"timer"`
+}
+
+type Schedule struct {
+	CalendarExpression *string `json:"calendarExpression"`
+	PollCadenceSec     *uint64 `json:"pollCadenceSec"`
+	NextTrigger        *string `json:"nextTrigger"`
+}
+
+type Runtime struct {
+	LastTrigger  *string `json:"lastTrigger"`
+	LastEmission *string `json:"lastEmission"`
+}
+
+// Load reads a recorded query.producers result when fixturePath is set, or
+// queries the live tally Unix socket otherwise. A missing live socket is a
+// clean skip and returns its resolved path for the caller's stderr notice.
+func Load(ctx context.Context, fixturePath string) (inventory Inventory, source string, skipped bool, err error) {
+	if fixturePath = strings.TrimSpace(fixturePath); fixturePath != "" {
+		f, openErr := os.Open(fixturePath)
+		if openErr != nil {
+			return Inventory{}, fixturePath, false, fmt.Errorf("open tally fixture %q: %w", fixturePath, openErr)
+		}
+		defer f.Close()
+
+		inventory, err = decodeInventory(io.LimitReader(f, maxFrameBytes+1))
+		if err != nil {
+			return Inventory{}, fixturePath, false, fmt.Errorf("read tally fixture %q: %w", fixturePath, err)
+		}
+		return inventory, fixturePath, false, nil
+	}
+
+	socketPath := SocketPath()
+	if _, statErr := os.Stat(socketPath); statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) {
+			return Inventory{}, socketPath, true, nil
+		}
+		return Inventory{}, socketPath, false, fmt.Errorf("stat tally socket %q: %w", socketPath, statErr)
+	}
+
+	inventory, err = querySocket(ctx, socketPath)
+	if err != nil {
+		return Inventory{}, socketPath, false, err
+	}
+	return inventory, socketPath, false, nil
+}
+
+// SocketPath follows tally-client's documented socket resolution order after
+// its CLI-only --socket flag.
+func SocketPath() string {
+	if path := strings.TrimSpace(os.Getenv("TALLY_SOCKET")); path != "" {
+		return path
+	}
+	if runtimeDir := strings.TrimSpace(os.Getenv("XDG_RUNTIME_DIR")); runtimeDir != "" {
+		return filepath.Join(runtimeDir, "tally", "tally.sock")
+	}
+	return filepath.Join(os.TempDir(), "tally", "tally.sock")
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+type rpcError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func querySocket(ctx context.Context, socketPath string) (Inventory, error) {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		return Inventory{}, fmt.Errorf("connect to tally socket %q: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(15 * time.Second)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		return Inventory{}, fmt.Errorf("set tally socket deadline: %w", err)
+	}
+
+	request := struct {
+		ID     string         `json:"id"`
+		Method string         `json:"method"`
+		Params map[string]any `json:"params"`
+	}{ID: "dcal-sync", Method: "query.producers", Params: map[string]any{}}
+	if err := json.NewEncoder(conn).Encode(request); err != nil {
+		return Inventory{}, fmt.Errorf("write query.producers request: %w", err)
+	}
+
+	limited := &io.LimitedReader{R: conn, N: maxFrameBytes + 1}
+	decoder := json.NewDecoder(limited)
+	var response rpcResponse
+	if err := decoder.Decode(&response); err != nil {
+		return Inventory{}, fmt.Errorf("read query.producers response: %w", err)
+	}
+	if decoder.InputOffset() > maxFrameBytes {
+		return Inventory{}, fmt.Errorf("query.producers response exceeds %d bytes", maxFrameBytes)
+	}
+	if response.Error != nil {
+		return Inventory{}, fmt.Errorf("query.producers: %s: %s", response.Error.Code, response.Error.Message)
+	}
+	if len(response.Result) == 0 {
+		return Inventory{}, errors.New("query.producers response has no result")
+	}
+	return decodeInventoryBytes(response.Result)
+}
+
+// decodeInventory accepts both the raw result printed by `tally query
+// producers` and a recorded NDJSON-RPC response containing that result.
+func decodeInventory(r io.Reader) (Inventory, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return Inventory{}, err
+	}
+	if len(data) > maxFrameBytes {
+		return Inventory{}, fmt.Errorf("query.producers payload exceeds %d bytes", maxFrameBytes)
+	}
+	return decodeInventoryBytes(data)
+}
+
+func decodeInventoryBytes(data []byte) (Inventory, error) {
+	var envelope rpcResponse
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return Inventory{}, fmt.Errorf("decode query.producers JSON: %w", err)
+	}
+	if envelope.Error != nil {
+		return Inventory{}, fmt.Errorf("query.producers: %s: %s", envelope.Error.Code, envelope.Error.Message)
+	}
+	if len(envelope.Result) > 0 {
+		data = envelope.Result
+	}
+
+	var inventory Inventory
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		return Inventory{}, fmt.Errorf("decode query.producers result: %w", err)
+	}
+	if inventory.SchemaVersion != 1 {
+		return Inventory{}, fmt.Errorf("unsupported query.producers schemaVersion %d (expected 1)", inventory.SchemaVersion)
+	}
+	if inventory.Items == nil {
+		inventory.Items = []Producer{}
+	}
+	return inventory, nil
+}

--- a/pkgs/dcal/internal/tallysource/inventory_test.go
+++ b/pkgs/dcal/internal/tallysource/inventory_test.go
@@ -1,0 +1,81 @@
+package tallysource
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeInventoryAcceptsRawResultAndRPCEnvelope(t *testing.T) {
+	raw := []byte(`{"schemaVersion":1,"protocolVersion":5,"items":[]}`)
+
+	direct, err := decodeInventoryBytes(raw)
+	require.NoError(t, err)
+	assert.Empty(t, direct.Items)
+
+	envelope, err := json.Marshal(map[string]any{
+		"id":     "fixture",
+		"result": json.RawMessage(raw),
+	})
+	require.NoError(t, err)
+	wrapped, err := decodeInventoryBytes(envelope)
+	require.NoError(t, err)
+	assert.Equal(t, direct, wrapped)
+}
+
+func TestQuerySocketUsesQueryProducersRPC(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "tally.sock")
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	requestSeen := make(chan map[string]any, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		var request map[string]any
+		if decodeErr := json.NewDecoder(conn).Decode(&request); decodeErr != nil {
+			return
+		}
+		requestSeen <- request
+		_ = json.NewEncoder(conn).Encode(map[string]any{
+			"id": request["id"],
+			"result": map[string]any{
+				"schemaVersion":   1,
+				"protocolVersion": 5,
+				"items": []map[string]any{{
+					"name":       "nightly-eval",
+					"kind":       "calendar",
+					"configured": true,
+					"enabled":    true,
+				}},
+			},
+		})
+	}()
+
+	inventory, err := querySocket(context.Background(), socketPath)
+	require.NoError(t, err)
+	require.Len(t, inventory.Items, 1)
+	assert.Equal(t, "nightly-eval", inventory.Items[0].Name)
+
+	request := <-requestSeen
+	assert.Equal(t, "query.producers", request["method"])
+	assert.Equal(t, map[string]any{}, request["params"])
+}
+
+func TestLoadMissingSocketIsCleanSkip(t *testing.T) {
+	t.Setenv("TALLY_SOCKET", filepath.Join(t.TempDir(), "missing.sock"))
+
+	_, source, skipped, err := Load(context.Background(), "")
+	require.NoError(t, err)
+	assert.True(t, skipped)
+	assert.Equal(t, filepath.Clean(source), source)
+}

--- a/pkgs/dcal/internal/tallysource/projector.go
+++ b/pkgs/dcal/internal/tallysource/projector.go
@@ -1,0 +1,363 @@
+package tallysource
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mecattaf/dcal/ent"
+	"github.com/mecattaf/dcal/ent/account"
+	"github.com/mecattaf/dcal/internal/calendar"
+	"github.com/mecattaf/dcal/internal/eventconv"
+	"github.com/mecattaf/dcal/internal/paths"
+	"github.com/mecattaf/dcal/internal/providers/local"
+	"github.com/mecattaf/dcal/repo"
+)
+
+const (
+	AccountID    = "dcal-tally-source"
+	CalendarID   = "dcal-tally-calendar"
+	CalendarName = "tally"
+
+	calendarFile       = "tally.ics"
+	calendarRemoteID   = "file:" + calendarFile
+	managedSourceKey   = "managedSource"
+	managedSourceValue = "tally"
+	eventDuration      = 15 * time.Minute
+)
+
+type Projector struct {
+	repo     *repo.Repo
+	root     string
+	now      func() time.Time
+	expander calendarExpander
+}
+
+type ProjectionResult struct {
+	CalendarID string
+	Events     int
+	Pruned     int
+}
+
+func NewProjector(r *repo.Repo) *Projector {
+	return &Projector{
+		repo:     r,
+		now:      time.Now,
+		expander: newCalendarExpander(),
+	}
+}
+
+// Sync replaces the complete managed tally snapshot. Stable UIDs make every
+// upsert idempotent; pruning the complement removes firings from vanished or
+// disabled producers.
+func (p *Projector) Sync(ctx context.Context, inventory Inventory) (ProjectionResult, error) {
+	if p == nil || p.repo == nil {
+		return ProjectionResult{}, errors.New("tally projector requires a repository")
+	}
+	now := p.now().UTC()
+	events, err := p.projectEvents(ctx, inventory.Items, now)
+	if err != nil {
+		return ProjectionResult{}, err
+	}
+
+	root, err := p.storageRoot()
+	if err != nil {
+		return ProjectionResult{}, err
+	}
+	provider, storedCalendar, err := p.ensureCalendar(ctx, root)
+	if err != nil {
+		return ProjectionResult{}, err
+	}
+
+	domainCalendar := calendar.Calendar{
+		ID:                  storedCalendar.ID,
+		AccountID:           AccountID,
+		RemoteID:            calendarRemoteID,
+		Name:                CalendarName,
+		ReadOnly:            true,
+		SupportedComponents: []string{calendar.ComponentVEvent},
+	}
+	if err := provider.ReplaceEvents(domainCalendar, events); err != nil {
+		return ProjectionResult{}, fmt.Errorf("write tally calendar snapshot: %w", err)
+	}
+
+	uids := make([]string, 0, len(events))
+	for i := range events {
+		events[i].CalendarID = storedCalendar.ID
+		if _, err := p.repo.UpsertEvent(ctx, eventconv.UpsertInput(storedCalendar.ID, &events[i])); err != nil {
+			return ProjectionResult{}, fmt.Errorf("upsert tally event %q: %w", events[i].UID, err)
+		}
+		uids = append(uids, events[i].UID)
+	}
+	pruned, err := p.repo.DeleteEventsNotInUIDs(ctx, storedCalendar.ID, uids)
+	if err != nil {
+		return ProjectionResult{}, fmt.Errorf("prune tally events: %w", err)
+	}
+
+	return ProjectionResult{CalendarID: storedCalendar.ID, Events: len(events), Pruned: pruned}, nil
+}
+
+func (p *Projector) storageRoot() (string, error) {
+	if p.root != "" {
+		return p.root, nil
+	}
+	dataDir, err := paths.DataDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve tally calendar data directory: %w", err)
+	}
+	return filepath.Join(dataDir, "tally"), nil
+}
+
+func (p *Projector) ensureCalendar(ctx context.Context, root string) (*local.Provider, *ent.Calendar, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve tally calendar root: %w", err)
+	}
+	if err := os.MkdirAll(absRoot, 0o700); err != nil {
+		return nil, nil, fmt.Errorf("create tally calendar root: %w", err)
+	}
+
+	settings := map[string]any{
+		"root":                absRoot,
+		local.SettingReadOnly: true,
+		managedSourceKey:      managedSourceValue,
+	}
+	storedAccount, err := p.repo.GetAccount(ctx, AccountID)
+	switch {
+	case err == nil:
+		if storedAccount.Kind != account.KindLocal {
+			return nil, nil, fmt.Errorf("reserved tally account %q has kind %q", AccountID, storedAccount.Kind)
+		}
+		displayName := "Tally"
+		storedAccount, err = p.repo.UpdateAccount(ctx, AccountID, repo.UpdateAccountInput{
+			DisplayName: &displayName,
+			Settings:    settings,
+		})
+	case repo.IsNotFound(err):
+		storedAccount, err = p.repo.CreateAccount(ctx, repo.CreateAccountInput{
+			ID:          AccountID,
+			Kind:        account.KindLocal,
+			DisplayName: "Tally",
+			Settings:    settings,
+		})
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("ensure tally account: %w", err)
+	}
+
+	domainAccount := calendar.Account{
+		ID:          storedAccount.ID,
+		Kind:        calendar.AccountLocal,
+		DisplayName: storedAccount.DisplayName,
+		Settings:    storedAccount.Settings,
+	}
+	provider, err := local.New(domainAccount, absRoot)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open tally local provider: %w", err)
+	}
+
+	calendarPath := filepath.Join(absRoot, calendarFile)
+	if info, statErr := os.Stat(calendarPath); statErr != nil {
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return nil, nil, fmt.Errorf("stat tally calendar: %w", statErr)
+		}
+		if _, err := local.CreateCalendar(absRoot, CalendarName); err != nil {
+			return nil, nil, fmt.Errorf("create tally calendar: %w", err)
+		}
+	} else if info.IsDir() {
+		return nil, nil, fmt.Errorf("tally calendar path %q is a directory", calendarPath)
+	}
+
+	storedCalendar, err := p.repo.UpsertCalendar(ctx, repo.UpsertCalendarInput{
+		ID:                  CalendarID,
+		AccountID:           AccountID,
+		RemoteID:            calendarRemoteID,
+		Name:                CalendarName,
+		Description:         "Scheduled and recent tally producer runs",
+		ReadOnly:            true,
+		SupportedComponents: []string{calendar.ComponentVEvent},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("ensure tally calendar: %w", err)
+	}
+	return provider, storedCalendar, nil
+}
+
+type firing struct {
+	producer     Producer
+	at           time.Time
+	scheduled    bool
+	pollTick     bool
+	lastTrigger  bool
+	lastEmission bool
+}
+
+func (p *Projector) projectEvents(ctx context.Context, producers []Producer, now time.Time) ([]calendar.Event, error) {
+	firings := make(map[string]*firing)
+	names := make(map[string]struct{}, len(producers))
+	for _, producer := range producers {
+		if !producer.Configured || !producer.Enabled {
+			continue
+		}
+		producer.Name = strings.TrimSpace(producer.Name)
+		if producer.Name == "" {
+			return nil, errors.New("tally producer has an empty name")
+		}
+		if _, exists := names[producer.Name]; exists {
+			return nil, fmt.Errorf("duplicate tally producer name %q", producer.Name)
+		}
+		names[producer.Name] = struct{}{}
+
+		isCalendar := producer.Kind == "calendar"
+		isPoll := producer.Kind == "poll" || producer.Schedule.PollCadenceSec != nil
+		if !isCalendar && !isPoll {
+			continue
+		}
+
+		if isCalendar {
+			if producer.Schedule.CalendarExpression == nil || strings.TrimSpace(*producer.Schedule.CalendarExpression) == "" {
+				return nil, fmt.Errorf("calendar producer %q has no calendarExpression", producer.Name)
+			}
+			times, err := p.expander.future(ctx, *producer.Schedule.CalendarExpression, now)
+			if err != nil {
+				return nil, fmt.Errorf("expand tally producer %q: %w", producer.Name, err)
+			}
+			for _, at := range times {
+				addFiring(firings, producer, at).scheduled = true
+			}
+		} else if at, ok, err := nextPollTick(producer); err != nil {
+			return nil, err
+		} else if ok && at.After(now) {
+			addFiring(firings, producer, at).pollTick = true
+		}
+
+		if at, ok, err := runtimeTime(producer.Name, "lastTrigger", producer.Runtime.LastTrigger); err != nil {
+			return nil, err
+		} else if ok {
+			addFiring(firings, producer, at).lastTrigger = true
+		}
+		if at, ok, err := runtimeTime(producer.Name, "lastEmission", producer.Runtime.LastEmission); err != nil {
+			return nil, err
+		} else if ok {
+			addFiring(firings, producer, at).lastEmission = true
+		}
+	}
+
+	events := make([]calendar.Event, 0, len(firings))
+	for _, point := range firings {
+		events = append(events, eventForFiring(*point))
+	}
+	sort.Slice(events, func(i, j int) bool {
+		if events[i].Start.Equal(events[j].Start) {
+			return events[i].UID < events[j].UID
+		}
+		return events[i].Start.Before(events[j].Start)
+	})
+	return events, nil
+}
+
+func addFiring(firings map[string]*firing, producer Producer, at time.Time) *firing {
+	at = at.UTC()
+	key := producer.Name + "\x00" + at.Format(time.RFC3339Nano)
+	if existing := firings[key]; existing != nil {
+		return existing
+	}
+	point := &firing{producer: producer, at: at}
+	firings[key] = point
+	return point
+}
+
+func nextPollTick(producer Producer) (time.Time, bool, error) {
+	if producer.Schedule.NextTrigger != nil && strings.TrimSpace(*producer.Schedule.NextTrigger) != "" {
+		at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*producer.Schedule.NextTrigger))
+		if err != nil {
+			return time.Time{}, false, fmt.Errorf("tally producer %q nextTrigger is not RFC3339: %w", producer.Name, err)
+		}
+		return at.UTC(), true, nil
+	}
+	if producer.Schedule.PollCadenceSec == nil || producer.Runtime.LastTrigger == nil {
+		return time.Time{}, false, nil
+	}
+	last, ok, err := runtimeTime(producer.Name, "lastTrigger", producer.Runtime.LastTrigger)
+	if err != nil || !ok {
+		return time.Time{}, false, err
+	}
+	seconds := *producer.Schedule.PollCadenceSec
+	if seconds > uint64((1<<63-1)/int64(time.Second)) {
+		return time.Time{}, false, fmt.Errorf("tally producer %q pollCadenceSec is too large", producer.Name)
+	}
+	return last.Add(time.Duration(seconds) * time.Second), true, nil
+}
+
+func runtimeTime(producerName, field string, raw *string) (time.Time, bool, error) {
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		return time.Time{}, false, nil
+	}
+	at, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(*raw))
+	if err != nil {
+		return time.Time{}, false, fmt.Errorf("tally producer %q %s is not RFC3339: %w", producerName, field, err)
+	}
+	return at.UTC(), true, nil
+}
+
+func eventForFiring(point firing) calendar.Event {
+	markers := make([]string, 0, 4)
+	categories := []string{"tally"}
+	if point.scheduled {
+		markers = append(markers, "scheduled calendar firing")
+		categories = append(categories, "scheduled")
+	}
+	if point.pollTick {
+		markers = append(markers, "next poll tick")
+		categories = append(categories, "scheduled")
+	}
+	if point.lastTrigger {
+		markers = append(markers, "last trigger")
+	}
+	if point.lastEmission {
+		markers = append(markers, "last emission")
+	}
+	if point.lastTrigger || point.lastEmission {
+		categories = append(categories, "retrospective")
+	}
+
+	description := []string{
+		"Tally producer: " + point.producer.Name,
+		"Kind: " + point.producer.Kind,
+		"Projection: " + strings.Join(markers, ", "),
+	}
+	if point.producer.Schedule.CalendarExpression != nil && strings.TrimSpace(*point.producer.Schedule.CalendarExpression) != "" {
+		description = append(description, "Schedule: "+strings.TrimSpace(*point.producer.Schedule.CalendarExpression))
+	}
+	if point.producer.Schedule.PollCadenceSec != nil {
+		description = append(description, fmt.Sprintf("Poll cadence: %ds", *point.producer.Schedule.PollCadenceSec))
+	}
+	if service := strings.TrimSpace(point.producer.Unit.Service); service != "" {
+		description = append(description, "Unit: "+service)
+	}
+
+	uid := eventUID(point.producer.Name, point.at)
+	return calendar.Event{
+		UID:          uid,
+		RemoteID:     uid,
+		Summary:      point.producer.Name,
+		Description:  strings.Join(description, "\n"),
+		Status:       calendar.EventConfirmed,
+		Start:        point.at,
+		End:          point.at.Add(eventDuration),
+		Categories:   categories,
+		Transparency: "transparent",
+	}
+}
+
+func eventUID(producerName string, at time.Time) string {
+	identity := producerName + "\x00" + at.UTC().Format(time.RFC3339Nano)
+	digest := sha256.Sum256([]byte(identity))
+	return fmt.Sprintf("tally-%x@dcal", digest)
+}

--- a/pkgs/dcal/internal/tallysource/projector_test.go
+++ b/pkgs/dcal/internal/tallysource/projector_test.go
@@ -1,0 +1,136 @@
+package tallysource
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mecattaf/dcal/internal/calendar"
+	"github.com/mecattaf/dcal/internal/providers/local"
+	"github.com/mecattaf/dcal/repo"
+)
+
+func TestProjectorIsIdempotentReadOnlyAndPrunesVanishedProducers(t *testing.T) {
+	ctx := context.Background()
+	client, err := repo.OpenFile(ctx, filepath.Join(t.TempDir(), "dcal.db"))
+	require.NoError(t, err)
+	r := repo.New(client)
+	t.Cleanup(func() { require.NoError(t, r.Close()) })
+
+	now := time.Date(2026, 8, 10, 10, 0, 0, 0, time.UTC)
+	root := filepath.Join(t.TempDir(), "tally")
+	projector := NewProjector(r)
+	projector.root = root
+	projector.now = func() time.Time { return now }
+	projector.expander = calendarExpander{
+		iterations: 2,
+		horizon:    defaultHorizon,
+		run: func(context.Context, string, ...string) ([]byte, error) {
+			return []byte(sampleCalendarOutput), nil
+		},
+	}
+
+	calendarExpression := "*-*-* 03:00:00"
+	pollCadence := uint64(300)
+	pollNext := now.Add(30 * time.Minute).Format(time.RFC3339)
+	calendarLast := now.Add(-time.Hour).Format(time.RFC3339)
+	pollLast := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	inventory := Inventory{SchemaVersion: 1, ProtocolVersion: 5, Items: []Producer{
+		{
+			Name:       "nightly-eval",
+			Kind:       "calendar",
+			Configured: true,
+			Enabled:    true,
+			Schedule: Schedule{
+				CalendarExpression: &calendarExpression,
+			},
+			Runtime: Runtime{LastTrigger: &calendarLast, LastEmission: &calendarLast},
+		},
+		{
+			Name:       "poll-sample",
+			Kind:       "poll",
+			Configured: true,
+			Enabled:    true,
+			Schedule: Schedule{
+				PollCadenceSec: &pollCadence,
+				NextTrigger:    &pollNext,
+			},
+			Runtime: Runtime{LastTrigger: &pollLast},
+		},
+	}}
+
+	first, err := projector.Sync(ctx, inventory)
+	require.NoError(t, err)
+	assert.Equal(t, CalendarID, first.CalendarID)
+	assert.Equal(t, 5, first.Events)
+	assert.Zero(t, first.Pruned)
+
+	cal, err := r.GetCalendar(ctx, CalendarID)
+	require.NoError(t, err)
+	assert.True(t, cal.ReadOnly)
+
+	events, total, err := r.ListEvents(ctx, repo.ListEventsParams{
+		Filter: repo.EventFilter{CalendarIDs: []string{CalendarID}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 5, total)
+	firstIDs := make(map[string]string, len(events))
+	for _, event := range events {
+		firstIDs[event.UID] = event.ID
+	}
+
+	second, err := projector.Sync(ctx, inventory)
+	require.NoError(t, err)
+	assert.Equal(t, first.Events, second.Events)
+	assert.Zero(t, second.Pruned)
+	events, total, err = r.ListEvents(ctx, repo.ListEventsParams{
+		Filter: repo.EventFilter{CalendarIDs: []string{CalendarID}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 5, total)
+	for _, event := range events {
+		assert.Equal(t, firstIDs[event.UID], event.ID)
+	}
+
+	ics, err := os.ReadFile(filepath.Join(root, calendarFile))
+	require.NoError(t, err)
+	assert.Equal(t, 5, strings.Count(string(ics), "BEGIN:VEVENT"))
+
+	account, err := r.GetAccount(ctx, AccountID)
+	require.NoError(t, err)
+	provider, err := local.New(calendar.Account{
+		ID:       account.ID,
+		Kind:     calendar.AccountLocal,
+		Settings: account.Settings,
+	}, root)
+	require.NoError(t, err)
+	calendars, err := provider.ListCalendars(ctx)
+	require.NoError(t, err)
+	require.Len(t, calendars, 1)
+	assert.True(t, calendars[0].ReadOnly)
+
+	empty, err := projector.Sync(ctx, Inventory{SchemaVersion: 1, ProtocolVersion: 5, Items: []Producer{}})
+	require.NoError(t, err)
+	assert.Zero(t, empty.Events)
+	assert.Equal(t, 5, empty.Pruned)
+	_, total, err = r.ListEvents(ctx, repo.ListEventsParams{
+		Filter: repo.EventFilter{CalendarIDs: []string{CalendarID}},
+	})
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	ics, err = os.ReadFile(filepath.Join(root, calendarFile))
+	require.NoError(t, err)
+	assert.NotContains(t, string(ics), "BEGIN:VEVENT")
+}
+
+func TestEventUIDDependsOnlyOnProducerAndFiringInstant(t *testing.T) {
+	at := time.Date(2026, 8, 11, 1, 0, 0, 0, time.UTC)
+	assert.Equal(t, eventUID("nightly-eval", at), eventUID("nightly-eval", at.In(time.FixedZone("offset", 2*60*60))))
+	assert.NotEqual(t, eventUID("nightly-eval", at), eventUID("poll-sample", at))
+}

--- a/pkgs/dcal/testdata/tally-producers.json
+++ b/pkgs/dcal/testdata/tally-producers.json
@@ -1,0 +1,78 @@
+{
+  "schemaVersion": 1,
+  "protocolVersion": 5,
+  "items": [
+    {
+      "name": "nightly-eval",
+      "kind": "calendar",
+      "configured": true,
+      "enabled": true,
+      "unit": {
+        "service": "tally-producer-nightly-eval.service",
+        "timer": "tally-producer-nightly-eval.timer"
+      },
+      "schedule": {
+        "calendarExpression": "*-*-* 03:00:00",
+        "pollCadenceSec": null,
+        "nextTrigger": null,
+        "nextTriggerUnavailableReason": "systemd-calendar-next-trigger-is-not-available-to-the-daemon"
+      },
+      "enqueue": [
+        {
+          "action": "calendar",
+          "pool": "sample",
+          "executor": null,
+          "priority": "low",
+          "adapter": "shell",
+          "source": "calendar"
+        }
+      ],
+      "runtime": {
+        "state": "unknown",
+        "stateReason": "last-dispatch-succeeded-but-unit-active-state-is-not-observed",
+        "lastTrigger": "2026-08-10T01:00:00Z",
+        "lastEmission": "2026-08-10T01:00:01Z",
+        "lastOutcome": {
+          "emitted": "synthetic-event"
+        },
+        "lastError": null,
+        "authority": "tally-lifecycle-observation"
+      },
+      "configurationAuthority": "nix-declarative-configuration"
+    },
+    {
+      "name": "poll-sample",
+      "kind": "poll",
+      "configured": true,
+      "enabled": true,
+      "unit": {
+        "service": "tally-producer-poll-sample.service",
+        "timer": null
+      },
+      "schedule": {
+        "calendarExpression": null,
+        "pollCadenceSec": 300,
+        "nextTrigger": "2026-08-10T12:05:00Z",
+        "nextTriggerUnavailableReason": null
+      },
+      "enqueue": [],
+      "runtime": {
+        "state": "unknown",
+        "stateReason": "last-dispatch-succeeded-but-unit-active-state-is-not-observed",
+        "lastTrigger": "2026-08-10T12:00:00Z",
+        "lastEmission": null,
+        "lastOutcome": null,
+        "lastError": null,
+        "authority": "tally-lifecycle-observation"
+      },
+      "configurationAuthority": "nix-declarative-configuration"
+    }
+  ],
+  "nextCursor": null,
+  "snapshot": {
+    "createdAt": "2026-08-10T12:00:00Z",
+    "cursor": null,
+    "configurationAuthority": "nix-effective-declarative-registry",
+    "runtimeAuthority": "tally-lifecycle-observation"
+  }
+}


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=dcal-calendar issue=210 task=dcal-tally-source revision=sha256:edc3bbf9f3664e383c9313548983f4c26d64087030ba95cbba96243d80b2a1e2 -->
Spec-build campaign progress for mecattaf/dotfiles#210.

Task `dcal-tally-source`: dcal: project tally scheduled runs into a read-only calendar

Task ref: `dcal-calendar/dcal-tally-source`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/210
Head: `ad8ebe008497c94d1dbd1ab24c577f626b6ebe33`

Closes #202