### PR TITLE
dcal-socket-wait: dcal: socket-requiring commands must tolerate a concurrently starting daemon

### DIFF
--- a/pkgs/dcal/cmd/dcal/account.go
+++ b/pkgs/dcal/cmd/dcal/account.go
@@ -249,7 +249,15 @@ func openStores(ctx context.Context) (*cliStores, func(), error) {
 // notifyDaemon tells a running daemon (if any) that accounts changed so the
 // GUI updates, optionally asking it to sync the account. Best-effort.
 func notifyDaemon(accountID string, refresh bool) bool {
-	socketPath, err := ipc.FindRunningSocket()
+	return notifyDaemonFoundBy(ipc.FindRunningSocket, accountID, refresh)
+}
+
+func waitForDaemonAndNotify(accountID string, refresh bool) bool {
+	return notifyDaemonFoundBy(ipc.WaitForRunningSocket, accountID, refresh)
+}
+
+func notifyDaemonFoundBy(findSocket func() (string, error), accountID string, refresh bool) bool {
+	socketPath, err := findSocket()
 	if err != nil {
 		return false
 	}

--- a/pkgs/dcal/cmd/dcal/commands_test.go
+++ b/pkgs/dcal/cmd/dcal/commands_test.go
@@ -119,6 +119,51 @@ func TestDaemonBackedEventRoundTrip(t *testing.T) {
 	assert.Equal(t, exitNotFound, code, stderr)
 }
 
+func TestCalendarAddWaitsForConcurrentlyStartingDaemon(t *testing.T) {
+	for run := 1; run <= 5; run++ {
+		t.Run(fmt.Sprintf("run-%d", run), func(t *testing.T) {
+			root := shortTempRoot(t)
+			setCLIEnv(t, root)
+			t.Setenv("DCAL_DISABLE_HTTP", "true")
+
+			args := []string{"-test.run=^TestCLIHelperProcess$", "--", "daemon"}
+			daemon := exec.Command(os.Args[0], args...)
+			daemon.Env = append(os.Environ(), helperEnv+"=1")
+			var daemonStdout, daemonStderr bytes.Buffer
+			daemon.Stdout = &daemonStdout
+			daemon.Stderr = &daemonStderr
+			require.NoError(t, daemon.Start())
+
+			daemonDone := make(chan error, 1)
+			go func() { daemonDone <- daemon.Wait() }()
+			var stopErr error
+			stopped := false
+			stopDaemon := func() {
+				if stopped {
+					return
+				}
+				stopped = true
+				_ = daemon.Process.Signal(os.Interrupt)
+				select {
+				case stopErr = <-daemonDone:
+				case <-time.After(5 * time.Second):
+					_ = daemon.Process.Kill()
+					<-daemonDone
+					stopErr = fmt.Errorf("daemon did not stop after interrupt")
+				}
+			}
+			t.Cleanup(stopDaemon)
+
+			stdout, stderr, code := runCLI(t, "", "calendar", "add", "x")
+			stopDaemon()
+
+			require.NoError(t, stopErr, "daemon stdout:\n%s\ndaemon stderr:\n%s", daemonStdout.String(), daemonStderr.String())
+			require.Equal(t, 0, code, "command stderr:\n%s\ndaemon stderr:\n%s", stderr, daemonStderr.String())
+			assert.Equal(t, "x", strings.TrimSpace(stdout))
+		})
+	}
+}
+
 func TestAddCRMContactUsesStubAndPersistsICSProperties(t *testing.T) {
 	root := shortTempRoot(t)
 	setCLIEnv(t, root)

--- a/pkgs/dcal/cmd/dcal/ipc.go
+++ b/pkgs/dcal/cmd/dcal/ipc.go
@@ -33,7 +33,7 @@ Method names and param keys complete with the shell (see 'dcal completion').`,
 
 		socketPath := os.Getenv("DCAL_SOCKET")
 		if socketPath == "" {
-			socketPath, err = ipc.FindRunningSocket()
+			socketPath, err = ipc.WaitForRunningSocket()
 			if err != nil {
 				return fmt.Errorf("dcal daemon not running: %w", err)
 			}

--- a/pkgs/dcal/cmd/dcal/reminders.go
+++ b/pkgs/dcal/cmd/dcal/reminders.go
@@ -76,7 +76,7 @@ func init() {
 func remindersCall(method string, params map[string]any) (any, error) {
 	socketPath := os.Getenv("DCAL_SOCKET")
 	if socketPath == "" {
-		path, err := ipc.FindRunningSocket()
+		path, err := ipc.WaitForRunningSocket()
 		if err != nil {
 			return nil, fmt.Errorf("dcal daemon not running: %w", err)
 		}

--- a/pkgs/dcal/cmd/dcal/rpc.go
+++ b/pkgs/dcal/cmd/dcal/rpc.go
@@ -20,7 +20,7 @@ func dialDaemon() (*daemonClient, error) {
 	socketPath := os.Getenv("DCAL_SOCKET")
 	var err error
 	if socketPath == "" {
-		socketPath, err = ipc.FindRunningSocket()
+		socketPath, err = ipc.WaitForRunningSocket()
 		if err != nil {
 			return nil, fmt.Errorf("dcal daemon is not running: %w", err)
 		}

--- a/pkgs/dcal/cmd/dcal/sync.go
+++ b/pkgs/dcal/cmd/dcal/sync.go
@@ -59,7 +59,7 @@ var syncCmd = &cobra.Command{
 		// Fixtures are a synchronous test seam even when a daemon happens to be
 		// running. Live sync retains the existing asynchronous daemon behavior
 		// after the tally projection has been committed locally.
-		if tallyFixture == "" && notifyDaemon(accountID, true) {
+		if tallyFixture == "" && waitForDaemonAndNotify(accountID, true) {
 			if jsonOutput {
 				return printJSON(syncResult("started", true, accountID))
 			}

--- a/pkgs/dcal/internal/ipc/models.go
+++ b/pkgs/dcal/internal/ipc/models.go
@@ -1,11 +1,16 @@
 package ipc
 
 import (
+	"time"
+
 	dcalipc "github.com/mecattaf/dcal/internal/support/ipc"
 	"github.com/mecattaf/dcal/internal/support/ipc/params"
 )
 
-const APIVersion = 1
+const (
+	APIVersion                 = 1
+	socketDiscoveryGracePeriod = 3 * time.Second
+)
 
 type (
 	Request         = dcalipc.Request
@@ -27,6 +32,10 @@ func Respond[T any](w *ConnWriter, id int, result T) { dcalipc.Respond(w, id, re
 func RespondError(w *ConnWriter, id int, msg string) { dcalipc.RespondError(w, id, msg) }
 
 func FindRunningSocket() (string, error) { return dcalipc.FindRunningSocket("dcal") }
+
+func WaitForRunningSocket() (string, error) {
+	return dcalipc.WaitForRunningSocket("dcal", socketDiscoveryGracePeriod)
+}
 
 func ParamString(p map[string]any, key string) string { return params.StringOpt(p, key, "") }
 

--- a/pkgs/dcal/internal/support/ipc/client.go
+++ b/pkgs/dcal/internal/support/ipc/client.go
@@ -19,6 +19,8 @@ type Client struct {
 	r    *bufio.Reader
 }
 
+const socketDiscoveryPollInterval = 100 * time.Millisecond
+
 func Dial(socketPath string) (*Client, error) {
 	conn, err := net.Dial("unix", socketPath)
 	if err != nil {
@@ -81,4 +83,31 @@ func FindRunningSocket(appName string) (string, error) {
 		return path, nil
 	}
 	return "", errors.New("no running " + appName + " socket found")
+}
+
+// WaitForRunningSocket retries discovery for gracePeriod after an initial
+// lookup fails. The initial lookup preserves the existing no-wait fast path
+// when a daemon is already listening.
+func WaitForRunningSocket(appName string, gracePeriod time.Duration) (string, error) {
+	path, err := FindRunningSocket(appName)
+	if err == nil || gracePeriod <= 0 {
+		return path, err
+	}
+
+	ticker := time.NewTicker(socketDiscoveryPollInterval)
+	defer ticker.Stop()
+	timer := time.NewTimer(gracePeriod)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			path, err = FindRunningSocket(appName)
+			if err == nil {
+				return path, nil
+			}
+		case <-timer.C:
+			return FindRunningSocket(appName)
+		}
+	}
 }

--- a/pkgs/dcal/internal/support/ipc/server_test.go
+++ b/pkgs/dcal/internal/support/ipc/server_test.go
@@ -154,6 +154,38 @@ func TestFindRunningSocket(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestWaitForRunningSocketFindsConcurrentlyStartingServer(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+
+	srv := ipc.NewServer(ipc.Config{AppName: "dcaltest", APIVersion: 1}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	listenErr := make(chan error, 1)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		err := srv.Listen()
+		listenErr <- err
+		if err == nil {
+			_ = srv.Serve(ctx)
+		}
+	}()
+
+	path, err := ipc.WaitForRunningSocket("dcaltest", time.Second)
+	require.NoError(t, err)
+	require.NoError(t, <-listenErr)
+	assert.Equal(t, srv.SocketPath(), path)
+}
+
+func TestWaitForRunningSocketKeepsExistingSocketFastPath(t *testing.T) {
+	srv := startServer(t, ipc.Config{AppName: "dcaltest", APIVersion: 1}, nil)
+
+	path, err := ipc.WaitForRunningSocket("dcaltest", 0)
+	require.NoError(t, err)
+	assert.Equal(t, srv.SocketPath(), path)
+}
+
 func TestMux(t *testing.T) {
 	mux := ipc.NewMux()
 	mux.Handle("version", func(ctx context.Context, w *ipc.ConnWriter, req ipc.Request, sub *ipc.Subscriber) {


### PR DESCRIPTION
<!-- tally:spec-build:v2 campaign=dcal-calendar issue=210 task=dcal-socket-wait revision=sha256:f0761097fd2d1086ca0e6d46560f29cf504648963721c89be7298e81aa92b0e2 -->
Spec-build campaign progress for mecattaf/dotfiles#210.

Task `dcal-socket-wait`: dcal: socket-requiring commands must tolerate a concurrently starting daemon

Task ref: `dcal-calendar/dcal-socket-wait`

Witnessed gates are the merge criterion. Campaign issue: https://github.com/mecattaf/dotfiles/issues/210
Head: `dde33367e745aea6cf8fdd7ec05653c4446e03d4`

Closes #222