### PR TITLE
dcal-service-timer: dcal: daemon user service + hourly sync producer

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -367,6 +367,21 @@ in
     ];
   };
 
+  # dcal keeps the local calendar database warm for CLI reads. Its IPC socket
+  # is PID-qualified directly beneath XDG_RUNTIME_DIR; do not add a nested
+  # RuntimeDirectory here because unix socket paths are limited to 108 chars.
+  systemd.user.services.dcal-daemon = {
+    Unit = {
+      Description = "dcal calendar daemon";
+      After = [ "graphical-session.target" ];
+    };
+    Service = {
+      ExecStart = "${lib.getExe pkgs.dcal} daemon";
+      Restart = "on-failure";
+    };
+    Install.WantedBy = [ "default.target" ];
+  };
+
   # ---------------------------------------------------------------------------
   # user packages.
   # ---------------------------------------------------------------------------

--- a/home/tally.nix
+++ b/home/tally.nix
@@ -180,6 +180,24 @@ in
         selfDrain = false;
       };
 
+      # Local CLI writes are immediate; this low-priority pass only refreshes
+      # inbound Google changes and re-projects Tally's producer schedules.
+      dcal-sync = {
+        kind = "calendar";
+        onCalendar = "*-*-* *:07:00";
+        enqueue = {
+          argv = [
+            "${lib.getExe pkgs.dcal}"
+            "sync"
+          ];
+          pool = "local-ai-review";
+          priority = "low";
+          dedupKey = "dcal-sync-%Y-%m-%d-%H";
+          evidence = [ "exit:0" ];
+          noEnqueue = true;
+        };
+      };
+
       # The parent serializes one monthly review but does not reserve the GPU.
       # After deterministic Git/Nix/HF preparation it enqueues one low-priority
       # coordinator-gpu child for Pi, waits for the commentary, then verifies and


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=dcal-calendar issue=210 task=dcal-service-timer revision=sha256:99bf9cc835debbf2769206804065223347a60340fbefbe95fdb838c2802765f5 -->
Spec-build campaign progress for mecattaf/dotfiles#210.

Task `dcal-service-timer`: dcal: daemon user service + hourly sync producer

Task ref: `dcal-calendar/dcal-service-timer`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/210
Head: `3100834181d5da63a1d18353463a3374617a1d6f`

Closes #205