### PR TITLE
dcal-migration-race: dcal: serialize first-run migrations — fix daemon/CLI race on fresh data tree

### DIFF
--- a/pkgs/dcal/repo/migrate_lock.go
+++ b/pkgs/dcal/repo/migrate_lock.go
@@ -1,0 +1,50 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const migrationLockRetry = 10 * time.Millisecond
+
+// acquireMigrationLock serializes the complete open-and-migrate path across
+// processes. The lock file is intentionally left beside the database: unlinking
+// it could let a new opener lock a different inode while an existing migration
+// still holds the old one.
+func acquireMigrationLock(ctx context.Context, path string) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open migration lock %q: %w", path, err)
+	}
+
+	ticker := time.NewTicker(migrationLockRetry)
+	defer ticker.Stop()
+	for {
+		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		switch {
+		case err == nil:
+			return file, nil
+		case !errors.Is(err, unix.EWOULDBLOCK):
+			_ = file.Close()
+			return nil, fmt.Errorf("lock migrations at %q: %w", path, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			_ = file.Close()
+			return nil, fmt.Errorf("wait for migration lock %q: %w", path, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func releaseMigrationLock(file *os.File) error {
+	unlockErr := unix.Flock(int(file.Fd()), unix.LOCK_UN)
+	closeErr := file.Close()
+	return errors.Join(unlockErr, closeErr)
+}

--- a/pkgs/dcal/repo/migrate_test.go
+++ b/pkgs/dcal/repo/migrate_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/pressly/goose/v3"
 	_ "modernc.org/sqlite"
+
+	entmigrate "github.com/mecattaf/dcal/ent/migrate"
 )
 
 func openRaw(t *testing.T, name string) (*sql.DB, string) {
@@ -34,6 +38,62 @@ func TestMigrateFreshDatabase(t *testing.T) {
 		if err != nil || !ok {
 			t.Fatalf("column %q missing on fresh db: ok=%v err=%v", col, ok, err)
 		}
+	}
+}
+
+func TestOpenFileSerializesConcurrentFreshMigrations(t *testing.T) {
+	const workers = 16
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	path := filepath.Join(t.TempDir(), "concurrent.db")
+	start := make(chan struct{})
+	results := make(chan error, workers)
+
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			client, err := OpenFile(ctx, path)
+			if err == nil {
+				err = client.Close()
+			}
+			results <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for err := range results {
+		if err != nil {
+			t.Errorf("concurrent open: %v", err)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	entries, err := entmigrate.Migrations.ReadDir(migrationsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var applied int
+	if err := db.QueryRowContext(ctx,
+		"SELECT count(*) FROM goose_db_version WHERE version_id > 0 AND is_applied = 1;",
+	).Scan(&applied); err != nil {
+		t.Fatal(err)
+	}
+	if applied != len(entries) {
+		t.Fatalf("applied migration rows = %d, want exactly one for each of %d migrations", applied, len(entries))
 	}
 }
 

--- a/pkgs/dcal/repo/repo.go
+++ b/pkgs/dcal/repo/repo.go
@@ -74,6 +74,12 @@ func Open(ctx context.Context, dsn string) (*ent.Client, error) {
 }
 
 func OpenFile(ctx context.Context, path string) (*ent.Client, error) {
+	lock, err := acquireMigrationLock(ctx, path+".migrate.lock")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = releaseMigrationLock(lock) }()
+
 	dsn := fmt.Sprintf("file:%s?cache=shared&_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(ON)", path)
 	return Open(ctx, dsn)
 }


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=dcal-calendar issue=210 task=dcal-migration-race revision=sha256:5b145ab66242e5cd834f7f6cebeadfc9e97a2c50d2a65275438aed2bf451eb87 -->
Spec-build campaign progress for mecattaf/dotfiles#210.

Task `dcal-migration-race`: dcal: serialize first-run migrations — fix daemon/CLI race on fresh data tree

Task ref: `dcal-calendar/dcal-migration-race`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/210
Head: `a0515a5a45ab6b798d0fba31682c57e95e8784aa`

Closes #218