### PR TITLE
dcal-done-dryrun: dcal: done --dry-run must be a side-effect-free plan preview that exits 0

### DIFF
--- a/pkgs/dcal/cmd/dcal/commands_test.go
+++ b/pkgs/dcal/cmd/dcal/commands_test.go
@@ -207,8 +207,15 @@ func TestDoneDryRunAndPendingStatusUseOnlyStubs(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(root, "config", "dcal"), 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(root, "config", "dcal", "config.json"), []byte(`{"default_calendar":"Calls"}`), 0o600))
 
-	crmArgvLog := filepath.Join(root, "crm-argv.log")
-	loggedDate := filepath.Join(root, "logged-date")
+	effectsRoot := filepath.Join(root, "effects")
+	recordings := filepath.Join(effectsRoot, "recordings")
+	crmBase := filepath.Join(effectsRoot, "crm")
+	require.NoError(t, os.MkdirAll(recordings, 0o700))
+	t.Setenv("DCAL_RECORDINGS_ROOT", recordings)
+	t.Setenv("DCAL_CRM_BASE", crmBase)
+
+	crmArgvLog := filepath.Join(effectsRoot, "crm-argv.log")
+	loggedDate := filepath.Join(effectsRoot, "logged-date")
 	fakeCRM := filepath.Join(root, "fake-crm")
 	fakeCRMScript := `#!/bin/sh
 printf '%s\n' "$*" >>"$DCAL_CRM_FAKE_LOG"
@@ -245,7 +252,7 @@ esac
 	t.Setenv("DCAL_CRM_FAKE_LOG", crmArgvLog)
 	t.Setenv("DCAL_CRM_LOGGED_DATE", loggedDate)
 
-	diarizeArgvLog := filepath.Join(root, "diarize-argv.log")
+	diarizeArgvLog := filepath.Join(effectsRoot, "diarize-argv.log")
 	fakeDiarize := filepath.Join(root, "fake-call-diarize")
 	fakeDiarizeScript := `#!/bin/sh
 printf '%s\n' "$*" >>"$DCAL_DIARIZE_FAKE_LOG"
@@ -258,8 +265,7 @@ printf '%s\n' '# Call transcript' '' '[00:00] Nick: Hello.' >"$1/transcript.md"
 	start := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
 	end := start.Add(time.Hour)
 	date := callEventDate(start)
-	recordingDir := filepath.Join(root, "Recordings", "calls", date+"-nick-dupont")
-	require.NoError(t, os.MkdirAll(recordingDir, 0o700))
+	recordingDir := filepath.Join(recordings, date+"-nick-dupont")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -283,15 +289,43 @@ printf '%s\n' '# Call transcript' '' '[00:00] Nick: Hello.' >"$1/transcript.md"
 	assert.Contains(t, stdout, "dcal done "+eventRef)
 	crmBeforeDryRun, err := os.ReadFile(crmArgvLog)
 	require.NoError(t, err)
+	transcriptRelative := filepath.Join("transcripts", date[:4], date+"-nick-dupont-call.md")
+	transcriptTarget := filepath.Join(crmBase, transcriptRelative)
+	effectsBeforeDryRun := snapshotTree(t, effectsRoot)
 
 	stdout, stderr, code = runCLI(t, services.SocketPath(), "done", eventRef, "--dry-run")
 	require.Equal(t, 0, code, stderr)
-	transcriptRelative := filepath.Join("transcripts", date[:4], date+"-nick-dupont-call.md")
-	transcriptTarget := filepath.Join(root, "mecattaf", "notes", "crm", transcriptRelative)
+	assert.Contains(t, stdout, "would search recording: none found under "+recordings)
+	assert.Contains(t, stdout, "would run call-diarize: matching recording is missing")
+	assert.Contains(t, stdout, "would copy transcript: matching recording is missing")
+	assert.Contains(t, stdout, "would run crm log: matching recording is missing")
+	assert.Equal(t, effectsBeforeDryRun, snapshotTree(t, effectsRoot), "dry-run must not change any prerequisite or output path")
+	require.NoDirExists(t, recordingDir)
+	require.NoDirExists(t, crmBase)
+	require.NoFileExists(t, diarizeArgvLog)
+	require.NoFileExists(t, loggedDate)
+
+	stdout, stderr, code = runCLI(t, services.SocketPath(), "done", eventRef, "--dry-run", "--format", "json")
+	require.Equal(t, 0, code, stderr)
+	var preview donePlan
+	require.NoError(t, json.Unmarshal([]byte(stdout), &preview))
+	require.Len(t, preview.Steps, 4)
+	assert.Equal(t, donePlanStep{Action: "search recording", Status: "missing", Detail: "none found under " + recordings}, preview.Steps[0])
+	assert.Equal(t, effectsBeforeDryRun, snapshotTree(t, effectsRoot), "JSON dry-run must also be side-effect-free")
+
+	_, stderr, code = runCLI(t, services.SocketPath(), "done", eventRef)
+	assert.Equal(t, 1, code)
+	assert.Contains(t, stderr, "no call recording found for "+date+" under "+recordings)
+
+	require.NoError(t, os.Mkdir(recordingDir, 0o700))
+	effectsBeforeReadyPreview := snapshotTree(t, effectsRoot)
+	stdout, stderr, code = runCLI(t, services.SocketPath(), "done", eventRef, "--dry-run")
+	require.Equal(t, 0, code, stderr)
 	assert.Contains(t, stdout, "Recording dir:\t"+recordingDir)
 	assert.Contains(t, stdout, "Transcript target:\t"+transcriptTarget)
 	assert.Contains(t, stdout, `"--refs","c42"`)
 	assert.Contains(t, stdout, `"--date","`+date+`"`)
+	assert.Equal(t, effectsBeforeReadyPreview, snapshotTree(t, effectsRoot), "ready dry-run must also be side-effect-free")
 	require.NoFileExists(t, transcriptTarget)
 	require.NoFileExists(t, diarizeArgvLog)
 	require.NoFileExists(t, loggedDate)
@@ -320,6 +354,20 @@ printf '%s\n' '# Call transcript' '' '[00:00] Nick: Hello.' >"$1/transcript.md"
 	require.Equal(t, 0, code, stderr)
 	assert.NotContains(t, stdout, "PENDING CALLS")
 	assert.NotContains(t, stdout, eventRef)
+
+	stdout, stderr, code = runCLI(t, services.SocketPath(),
+		"add", "Unlinked call", "--calendar", "Calls",
+		"--start", start.Format(time.RFC3339), "--end", end.Format(time.RFC3339),
+	)
+	require.Equal(t, 0, code, stderr)
+	stdout, stderr, code = runCLI(t, services.SocketPath(), "done", strings.TrimSpace(stdout), "--dry-run")
+	require.Equal(t, 0, code, stderr)
+	assert.Contains(t, stdout, "CRM call kind is missing")
+	assert.Contains(t, stdout, "CRM linkage is missing")
+
+	_, stderr, code = runCLI(t, services.SocketPath(), "done", "not-an-event", "--dry-run")
+	assert.NotEqual(t, 0, code)
+	assert.Contains(t, stderr, "not found")
 }
 
 func TestFreshSyncAndStatusAreCleanNoOps(t *testing.T) {
@@ -404,6 +452,31 @@ func shortTempRoot(t *testing.T) string {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, os.RemoveAll(root)) })
 	return root
+}
+
+func snapshotTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	state := make(map[string]string)
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		value := fmt.Sprintf("%s|%d|%d", info.Mode(), info.Size(), info.ModTime().UnixNano())
+		if info.Mode().IsRegular() {
+			content, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			value += "|" + string(content)
+		}
+		state[relative] = value
+		return nil
+	}))
+	return state
 }
 
 func setCLIEnv(t *testing.T, root string) {

--- a/pkgs/dcal/cmd/dcal/done.go
+++ b/pkgs/dcal/cmd/dcal/done.go
@@ -26,15 +26,22 @@ type doneOptions struct {
 }
 
 type donePlan struct {
-	EventRef         string   `json:"eventRef"`
-	CRMRef           string   `json:"crmRef"`
-	Date             string   `json:"date"`
-	RecordingDir     string   `json:"recordingDir"`
-	TranscriptSource string   `json:"transcriptSource"`
-	TranscriptTarget string   `json:"transcriptTarget"`
-	DiarizeArgv      []string `json:"diarizeArgv"`
-	CRMLogArgv       []string `json:"crmLogArgv"`
-	DryRun           bool     `json:"dryRun"`
+	EventRef         string         `json:"eventRef"`
+	CRMRef           string         `json:"crmRef"`
+	Date             string         `json:"date"`
+	RecordingDir     string         `json:"recordingDir"`
+	TranscriptSource string         `json:"transcriptSource"`
+	TranscriptTarget string         `json:"transcriptTarget"`
+	DiarizeArgv      []string       `json:"diarizeArgv"`
+	CRMLogArgv       []string       `json:"crmLogArgv"`
+	DryRun           bool           `json:"dryRun"`
+	Steps            []donePlanStep `json:"steps,omitempty"`
+}
+
+type donePlanStep struct {
+	Action string `json:"action"`
+	Status string `json:"status"`
+	Detail string `json:"detail"`
 }
 
 var doneFlags doneOptions
@@ -54,14 +61,16 @@ var doneCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if event.CRMKind != "call" {
-			return fmt.Errorf("event %s is not a CRM call", event.ID)
-		}
-		if event.CRMRef == "" {
-			return fmt.Errorf("event %s has no CRM ref", event.ID)
-		}
-		if !event.End.Before(timeNow()) {
-			return fmt.Errorf("event %s has not ended yet", event.ID)
+		if !doneFlags.dryRun {
+			if event.CRMKind != "call" {
+				return fmt.Errorf("event %s is not a CRM call", event.ID)
+			}
+			if event.CRMRef == "" {
+				return fmt.Errorf("event %s has no CRM ref", event.ID)
+			}
+			if !event.End.Before(timeNow()) {
+				return fmt.Errorf("event %s has not ended yet", event.ID)
+			}
 		}
 
 		plan, err := buildDonePlan(event, doneFlags.dryRun)
@@ -86,60 +95,173 @@ var timeNow = func() time.Time { return time.Now() }
 
 func buildDonePlan(event eventRecord, dryRun bool) (donePlan, error) {
 	date := callEventDate(event.Start)
-	recordings, err := recordingsRoot()
-	if err != nil {
-		return donePlan{}, err
-	}
 	subject := callSubject(event.Summary)
-	recordingDir, err := locateCallRecording(recordings, date, event.Summary, subject, event.CRMRef)
-	if err != nil {
-		return donePlan{}, err
+	plan := donePlan{
+		EventRef: event.ID,
+		CRMRef:   event.CRMRef,
+		Date:     date,
+		DryRun:   dryRun,
 	}
-	crmBase, err := crmBaseDir()
-	if err != nil {
-		return donePlan{}, err
+
+	recordings, recordingErr := recordingsRoot()
+	if recordingErr == nil {
+		plan.RecordingDir, recordingErr = locateCallRecording(recordings, date, event.Summary, subject, event.CRMRef)
+	}
+	if recordingErr != nil && !dryRun {
+		return donePlan{}, recordingErr
+	}
+	if recordingErr == nil {
+		plan.TranscriptSource = filepath.Join(plan.RecordingDir, "transcript.md")
+		plan.DiarizeArgv = []string{callDiarizeBinary(), plan.RecordingDir}
+	}
+
+	crmBase, targetErr := crmBaseDir()
+	if targetErr != nil && !dryRun {
+		return donePlan{}, targetErr
 	}
 	nameSlug := callSlug(subject)
 	if nameSlug == "" {
 		nameSlug = event.CRMRef
 	}
+	if nameSlug == "" {
+		nameSlug = "call"
+	}
 	relative := filepath.Join("transcripts", date[:4], date+"-"+nameSlug+"-call.md")
-	target := filepath.Join(crmBase, relative)
-	summary := shortCallSummary(event.Summary)
-	return donePlan{
-		EventRef:         event.ID,
-		CRMRef:           event.CRMRef,
-		Date:             date,
-		RecordingDir:     recordingDir,
-		TranscriptSource: filepath.Join(recordingDir, "transcript.md"),
-		TranscriptTarget: target,
-		DiarizeArgv:      []string{callDiarizeBinary(), recordingDir},
-		CRMLogArgv: []string{
+	if targetErr == nil {
+		plan.TranscriptTarget = filepath.Join(crmBase, relative)
+	}
+	if event.CRMRef != "" {
+		plan.CRMLogArgv = []string{
 			crmBinary(), "log",
 			"--kind", "call",
 			"--transcript", filepath.ToSlash(relative),
 			"--refs", event.CRMRef,
 			"--date", date,
-			"--summary", summary,
-		},
-		DryRun: dryRun,
-	}, nil
+			"--summary", shortCallSummary(event.Summary),
+		}
+	}
+	if dryRun {
+		plan.Steps = buildDonePreviewSteps(event, recordings, recordingErr, targetErr, plan)
+	}
+	return plan, nil
+}
+
+func buildDonePreviewSteps(event eventRecord, recordings string, recordingErr, targetErr error, plan donePlan) []donePlanStep {
+	var steps []donePlanStep
+	if recordingErr == nil {
+		steps = append(steps, readyDoneStep("search recording", plan.RecordingDir))
+	} else {
+		steps = append(steps, missingDoneStep("search recording", previewRecordingMissing(recordings, recordingErr)))
+	}
+
+	var actionMissing []string
+	if recordingErr != nil {
+		actionMissing = append(actionMissing, "matching recording is missing")
+	}
+	if len(actionMissing) == 0 {
+		steps = append(steps, readyDoneStep("run call-diarize", formatArgv(plan.DiarizeArgv)))
+	} else {
+		steps = append(steps, missingDoneStep("run call-diarize", actionMissing...))
+	}
+
+	copyMissing := append([]string(nil), actionMissing...)
+	if targetErr != nil {
+		copyMissing = append(copyMissing, "CRM transcript root is unavailable: "+targetErr.Error())
+	}
+	if len(copyMissing) == 0 {
+		detail := fmt.Sprintf("%s -> %s (source produced by call-diarize)", plan.TranscriptSource, plan.TranscriptTarget)
+		steps = append(steps, readyDoneStep("copy transcript", detail))
+	} else {
+		steps = append(steps, missingDoneStep("copy transcript", copyMissing...))
+	}
+	logMissing := doneEventPrerequisites(event, timeNow())
+	logMissing = append(logMissing, copyMissing...)
+	if len(logMissing) == 0 {
+		steps = append(steps, readyDoneStep("run crm log", formatArgv(plan.CRMLogArgv)))
+	} else {
+		steps = append(steps, missingDoneStep("run crm log", logMissing...))
+	}
+	return steps
+}
+
+func doneEventPrerequisites(event eventRecord, now time.Time) []string {
+	var missing []string
+	if event.CRMKind != "call" {
+		if event.CRMKind == "" {
+			missing = append(missing, "CRM call kind is missing")
+		} else {
+			missing = append(missing, fmt.Sprintf("CRM call kind is %q, not %q", event.CRMKind, "call"))
+		}
+	}
+	if event.CRMRef == "" {
+		missing = append(missing, "CRM linkage is missing")
+	}
+	if !event.End.Before(now) {
+		missing = append(missing, "event has not ended yet")
+	}
+	return missing
+}
+
+func previewRecordingMissing(root string, err error) string {
+	if root == "" {
+		return "recordings root is unavailable: " + err.Error()
+	}
+	if errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "no call recording found") {
+		return "none found under " + root
+	}
+	return err.Error()
+}
+
+func readyDoneStep(action, detail string) donePlanStep {
+	return donePlanStep{Action: action, Status: "ready", Detail: detail}
+}
+
+func missingDoneStep(action string, missing ...string) donePlanStep {
+	if len(missing) == 0 {
+		missing = []string{"prerequisite is missing"}
+	}
+	return donePlanStep{Action: action, Status: "missing", Detail: strings.Join(missing, "; ")}
+}
+
+func formatArgv(argv []string) string {
+	encoded, _ := json.Marshal(argv)
+	return string(encoded)
 }
 
 func printDonePlan(plan donePlan) error {
 	if jsonOutput {
 		return printJSON(plan)
 	}
-	diarize, _ := json.Marshal(plan.DiarizeArgv)
-	crmLog, _ := json.Marshal(plan.CRMLogArgv)
 	fmt.Fprintf(os.Stdout, "Event:\t%s\n", plan.EventRef)
-	fmt.Fprintf(os.Stdout, "CRM ref:\t%s\n", plan.CRMRef)
+	if plan.CRMRef == "" {
+		fmt.Fprintln(os.Stdout, "CRM ref:\t(missing)")
+	} else {
+		fmt.Fprintf(os.Stdout, "CRM ref:\t%s\n", plan.CRMRef)
+	}
 	fmt.Fprintf(os.Stdout, "Date:\t%s\n", plan.Date)
-	fmt.Fprintf(os.Stdout, "Recording dir:\t%s\n", plan.RecordingDir)
-	fmt.Fprintf(os.Stdout, "Transcript source:\t%s\n", plan.TranscriptSource)
-	fmt.Fprintf(os.Stdout, "Transcript target:\t%s\n", plan.TranscriptTarget)
-	fmt.Fprintf(os.Stdout, "call-diarize argv:\t%s\n", diarize)
-	fmt.Fprintf(os.Stdout, "crm log argv:\t%s\n", crmLog)
+	fmt.Fprintln(os.Stdout, "Plan:")
+	for _, step := range plan.Steps {
+		if step.Status == "ready" {
+			fmt.Fprintf(os.Stdout, "would %s: ready — %s\n", step.Action, step.Detail)
+			continue
+		}
+		fmt.Fprintf(os.Stdout, "would %s: %s (missing)\n", step.Action, step.Detail)
+	}
+	if plan.RecordingDir != "" {
+		fmt.Fprintf(os.Stdout, "Recording dir:\t%s\n", plan.RecordingDir)
+	}
+	if plan.TranscriptSource != "" {
+		fmt.Fprintf(os.Stdout, "Transcript source:\t%s\n", plan.TranscriptSource)
+	}
+	if plan.TranscriptTarget != "" {
+		fmt.Fprintf(os.Stdout, "Transcript target:\t%s\n", plan.TranscriptTarget)
+	}
+	if len(plan.DiarizeArgv) > 0 {
+		fmt.Fprintf(os.Stdout, "call-diarize argv:\t%s\n", formatArgv(plan.DiarizeArgv))
+	}
+	if len(plan.CRMLogArgv) > 0 {
+		fmt.Fprintf(os.Stdout, "crm log argv:\t%s\n", formatArgv(plan.CRMLogArgv))
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=dcal-calendar issue=210 task=dcal-done-dryrun revision=sha256:d2c9d7ed3e65776020ba208c991945823d103148361696bca14327cf10734b5b -->
Spec-build campaign progress for mecattaf/dotfiles#210.

Task `dcal-done-dryrun`: dcal: done --dry-run must be a side-effect-free plan preview that exits 0

Task ref: `dcal-calendar/dcal-done-dryrun`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/210
Head: `c9b0d263b9da7c6026a2930d1278248e6cf06492`

Closes #220