### PR TITLE
dcal-nix: dcal: nix package + overlay/flake/home wiring

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -477,6 +477,7 @@
             brother-print-text
             call-diarize
             crm
+            dcal
             local-ai-monthly
             mactahoe-gtk-theme
             mactahoe-icon-theme

--- a/home/home.nix
+++ b/home/home.nix
@@ -456,6 +456,7 @@ in
     wrangler # CF Pages/DNS control plane; auth = wrangler-config.age (coordinator-only cred, binary fleet-wide)
     backlog-md # bespoke pkg via overlay — see pkgs/backlog-md.nix
     pkgs.crm # vendored personal CRM CLI; data stays at its built-in notes path
+    pkgs.dcal # vendored calendar CLI; data lives under XDG, nothing in git
     cliamp # terminal music player → navidrome. overlay pkg, see pkgs/cliamp.nix
     uv # Astral Python pkg/project manager. "hot" overlay pkg — rides nixpkgs-fresh HEAD (flake.nix), so it stays latest independent of the main pin.
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -80,6 +80,9 @@ final: prev: {
   # Personal git-backed CRM CLI, vendored with its package definition.
   crm = final.callPackage ../pkgs/crm/nix/package.nix { };
 
+  # Headless calendar CLI, vendored with its package definition.
+  dcal = final.callPackage ../pkgs/dcal/nix/package.nix { };
+
   # VibeVoice call transcription. Torch is the gfx1151 ROCm wheel bundle from
   # nix-strix-halo; pure-Python runtime pieces stay on this flake's Python pin.
   call-diarize = final.callPackage ../pkgs/call-diarize {

--- a/pkgs/dcal/nix/package.nix
+++ b/pkgs/dcal/nix/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildGoModule,
+  systemd,
+}:
+
+buildGoModule rec {
+  pname = "dcal";
+  version = "0.3.0";
+
+  src = lib.cleanSource ../.;
+  vendorHash = "sha256-ROvf5F6tkAr+QXVHaIaezizFWqYdP1aGyS7Jjb8r5TE=";
+
+  subPackages = [ "cmd/dcal" ];
+  env.CGO_ENABLED = 0;
+  nativeCheckInputs = [ systemd ];
+
+  # The vendored CLI has a `version` command but does not wire its version into
+  # Cobra's standard flag. Keep that build metadata local to this derivation.
+  postPatch = ''
+    substituteInPlace cmd/dcal/commands.go \
+      --replace-fail \
+        'var rootCmd = &cobra.Command{' \
+        $'var rootCmd = &cobra.Command{\n\tVersion: Version,'
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    actual="$($out/bin/dcal --version)"
+    if [ "$actual" != "dcal version ${version}" ]; then
+      echo "dcal --version returned '$actual'; expected 'dcal version ${version}'" >&2
+      exit 1
+    fi
+
+    runHook postInstallCheck
+  '';
+
+  # systemd-analyze, call-diarize, and crm are intentionally resolved from PATH
+  # at runtime so dcal does not pull those optional workflows into its closure.
+  meta = {
+    description = "Headless CLI for local and synced calendars";
+    homepage = "https://github.com/AvengeMedia/dankcalendar";
+    license = lib.licenses.mit;
+    mainProgram = "dcal";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=dcal-calendar issue=210 task=dcal-nix revision=sha256:7a9c897d8067e7e1bf9bc23d60bd452f11e4f51a56999462fb30db1cd89c8632 -->
Spec-build campaign progress for mecattaf/dotfiles#210.

Task `dcal-nix`: dcal: nix package + overlay/flake/home wiring

Task ref: `dcal-calendar/dcal-nix`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/210
Head: `e9492396958d03f615ebd9b1fd430872d6ef4b50`

Closes #204